### PR TITLE
Add minimal main code for hwidevice, print what telnet ports are for

### DIFF
--- a/hwidevice.py
+++ b/hwidevice.py
@@ -351,3 +351,29 @@ class SpecterSimulator(SpecterBase):
         res = self.read_until(s, self.EOL, timeout)[:-len(self.EOL)]
         s.close()
         return res.decode()
+
+###### test for communication ######
+
+if __name__ == '__main__':
+    import sys
+
+    devices = enumerate()
+    if len(devices) == 0:
+        print("No devices found")
+        sys.exit()
+    inp = 0;
+    if len(devices) > 1:
+        print("Found %d devices." % len(devices))
+        for i, dev in enumerate(devices):
+            print("[%d]" % i, dev)
+        inp = int(raw_input("Enter the device number to use:"))
+        if inp > len(devices):
+            print("Meh... Screw you.")
+            sys.exit()
+    dev = SpecterClient(devices[inp]["path"])
+    mfp = dev.get_master_fingerprint_hex()
+    derivation = "m/84h/0h/0h"
+    xpub = dev.get_pubkey_at_path(derivation)["xpub"]
+    print(f"Device fingerprint: {mfp}")
+    print(f"Segwit xpub: {xpub}")
+    print(f"Full key: [{mfp}{derivation[1:]}]{xpub}")

--- a/src/hosts/qr.py
+++ b/src/hosts/qr.py
@@ -60,6 +60,8 @@ class QRHost(Host):
         self.data = b""
         self.uart_bus = uart
         self.uart = pyb.UART(uart, baudrate, read_buf_len=2048)
+        if simulator:
+            print("Connect to 127.0.0.1:22849 to send QR code content")
         self.trigger = None
         self.is_configured = False
         if trigger is not None or simulator:

--- a/src/hosts/usb.py
+++ b/src/hosts/usb.py
@@ -32,6 +32,8 @@ class USBHost(Host):
         if self.usb is None:
             self.usb = pyb.USB_VCP()
             self.usb.init(flow=(pyb.USB_VCP.RTS | pyb.USB_VCP.CTS))
+            if platform.simulator:
+                print("Connect to 127.0.0.1:8789 to do USB communication")
 
     async def enable(self):
         # cleanup first

--- a/src/platform.py
+++ b/src/platform.py
@@ -90,7 +90,8 @@ def delete_recursively(path, include_self=False):
         return True
     raise RuntimeError("Failed to delete folder %s" % path)
 
-stlk = pyb.UART('YB',9600)
+if not simulator:
+    stlk = pyb.UART('YB',9600)
 
 def set_usb_mode(dev=False, usb=False):
     if simulator:


### PR DESCRIPTION
In simulator telnet ports are used to simulate UART and USB communication.
With this PR we add information about telnet ports on simulator. When you run the simulator you should see:

```
Running TCP-UART on 127.0.0.1 port 22849 - connect with telnet
Connect to 127.0.0.1:22849 to send QR code content
...
Running TCP-USB_VCP on 127.0.0.1 port 8789 - connect with telnet
Connect to 127.0.0.1:8789 to do USB communication
```

Also adds some minimal code to `hwidevice.py` so if the simulator is running or real device is connected you can check right away that USB communication works:

```sh
python3 hwidevice.py
```

This will print you the fingerprint of the master key, and xpub at path `m/84h/0h/0h`.