### PR TITLE
reckless storage - no pin, no encryption

### DIFF
--- a/components/gui/gui.h
+++ b/components/gui/gui.h
@@ -2,6 +2,7 @@
 #define __GUI_H__
 
 #include <stdint.h>
+#include "./alert/alert.h"
 
 /** possible GUI actions (main needs to handle them) */
 #define GUI_NO_ACTION            0
@@ -15,6 +16,11 @@
 #define GUI_VERIFY_ADDRESS       8
 #define GUI_SIGN_PSBT            9
 #define GUI_PSBT_CONFIRMED      10
+// reckless
+#define GUI_SHOW_MNEMONIC 		11
+#define GUI_SAVE_MNEMONIC		12
+#define GUI_DELETE_MNEMONIC 	13
+#define GUI_LOAD_MNEMONIC		14
 
 /** structure to display output */
 typedef struct _txout_t {
@@ -44,6 +50,7 @@ void gui_show_xpub(const char * fingerprint, const char * derivation, const char
 void gui_show_addresses(const char * derivation, const char * segwit_addr, const char * base58_addr);
 void gui_show_psbt(uint64_t out_amount, uint64_t change_amount, uint64_t fee, uint8_t num_outputs, txout_t * outputs);
 void gui_show_signed_psbt(const char * output);
+void gui_show_reckless_mnemonic(const char * mnemonic);
 
 void gui_calibrate();
 

--- a/components/storage/storage.cpp
+++ b/components/storage/storage.cpp
@@ -16,6 +16,51 @@ int storage_erase(){
     // return fs.remove("/internal/gui/calibration");
 }
 
+int storage_init(){
+    int err = fs.mount(&bd);
+    printf("%s\r\n", (err ? "Fail :(" : "OK"));
+    if (err) {
+        printf("No filesystem found, formatting...\r\n");
+        err = fs.reformat(&bd);
+        printf("%s\r\n", (err ? "Fail :(" : "OK"));
+        if (err) {
+            printf("error: %s (%d)\r\n", strerror(-err), err);
+            return err;
+        }
+    }
+    return STORAGE_OK;
+}
+
+int storage_save_mnemonic(const char * mnemonic){
+    FILE *f = fopen("/internal/mnemonic", "w");
+    if(!f){
+        return -1;
+    }
+    fprintf(f, mnemonic);
+    fclose(f);
+    return 0;
+}
+
+int storage_load_mnemonic(char ** mnemonic){
+    FILE *f = fopen("/internal/mnemonic", "r");
+    if(!f){
+        return -1;
+    }
+    // TODO: check length
+    char content[300];
+    fscanf(f,"%[^\n]", content);
+    *mnemonic = (char *)malloc(strlen(content)+1);
+    strcpy(*mnemonic, content);
+    memset(content, 0, sizeof(content));
+    fclose(f);
+    return 0;
+}
+
+int storage_delete_mnemonic(){
+    return remove("/internal/mnemonic");
+}
+
+#if 0
 void listRoot(){
     // Display the root directory
     printf("Opening the root directory... ");
@@ -41,21 +86,6 @@ void listRoot(){
     if (err < 0) {
         error("error: %s (%d)\r\n", strerror(errno), -errno);
     }
-}
-
-int storage_init(){
-    int err = fs.mount(&bd);
-    printf("%s\r\n", (err ? "Fail :(" : "OK"));
-    if (err) {
-        printf("No filesystem found, formatting...\r\n");
-        err = fs.reformat(&bd);
-        printf("%s\r\n", (err ? "Fail :(" : "OK"));
-        if (err) {
-            printf("error: %s (%d)\r\n", strerror(-err), err);
-            return err;
-        }
-    }
-    return STORAGE_OK;
 }
 
 int save(const char * fname, const char * content){
@@ -94,7 +124,7 @@ int makeDir(const char * dirname){
     free(fullname);
     return err;
 }
-#if 0
+
 static int qspi_init(){
     int err = fs.mount(&bd);
     printf("%s\r\n", (err ? "Fail :(" : "OK"));

--- a/components/storage/storage.h
+++ b/components/storage/storage.h
@@ -5,6 +5,12 @@
 
 int storage_init();
 int storage_erase();
+
+// reckless storage
+int storage_save_mnemonic(const char * mnemonic);
+int storage_load_mnemonic(char ** mnemonic);
+int storage_delete_mnemonic();
+
 // void listRoot();
 // int save(const char * fname, const char * content);
 // bool dirExists(const char * dirname);

--- a/main.cpp
+++ b/main.cpp
@@ -283,6 +283,50 @@ void process_action(int action){
             gui_show_init_screen();
             break;
         }
+        case GUI_SHOW_MNEMONIC:
+        {
+            gui_show_reckless_mnemonic(mnemonic);
+            break;
+        }
+        case GUI_SAVE_MNEMONIC:
+        { // TODO: set and verify pin code
+            int res = storage_save_mnemonic(mnemonic);
+            if(res < 0){
+                show_err("Failed to save mnemonic");
+            }else{
+                gui_alert_create("Success!", "Your recovery phrase is saved to memory", "Ok");
+            }
+            break;
+        }
+        case GUI_DELETE_MNEMONIC:
+        { // TODO: securely erase this file
+            int res = storage_delete_mnemonic();
+            if(res < 0){
+                show_err("Failed to delete mnemonic");
+            }else{
+                gui_alert_create("Success!", "Your recovery phrase is removed from memory", "Ok");
+            }
+            break;
+        }
+        case GUI_LOAD_MNEMONIC:
+        {
+            if(mnemonic != NULL){
+                wally_free_string(mnemonic);
+                mnemonic = NULL;
+            }
+            int res = storage_load_mnemonic(&mnemonic);
+            if(res < 0){
+                show_err("Failed to load mnemonic");
+            }else{
+                if(bip39_mnemonic_validate(NULL, mnemonic)!=WALLY_OK){
+                    show_err("mnemonic is not correct");
+                }else{
+                    logit("main", "mnemonic is saved in memory");
+                    gui_get_password();
+                }
+            }
+            break;
+        }
         default:
             show_err("unrecognized action");
     }

--- a/specter_config.h
+++ b/specter_config.h
@@ -6,9 +6,4 @@
 // buffer size for host module
 #define SPECTER_HOST_INPUT_SIZE	3000
 
-/** put in debug.h your hardcoded debug mnemonic */
-// #include "debug.h"
-/** or put it here and uncomment this line */
-// #define DEBUG_MNEMONIC "also panda decline code guard palace spread squirrel stereo sudden fee noodle"
-
 #endif // __SPECTER_CONFIG_H__


### PR DESCRIPTION
Adds a `Reckless` menu in the main screen where you can save mnemonic to and delete from internal storage.
In the init menu it adds `Load key from memory` button. When clicked - goes to the password screen (password is never saved on the device).
File name used: `/internal/mnemonic`
No PIN, no encryption, just to make testing easier. We are not using it on the main net, right?