### PR TITLE
security settings - usb and developer mode

### DIFF
--- a/src/boot.py
+++ b/src/boot.py
@@ -11,29 +11,26 @@ pwr.on()
 pwrcb = lambda e: pwr.off()
 pyb.ExtInt(pyb.Pin('B1'), pyb.ExtInt.IRQ_FALLING, pyb.Pin.PULL_NONE, pwrcb)
 
-# pyb.usb_mode('CDC')
-# check if blue button is pressed
-# userbtn = pyb.Switch()
+from platform import USB_ENABLED, DEV_ENABLED
 
-# leds = [pyb.LED(i) for i in range(1,5)]
-# for led in leds:
-#     led.on()
-# for led in leds[::-1]:
-#     time.sleep(0.25)
-#     led.off()
+# set up usb mode
+if USB_ENABLED and DEV_ENABLED:
+    pyb.usb_mode('CDC+MSC')
+elif USB_ENABLED:
+    pyb.usb_mode('CDC')
+elif DEV_ENABLED:
+    pyb.usb_mode('MSC')
+else:
+    pyb.usb_mode(None)
 
-# if not userbtn.value():
-#     # don't use USB
-#     pyb.usb_mode('CDC')
-# else:
-#     # use USB as mass storage for development
-#     pyb.usb_mode('CDC+MSC')
+if DEV_ENABLED:
+    repl = pyb.UART('YB',115200)
+    # redirect REPL to STLINK UART
+    os.dupterm(repl,0)
+if USB_ENABLED:
+    # unconnect REPL from USB
+    os.dupterm(None, 1)
 
-repl = pyb.UART('YB',115200)
-# redirect REPL to STLINK UART
-os.dupterm(repl,0)
-# unconnect REPL from USB
-os.dupterm(None, 1)
 # pyb.main('main.py') # main script to run after this one
 # pyb.usb_mode('CDC+MSC') # act as a serial and a storage device
 # pyb.usb_mode('CDC+HID') # act as a serial device and a mouse

--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -149,3 +149,30 @@ def show_wallet(wallet, delete_cb=None):
                                "Next", on_release(cb_next),
                                y=500)
     prv.set_state(lv.btn.STATE.INA)
+
+def show_settings(config, save_callback):
+    def cb():
+        new_config = {"usb": usb_switch.get_state(), "developer": dev_switch.get_state()}
+        save_callback(new_config)
+
+    scr = Prompt("Device settings", "", confirm_callback=cb)
+    scr.confirm_label.set_text("Save & Reboot")
+    usb_label = add_label("USB communication", 120, scr=scr)
+    usb_hint = add_label("If USB is enabled the device will be able to talk to your computer. This increases attack surface but sometimes makes it more convenient to use.", 160, scr=scr, style="hint")
+    usb_switch = lv.sw(scr)
+    usb_switch.align(usb_hint, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
+    lbl = add_label(" OFF                              ON  ")
+    lbl.align(usb_switch, lv.ALIGN.CENTER, 0, 0)
+    if config["usb"]:
+        usb_switch.on(lv.ANIM.OFF)
+
+    dev_label = add_label("Developer mode", 320, scr=scr)
+    dev_hint = add_label("In developer mode internal flash will be mounted to your computer so you could edit files, but your secrets will be visible as well. Also enables interactive shell through miniUSB port.", 360, scr=scr, style="hint")
+    dev_switch = lv.sw(scr)
+    dev_switch.align(dev_hint, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
+    lbl = add_label(" OFF                              ON  ")
+    lbl.align(dev_switch, lv.ALIGN.CENTER, 0, 0)
+    if config["developer"]:
+        dev_switch.on(lv.ANIM.OFF)
+
+

--- a/src/platform.py
+++ b/src/platform.py
@@ -1,12 +1,24 @@
 # detect if it's a hardware device or linuxport
-try:
-    import pyb
-    simulator = False
-except:
-    simulator = True
+import sys, os
+simulator = (sys.platform != 'pyboard')
 
 # path to store #reckless entropy
 if simulator:
     storage_root = "../userdata"
 else:
     storage_root = "/flash/userdata"
+
+USB_ENABLED = False
+DEV_ENABLED = False
+
+try:
+    s = os.stat("%s/%s" % (storage_root, "USB_ENABLED"))
+    USB_ENABLED = True
+except:
+    pass
+
+try:
+    s = os.stat("%s/%s" % (storage_root, "DEV_ENABLED"))
+    DEV_ENABLED = True
+except:
+    pass

--- a/src/usbhost.py
+++ b/src/usbhost.py
@@ -1,5 +1,5 @@
 import utime as time
-from platform import simulator
+from platform import simulator, USB_ENABLED
 
 if not simulator:
     import pyb
@@ -8,13 +8,16 @@ else:
 
 class USBHost:
     def __init__(self, callback=None):
-        self.usb = pyb.USB_VCP()
         self.callback = callback
         self.data = ""
+        if USB_ENABLED:
+            self.usb = pyb.USB_VCP()
         # alternatively make EOL "\r" and strip "\n"
         # self.EOL = "\r\n"
 
     def process_data(self):
+        if not USB_ENABLED:
+            return
         if self.callback is None:
             self.data = ""
             return
@@ -27,10 +30,14 @@ class USBHost:
                 self.callback(e)
 
     def respond(self, data):
+        if not USB_ENABLED:
+            return
         self.usb.write(data)
         self.usb.write("\r\n")
 
     def update(self):
+        if not USB_ENABLED:
+            return
         res = self.usb.read()
         if res is not None and len(res) > 0:
             # if non-unicode character is found - fail right away


### PR DESCRIPTION
Now it's possible to change the following settings:

- USB communication. When disabled it doesn't even appear on a computer.
- Developer settings. When disabled micropython doesnt mount flash to the computer and REPL is also unavailable.

This settings screen is hidden under the PIN, so should be ok.

I decided to keep these settings as files because parsing jsons is errorprone. Plus `boot.py` should be as minimal as possible.

![image](https://user-images.githubusercontent.com/1706012/73326008-e8df8100-4250-11ea-90ad-c4b11db5ff89.png)
