### PR TITLE
uBitcoin version update

### DIFF
--- a/libraries/uBitcoin.lib
+++ b/libraries/uBitcoin.lib
@@ -1,1 +1,1 @@
-https://github.com/micro-bitcoin/uBitcoin/#d95cd475b8a61e887dd8cab39b14f6879b21828c
+https://github.com/micro-bitcoin/uBitcoin/#850a1d2952cb57b2d5820eb957b75a924157ce9b


### PR DESCRIPTION
This update of uBitcoin.lib is required to instruct mbed fetching newer version of external library. Otherwise project is not built due to missing HDPrivateKey::fingerprint() overridden method and other incompatibilities.