### PR TITLE
check for address gap limit violation

### DIFF
--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -124,6 +124,14 @@ def prompt_tx(title, data, ok=None, cancel=None):
     lbl = lv.label(scr)
     lbl.set_text("Fee: %u satoshi - %.1f" % (data["fee"], 100*data["fee"]/data["spending"]) + "%")
     lbl.align(obj, lv.ALIGN.OUT_BOTTOM_MID, 0, 50)
+
+    if "warning" in data:
+        lbl_w = lv.label(scr)
+        lbl_w.set_recolor(True)
+        lbl_w.set_text(data["warning"])
+        lbl_w.set_align(lv.label.ALIGN.CENTER)
+        lbl_w.align(lbl, lv.ALIGN.OUT_BOTTOM_MID, 0, 70)
+
     return scr
 
 def error(message):

--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -204,7 +204,7 @@ def show_wallet(wallet, delete_cb=None):
     scr.message.set_style(0, style)
 
     # warning label for address gap limit
-    lbl_w = add_label("Warning")
+    lbl_w = add_label("")
     lbl_w.align(scr.message, lv.ALIGN.OUT_BOTTOM_MID, 0, 15)
     lbl_w.set_recolor(True)
 
@@ -225,6 +225,9 @@ def show_wallet(wallet, delete_cb=None):
             lbl_w.set_text("#ff0000 This address exceeds the gap limit.# "
                             "#ff0000 Using this address may lead to locking of# "
                             "#ff0000 your funds! #")
+        elif idx <= wallet.last_rcv_idx:
+            lbl_w.set_text("#ff0000 This address may have been used before.#\n"
+                           "#ff0000 Reusing it would diminish your privacy!#")
         else:
             lbl_w.set_text("")
 
@@ -238,7 +241,8 @@ def show_wallet(wallet, delete_cb=None):
     delbtn = add_button("Delete wallet", on_release(cb_del), y=610)
     prv = add_button(lv.SYMBOL.LEFT, on_release(cb_prev))
     nxt = add_button(lv.SYMBOL.RIGHT, on_release(cb_next))
-    prv.set_state(lv.btn.STATE.INA)
+    if idx <= 0:
+        prv.set_state(lv.btn.STATE.INA)
     prv.set_width(70)
     prv.align(scr.qr, lv.ALIGN.OUT_LEFT_MID, -10, 0)
     nxt.set_width(70)

--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -203,6 +203,11 @@ def show_wallet(wallet, delete_cb=None):
     style.text.font = lv.font_roboto_mono_22
     scr.message.set_style(0, style)
 
+    # warning label for address gap limit
+    lbl_w = add_label("Warning")
+    lbl_w.align(scr.message, lv.ALIGN.OUT_BOTTOM_MID, 0, 15)
+    lbl_w.set_recolor(True)
+
     lbl = add_label("Receiving address #%d" % (idx+1), y=80)
     def cb_update(delta):
         idx = int(lbl.get_text().split("#")[1])-1
@@ -216,6 +221,13 @@ def show_wallet(wallet, delete_cb=None):
             prv.set_state(lv.btn.STATE.REL)
         else:
             prv.set_state(lv.btn.STATE.INA)
+        if idx > wallet.last_rcv_idx + wallet.gap_limit:
+            lbl_w.set_text("#ff0000 This address exceeds the gap limit.# "
+                            "#ff0000 Using this address may lead to locking of# "
+                            "#ff0000 your funds! #")
+        else:
+            lbl_w.set_text("")
+
     def cb_next():
         cb_update(1)
     def cb_prev():

--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -191,7 +191,7 @@ def show_mnemonic(mnemonic):
     add_mnemonic_table(mnemonic, y=100)
 
 def show_wallet(wallet, delete_cb=None):
-    idx = 0
+    idx = wallet.last_rcv_idx + 1
     addr = wallet.address(idx)
     # dirty hack: add \n at the end to increase title size 
     #             to skip realigning of the qr code
@@ -224,10 +224,13 @@ def show_wallet(wallet, delete_cb=None):
         scr.close()
         delete_cb(wallet)
     delbtn = add_button("Delete wallet", on_release(cb_del), y=610)
-    prv, nxt = add_button_pair("Previous", on_release(cb_prev),
-                               "Next", on_release(cb_next),
-                               y=520)
+    prv = add_button(lv.SYMBOL.LEFT, on_release(cb_prev))
+    nxt = add_button(lv.SYMBOL.RIGHT, on_release(cb_next))
     prv.set_state(lv.btn.STATE.INA)
+    prv.set_width(70)
+    prv.align(scr.qr, lv.ALIGN.OUT_LEFT_MID, -10, 0)
+    nxt.set_width(70)
+    nxt.align(scr.qr, lv.ALIGN.OUT_RIGHT_MID, 10, 0)
 
 def show_settings(config, save_callback):
     def cb():

--- a/src/gui/popups.py
+++ b/src/gui/popups.py
@@ -46,6 +46,7 @@ class Alert(Popup):
         self.page = lv.page(lv.scr_act())
         self.page.set_size(480, 550)
         self.message = add_label(message, scr=self.page)
+        self.message.set_recolor(True)
         self.page.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 50)
 
 class Prompt(Alert):

--- a/src/keystore.py
+++ b/src/keystore.py
@@ -243,12 +243,15 @@ def parse_descriptor(desc):
     return wrappers, args
 
 class Wallet:
