### PR TITLE
popups refactor with classes

### DIFF
--- a/src/gui/common.py
+++ b/src/gui/common.py
@@ -96,7 +96,7 @@ def add_label(text, y=PADDING, scr=None, style=None, width=None):
     lbl.set_y(y)
     return lbl
 
-def add_button(text, callback=None, scr=None, y=700):
+def add_button(text=None, callback=None, scr=None, y=700):
     """Helper function that creates a button with a text label"""
     if scr is None:
         scr = lv.scr_act()
@@ -104,9 +104,10 @@ def add_button(text, callback=None, scr=None, y=700):
     btn.set_width(HOR_RES-2*PADDING);
     btn.set_height(BTN_HEIGHT);
     
-    lbl = lv.label(btn)
-    lbl.set_text(text)
-    lbl.set_align(lv.label.ALIGN.CENTER)
+    if text is not None:
+        lbl = lv.label(btn)
+        lbl.set_text(text)
+        lbl.set_align(lv.label.ALIGN.CENTER)
 
     btn.align(scr, lv.ALIGN.IN_TOP_MID, 0, 0)
     btn.set_y(y)

--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -2,82 +2,119 @@ import lvgl as lv
 from .common import *
 from .decorators import *
 
+# global popups array
+# we use it in close_all_popups()
+popups = []
+
 # pop-up screens
+
+class Popup(lv.obj):
+    def __init__(self, close_callback=None):
+        super().__init__()
+        self.old_screen = lv.scr_act()
+        self.close_callback = close_callback
+        # add back button
+        self.close_button = add_button(scr=self, 
+                                       callback=on_release(self.close)
+                                       )
+
+        self.close_label = lv.label(self.close_button)
+        self.close_label.set_text("OK") #lv.SYMBOL.LEFT+" Back")
+
+        # activate the screen
+        lv.scr_load(self)
+        popups.append(self)
+
+    def close(self):
+        # activate old screen
+        lv.scr_load(self.old_screen)
+        if self.close_callback is not None:
+            self.close_callback()
+        popups.remove(self)
+        # delete this screen
+        self.del_async()
+
+class Alert(Popup):
+    def __init__(self,
+                 title="Alert!", 
+                 message="Something happened", 
+                 close_callback=None):
+
+        super().__init__(close_callback)
+        self.title = add_label(title, scr=self, style="title")
+        self.message = add_label(message, scr=self)
+        self.message.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 50)
+
+class Prompt(Alert):
+    def __init__(self, title="Are you sure?", message="Make a choice", 
+                        confirm_callback=None, close_callback=None):
+        super().__init__(title, message, close_callback)
+
+        w = (HOR_RES-3*PADDING)//2
+        self.close_button.set_width(w)
+        self.close_label.set_text("Cancel")
+
+        self.confirm_button = add_button(callback=on_release(self.confirm), scr=self)
+        self.confirm_button.set_width(w)
+        self.confirm_button.set_x(HOR_RES//2+PADDING//2)
+        self.confirm_callback = confirm_callback
+        self.confirm_label = lv.label(self.confirm_button)
+        self.confirm_label.set_text("Confirm")
+
+    def confirm(self):
+        # a hack to call confirm callback
+        self.close_callback = self.confirm_callback
+        self.close()
+
+class QRAlert(Alert):
+    def __init__(self,
+                 title="QR Alert!", 
+                 qr_message="QR code of something",
+                 message="Something happened", 
+                 close_callback=None, qr_width=None):
+        super().__init__(title, message, close_callback)
+        self.qr = add_qrcode(qr_message, scr=self, width=qr_width)
+        self.qr.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 50)
+        self.message.align(self.qr, lv.ALIGN.OUT_BOTTOM_MID, 0, 50)
+
+# one-liners
+
+def close_all_popups():
+    for p in reversed(popups):
+        p.close()
+
 def alert(title, message, callback=None):
-    old_scr = lv.scr_act()
-    scr = lv.obj()
-    lv.scr_load(scr)
-    add_label(title, style="title")
-    add_label(message, y=PADDING+100)
-    def cb(obj, event):
-        if event == lv.EVENT.RELEASED:
-            lv.scr_load(old_scr)
-            if callback is not None:
-                callback()
-    add_button("OK", cb)
+    return Alert(title, message, close_callback=callback)
+
+def cb_with_args(callback, *args, **kwargs):
+    def cb():
+        callback(*args, **kwargs)
+    return cb
 
 def prompt(title, message, ok=None, cancel=None, **kwargs):
