### PR TITLE
Use internal flash for key storage

### DIFF
--- a/boot/boot.py
+++ b/boot/boot.py
@@ -18,8 +18,9 @@ pyb.usb_mode(None)
 os.dupterm(None,0)
 os.dupterm(None,1)
 
-# check and mount internal flash
 # last 512 kB are used for secrets
+FLASH_SIZE = 512*1024
+# check and mount internal flash
 if os.statvfs('/flash')==os.statvfs('/qspi'):
     os.umount('/flash')
     f = pyb.Flash()
@@ -27,7 +28,7 @@ if os.statvfs('/flash')==os.statvfs('/qspi'):
     blocksize = f.ioctl(5,None) # 512
     size = numblocks*blocksize
     # we use last 512 kB
-    start = numblocks*blocksize-512*1024
+    start = numblocks*blocksize-FLASH_SIZE
     if start < 0:
         start = 0
     # try to mount

--- a/boot/boot.py
+++ b/boot/boot.py
@@ -17,3 +17,23 @@ pyb.ExtInt(pyb.Pin('B1'), pyb.ExtInt.IRQ_FALLING, pyb.Pin.PULL_NONE, pwrcb)
 pyb.usb_mode(None)
 os.dupterm(None,0)
 os.dupterm(None,1)
+
+# check and mount internal flash
+# last 512 kB are used for secrets
+if os.statvfs('/flash')==os.statvfs('/qspi'):
+    os.umount('/flash')
+    f = pyb.Flash()
+    numblocks = f.ioctl(4,None)
+    blocksize = f.ioctl(5,None) # 512
+    size = numblocks*blocksize
+    # we use last 512 kB
+    start = numblocks*blocksize-512*1024
+    if start < 0:
+        start = 0
+    # try to mount
+    try:
+        os.mount(pyb.Flash(start=start), '/flash')
+    # if fail - format and mount
+    except:
+        os.VfsFat.mkfs(pyb.Flash(start=start))
+        os.mount(pyb.Flash(start=start), '/flash')


### PR DESCRIPTION
Close https://github.com/cryptoadvance/specter-diy/issues/54

Uses the last 512 kB of internal flash for secret storage. Can be reduced further if we will hit the limit because the firmware is too large, or increased if we find what else to put there.