-    def __init__(self, name, descriptor, network, fname=None):
+    def __init__(self, name, descriptor, network, fname=None, last_rcv_idx=-1, last_chg_idx=-1):
         self.fname = fname
         self.name = name
         self.descriptor = descriptor
         self.network = network
         self.wrappers, self.args = parse_descriptor(descriptor)
+        self.last_rcv_idx = last_rcv_idx
+        self.last_chg_idx = last_chg_idx
+        self.gap_limit = 20
 
     @property
     def is_multisig(self):
@@ -416,7 +419,9 @@ class Wallet:
         return (sc == output.script_pubkey)
 
     def save(self, fname):
-        obj = {"name": self.name, "descriptor": self.descriptor}
+        obj = {"name": self.name, "descriptor": self.descriptor, \
+               "last_rcv_idx": self.last_rcv_idx, \
+               "last_chg_idx": self.last_chg_idx}
         data = json.dumps(obj)
         with open(fname,"w") as f:
             f.write(data)
@@ -431,4 +436,8 @@ class Wallet:
     @classmethod
     def parse(cls, s, network, fname=None):
         content = json.loads(s)
-        return cls(content["name"], content["descriptor"], network, fname)
+        if "last_rcv_idx" in content:
+            return cls(content["name"], content["descriptor"], network, fname, \
+                       content["last_rcv_idx"], content["last_chg_idx"])
+        else:
+            return cls(content["name"], content["descriptor"], network, fname)

--- a/src/main.py
+++ b/src/main.py
@@ -181,6 +181,7 @@ def xpubs_menu():
 def sign_psbt(wallet=None, tx=None, success_callback=None):
     wallet.fill_psbt(tx)
     keystore.sign(tx)
+    keystore.update_wallet_indexes(wallet, tx)
     # remove everything but partial sigs
     # to reduce QR code size
     tx.unknown = {}

--- a/src/main.py
+++ b/src/main.py
@@ -300,6 +300,9 @@ def verify_address(s):
             if index > w.last_rcv_idx + w.gap_limit:
                 warning = ("\n\n #ff0000 Possible gap limit. Using this address# "
                            "#ff0000 may lead to locking of your funds!#")
+            elif index <= w.last_rcv_idx:
+                warning = ("\n\n #ff0000 This address may have been used before.#\n"
+                           "#ff0000 Reusing it would diminish your privacy!#")
             popups.qr_alert("Address #%d from wallet\n\"%s\"" % (index+1, w.name),
                             "bitcoin:%s"%addr, message_text=addr + warning)
             return

--- a/src/main.py
+++ b/src/main.py
@@ -296,8 +296,12 @@ def verify_address(s):
         return
     for w in keystore.wallets:
         if w.address(index) == addr:
+            warning = ""
+            if index > w.last_rcv_idx + w.gap_limit:
+                warning = ("\n\n #ff0000 Possible gap limit. Using this address# "
+                           "#ff0000 may lead to locking of your funds!#")
             popups.qr_alert("Address #%d from wallet\n\"%s\"" % (index+1, w.name),
-                            "bitcoin:%s"%addr, message_text=addr)
+                            "bitcoin:%s"%addr, message_text=addr + warning)
             return
     gui.error("Address doesn't belong to any wallet. Wrong device or network?")
 

--- a/src/main.py
+++ b/src/main.py
@@ -231,9 +231,33 @@ def parse_transaction(b64_tx, success_callback=None, error_callback=None):
         if error_callback is not None:
             error_callback("invalid argument")
         return
+
+    # check for address gap limit
+    gap_limit = False
+    w = data["wallet"]
+    wallet_key = b"\xfc\xca\x01" + data["wallet"].fingerprint
+    for el in tx.inputs + tx.outputs:
+        if el.bip32_derivations:
+            # full PSBT
+            for der in el.bip32_derivations:
+                drv = el.bip32_derivations[der].derivation
+                if drv[-1] > w.gap_limit + (w.last_chg_idx if drv[-2] else w.last_rcv_idx):
+                    gap_limit = True
+        elif wallet_key in el.unknown:
+            # compressed PSBT
+            idxs = el.unknown[wallet_key]
+            chg = int.from_bytes(idxs[0:4], 'little')
+            idx = int.from_bytes(idxs[4:8], 'little')
+            if idx > w.gap_limit + (w.last_chg_idx if chg else w.last_rcv_idx):
+                gap_limit = True
+    if gap_limit:
+        data["warning"] = ("#ff0000 Possible gap limit exceeded with some#\n"
+                           "#ff0000 addresses. Your funds may get locked. #\n "
+                           "#ff0000 Proceed at your own risk!#")
+
     title = "Spending %u\nfrom %s" % (data["spending"], data["wallet"].name)
     popups.prompt_tx(title, data,
-        ok=cb_with_args(sign_psbt, wallet=data["wallet"], tx=tx, success_callback=success_callback), 
+        ok=cb_with_args(sign_psbt, wallet=data["wallet"], tx=tx, success_callback=success_callback),
         cancel=cb_with_args(error_callback, "user cancel")
     )
 


### PR DESCRIPTION
## Abstract

Close #50 

## Status

~WIP~ Ready for review:
- [x] final testing
- [x] extracting indexes from compressed and full PSBTs
- [x] noticed also: on verify address screen cancel button does not work if running telnet
   * opened a new issue #60
- [x] when creating a new wallet initialize indexes with -1, so that we correctly browse wallet addresses. If we initialize with 0  we cant know if the address was used already or not
- [x] when browsing wallet addresses we currently allow to go back to address Nr. 1 regardless of max indexes . Should we disallow that or warn that these addresses may have been used already? -> Warnings added.