### PR TITLE
Nonblocking GUI

### DIFF
--- a/src/gui/common.py
+++ b/src/gui/common.py
@@ -13,6 +13,13 @@ QR_PADDING = const(40)
 
 styles = {}
 
+def switch_to_new_screen():
+    scr = lv.obj()
+    old_scr = lv.scr_act()
+    lv.scr_load(scr)
+    old_scr.del_async()
+    return scr
+
 def init_styles():
     # Set theme
     th = lv.theme_night_init(210, lv.font_roboto_22)

--- a/src/gui/core.py
+++ b/src/gui/core.py
@@ -4,7 +4,6 @@ import utime as time
 import display
 
 from .common import init_styles
-from .decorators import handle_queue
 
 def init(blocking=True):
     display.init(not blocking)
@@ -18,7 +17,6 @@ def init(blocking=True):
 
 def update(dt:int=30):
     display.update(dt)
-    handle_queue()
 
 def ioloop(dt:int=30):
     while True:

--- a/src/gui/core.py
+++ b/src/gui/core.py
@@ -1,24 +1,20 @@
 import lvgl as lv
 import utime as time
 
-try:
-    # hardware - use udisplay
-    import udisplay as display
-except:
-    # otherwise - display_unixport frozen in unix simulator
-    import display
+import display
 
 from .common import init_styles
 from .decorators import handle_queue
 
-def init():
-    display.init()
-    
+def init(blocking=True):
+    display.init(not blocking)
+
     # Initialize the styles
     init_styles()
 
     scr = lv.obj()
     lv.scr_load(scr)
+    update()
 
 def update(dt:int=30):
     display.update(dt)

--- a/src/gui/decorators.py
+++ b/src/gui/decorators.py
@@ -1,26 +1,10 @@
 import lvgl as lv
 
-queue = []
-
-# decorators
-def queued(func):
-    """A decorator to put a function in a queue
-    after lvgl update instead of calling it right away
-    """
-    def wrapper(*args, **kwargs):
-        queue.append((func, args, kwargs))
-    return wrapper
-
 def on_release(func):
     def wrapper(o, e):
         if e == lv.EVENT.RELEASED:
             func()
     return wrapper
-
-def handle_queue():
-    while len(queue) > 0:
-        cb, args, kwargs = queue.pop()
-        cb(*args, **kwargs)
 
 def cb_with_args(callback, *args, **kwargs):
     def cb():

--- a/src/gui/screens.py
+++ b/src/gui/screens.py
@@ -4,11 +4,9 @@ from .decorators import *
 from .popups import alert
 from pin import Secret, Key, Pin, antiphishing_word, Factory_settings
 
-# queued screens
-@queued
+# "main" screens
 def ask_pin(first_time_usage, callback):
-    scr = lv.scr_act()
-    scr.clean()
+    scr = switch_to_new_screen()
     first_time_title = "Choose a PIN code"
     title = "Enter your PIN code"
     if first_time_usage:
@@ -88,10 +86,8 @@ def ask_pin(first_time_usage, callback):
 
     btnm.set_event_cb(cb);
 
-@queued
 def create_menu(buttons=[], title="What do you want to do?", y0=100, cb_back=None):
-    scr = lv.scr_act()
-    scr.clean()
+    scr = switch_to_new_screen()
     add_label(title, style="title")
     y = y0
     for text, callback in buttons:
@@ -100,22 +96,18 @@ def create_menu(buttons=[], title="What do you want to do?", y0=100, cb_back=Non
     if cb_back is not None:
         add_button(lv.SYMBOL.LEFT+" Back", on_release(cb_back))
 
-@queued
 def show_progress(title, text, callback=None):
-    scr = lv.scr_act()
-    scr.clean()
+    scr = switch_to_new_screen()
     add_label(title, style="title")
     add_label(text, y=200)
     if callback is not None:
         add_button("Cancel", on_release(callback))
 
-@queued
 def new_mnemonic(mnemonic, 
                  cb_continue, cb_back, cb_update=None, 
                  title="Your new recovery phrase:"):
     """Makes the new mnemonic screen with a slider to change number of words"""
-    scr = lv.scr_act()
-    scr.clean()
+    scr = switch_to_new_screen()
     add_label(title, style="title")
     table = add_mnemonic_table(mnemonic, y=100)
 
@@ -155,10 +147,8 @@ CHARSET_EXTRA = [
     lv.SYMBOL.CLOSE+" Clear"," ",lv.SYMBOL.OK+" Done",""
 ]
 
-@queued
 def ask_for_password(cb_continue, title="Enter your password (optional)"):
-    scr = lv.scr_act()
-    scr.clean()
+    scr = switch_to_new_screen()
     add_label(title, style="title")
 
     btnm = lv.btnm(scr)
@@ -212,12 +202,10 @@ def ask_for_password(cb_continue, title="Enter your password (optional)"):
 # global
 words = []
 
-@queued
 def ask_for_mnemonic(cb_continue, cb_back, 
                      check_mnemonic=None, words_lookup=None,
                      title="Enter your recovery phrase"):
-    scr = lv.scr_act()
-    scr.clean()
+    scr = switch_to_new_screen()
     add_label(title, style="title")
     table = add_mnemonic_table("", y=70)
 

--- a/src/main.py
+++ b/src/main.py
@@ -470,6 +470,15 @@ def host_callback(data):
     # - signmessage <message>
     # - showdescraddr <descriptor>
 
+def update(dt=30):
+    gui.update(dt)
+    qr_scanner.update()
+    usb_host.update()
+
+def ioloop():
+    while True:
+        time.sleep_ms(30)
+        update(30)
 
 def main(blocking=True):
     # FIXME: check for all ports (unix, js, stm)
@@ -479,17 +488,16 @@ def main(blocking=True):
         os.mkdir(storage_root)
     except:
         pass
-    gui.init()
+    # schedules display autoupdates if blocking=False
+    # it may cause GUI crashing when out of memory
+    # but perfect to debug
+    gui.init(blocking)
     ret = Secret.load_secret()
     if ret == False:
         Secret.generate_secret()
     screens.ask_pin(not ret, show_init)
     if blocking:
-        while True:
-            time.sleep_ms(30)
-            gui.update(30)
-            qr_scanner.update()
-            usb_host.update()
+        ioloop()
 
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 import gui
 from gui import screens, popups
-from gui.decorators import queued, cb_with_args
+from gui.decorators import cb_with_args
 import gui.common
 import lvgl as lv
 
@@ -133,8 +133,6 @@ def sign_psbt(wallet=None, tx=None, success_callback=None):
 def parse_transaction(b64_tx, success_callback=None, error_callback=None):
     # we will go to main afterwards
     show_main()
-    # we need to update gui because screens are queued
-    gui.update(100)
     try:
         raw = a2b_base64(b64_tx)
         tx = psbt.PSBT.parse(raw)
@@ -173,8 +171,6 @@ def scan_transaction():
 def verify_address(s):
     # we will go to main afterwards
     show_main()
-    # we need to update gui because screens are queued
-    gui.update(100)
     # verifies address in the form [bitcoin:]addr?index=i
     s = s.replace("bitcoin:", "")
     arr = s.split("?")


### PR DESCRIPTION
I got rid of annoying handle_queue for GUI updates, now the screen functions are called right away. Old screen is deleted during the next display update.

Now it is also possible to run `main` function with `blocking=False` - in this case, one can get to REPL and work on the device interactively. Data from UART and USB will not be parsed until `update` function is called. Then all the data will be processed and the wallet will do whatever is required.