-    old_scr = lv.scr_act()
-    scr = lv.obj()
-    lv.scr_load(scr)
-    add_label(title, style="title")
-    add_label(message, y=PADDING+100)
-
-    def cb_ok(obj, event):
-        if event == lv.EVENT.RELEASED:
-            lv.scr_load(old_scr)
-            if ok is not None:
-                ok(**kwargs)
-
-    def cb_cancel(obj, event):
-        if event == lv.EVENT.RELEASED:
-            lv.scr_load(old_scr)
-            if cancel is not None:
-                cancel(**kwargs)
-
-    add_button_pair(
-            "Cancel", cb_cancel,
-            "Confirm", cb_ok,
-        )
+    return Prompt(title, message, confirm_callback=cb_with_args(ok,**kwargs), close_callback=cb_with_args(cancel,**kwargs))
 
 def error(message):
     alert("Error!", message)
 
 def qr_alert(title, message, message_text=None, callback=None, ok_text="OK", width=None):
-    old_scr = lv.scr_act()
-    scr = lv.obj()
-    lv.scr_load(scr)
-    add_label(title, style="title")
-    qrobj = add_qrcode(message, scr=scr, y=PADDING+120, width=width)
-    msg_obj = None
-    if message_text is not None:
-        y = qrobj.get_y()+qrobj.get_height()+30
-        msg_obj = add_label(message_text, y=y)
-    def cb(obj, event):
-        if event == lv.EVENT.RELEASED:
-            lv.scr_load(old_scr)
-            qrobj.delete()
-            gc.collect()
-            if callback is not None:
-                callback()
-    add_button(ok_text, cb)
-    # objects to manupulate if necessary
-    return (qrobj, msg_obj)
+    scr = QRAlert(title, message, message_text, callback, qr_width=width)
+    scr.close_label.set_text(ok_text)
+    return scr
 
 def show_xpub(name, xpub, prefix=None, callback=None):
     msg = prefix+xpub
-    qrobj, msgobj = qr_alert("Master "+name, msg, msg, callback)
-    scr = lv.scr_act()
+    scr = qr_alert("Master "+name, msg, msg, callback)
     # add checkbox
     if prefix is not None:
         def cb():
-            txt = msgobj.get_text()
+            txt = scr.message.get_text()
             if prefix in txt:
                 txt = xpub
             else:
                 txt = prefix+xpub
-            msgobj.set_text(txt)
-            qrobj.set_text(txt)
+            scr.message.set_text(txt)
+            scr.qr.set_text(txt)
         btn = add_button("Toggle derivation", on_release(cb), y=600)
 
 def show_mnemonic(mnemonic):
@@ -85,20 +122,21 @@ def show_mnemonic(mnemonic):
     add_mnemonic_table(mnemonic, y=100)
 
 def show_wallet(wallet, delete_cb=None):
-    old_scr = lv.scr_act()
     idx = 0
     addr = wallet.address(idx)
-    qrobj, msgobj = qr_alert("Wallet \"%s\"" % wallet.name,
+    # dirty hack: add \n at the end to increase title size 
+    #             to skip realigning of the qr code
+    scr = qr_alert("Wallet \"%s\"\n" % wallet.name,
                              "bitcoin:"+addr, addr,
                              ok_text="Close", width=350)
-    lbl = add_label("Receiving address #%d" % idx, y=80)
+    lbl = add_label("Receiving address #%d" % (idx+1), y=80)
     def cb_update(delta):
         idx = int(lbl.get_text().split("#")[1])
         if idx+delta >= 0:
             idx += delta
         addr = wallet.address(idx)
-        msgobj.set_text(addr)
-        qrobj.set_text("bitcoin:"+addr)
+        scr.message.set_text(addr)
+        scr.qr.set_text("bitcoin:"+addr)
         lbl.set_text("Receiving address #%d" % idx)
         if idx > 0:
             prv.set_state(lv.btn.STATE.REL)
@@ -110,9 +148,7 @@ def show_wallet(wallet, delete_cb=None):
         cb_update(-1)
     def cb_del():
         delete_cb(wallet)
-        lv.scr_load(old_scr)
-        qrobj.delete()
-        gc.collect()
+        scr.close()
     delbtn = add_button("Delete wallet", on_release(cb_del), y=600)
     prv, nxt = add_button_pair("Previous", on_release(cb_prev),
                                "Next", on_release(cb_next),


### PR DESCRIPTION
I started refactoring the GUI with classes, for now only popups (`Alert`, `Prompt`, `QRAlert`).
Also `gui.popups` module keeps track of all active popups that we can close with `close_all_popups` function.

This will be required for USB communication - if a request is coming from the host we want to close all popups and open a single one triggered by the host. Otherwise host could spam us with requests and exhaust our memory with large number of popups.