### PR TITLE
Add specify BIP44 account option to export screen

### DIFF
--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -1,5 +1,5 @@
 from app import BaseApp, AppError
-from gui.screens import Menu, DerivationScreen
+from gui.screens import Menu, DerivationScreen, NumericScreen
 from .screens import XPubScreen
 
 from binascii import hexlify
@@ -19,33 +19,39 @@ class XpubApp(BaseApp):
     prefixes = [b"fingerprint", b"xpub"]
 
     def __init__(self, path):
-        # we don't need to store anything
+        self.account = 0
         pass
 
     async def menu(self, show_screen, show_all=False):
         net = NETWORKS[self.network]
+        coin = net["bip32"]
         buttons = [
             (None, "Recommended"),
-            ("m/84h/%dh/0h" % net["bip32"], "Single key"),
-            ("m/48h/%dh/0h/2h" % net["bip32"], "Multisig"),
+            ("m/84h/%dh/%dh" % (coin, self.account), "Single key"),
+            ("m/48h/%dh/%dh/2h" % (coin, self.account), "Multisig"),
             (None, "Other keys"),
         ]
         if show_all:
-            coin = net["bip32"]
             buttons += [
-                ("m/84h/%dh/0h" % coin, "Single Native Segwit\nm/84h/%dh/0h" % coin),
-                ("m/49h/%dh/0h" % coin, "Single Nested Segwit\nm/49h/%dh/0h" % coin),
                 (
-                    "m/48h/%dh/0h/2h" % coin,
-                    "Multisig Native Segwit\nm/48h/%dh/0h/2h" % coin,
+                    "m/84h/%dh/%dh" % (coin, self.account),
+                    "Single Native Segwit\nm/84h/%dh/%dh" % (coin, self.account)
                 ),
                 (
-                    "m/48h/%dh/0h/1h" % coin,
-                    "Multisig Nested Segwit\nm/48h/%dh/0h/1h" % coin,
+                    "m/49h/%dh/%dh" % (coin, self.account),
+                    "Single Nested Segwit\nm/49h/%dh/%dh" % (coin, self.account)
+                ),
+                (
+                    "m/48h/%dh/%dh/2h" % (coin, self.account),
+                    "Multisig Native Segwit\nm/48h/%dh/%dh/2h" % (coin, self.account),
+                ),
+                (
+                    "m/48h/%dh/%dh/1h" % (coin, self.account),
+                    "Multisig Nested Segwit\nm/48h/%dh/%dh/1h" % (coin, self.account),
                 ),
             ]
         else:
-            buttons += [(0, "Show more keys"), (1, "Enter custom derivation")]
+            buttons += [(0, "Show more keys"), (2, "Specify BIP44 account"), (1, "Enter custom derivation")]
         # wait for menu selection
         menuitem = await show_screen(Menu(buttons, last=(255, None)))
 
@@ -60,6 +66,13 @@ class XpubApp(BaseApp):
             if der is not None:
                 await self.show_xpub(der, show_screen)
                 return True
+        elif menuitem == 2:
+            account = await show_screen(NumericScreen(current_val=str(self.account)))
+            try:
+                self.account = int(account)
+            except:
+                self.account = 0
+            return await self.menu(show_screen)
         else:
             await self.show_xpub(menuitem, show_screen)
             return True

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -51,9 +51,9 @@ class XpubApp(BaseApp):
                 ),
             ]
         else:
-            buttons += [(0, "Show more keys"), (2, "Specify BIP44 account"), (1, "Enter custom derivation")]
+            buttons += [(0, "Show more keys"), (2, "Change account number"), (1, "Enter custom derivation")]
         # wait for menu selection
-        menuitem = await show_screen(Menu(buttons, last=(255, None)))
+        menuitem = await show_screen(Menu(buttons, last=(255, None), title="Select the key"))
 
         # process the menu button:
         # back button
@@ -68,6 +68,8 @@ class XpubApp(BaseApp):
                 return True
         elif menuitem == 2:
             account = await show_screen(NumericScreen(current_val=str(self.account)))
+            if account and int(account) > 0x80000000:
+                    raise AppError('Account number too large')
             try:
                 self.account = int(account)
             except:

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -53,7 +53,9 @@ class XpubApp(BaseApp):
         else:
             buttons += [(0, "Show more keys"), (2, "Change account number"), (1, "Enter custom derivation")]
         # wait for menu selection
-        menuitem = await show_screen(Menu(buttons, last=(255, None), title="Select the key"))
+        menuitem = await show_screen(Menu(buttons, last=(255, None),
+                                          title="Select the key",
+                                          note="Current account number: %d" % self.account))
 
         # process the menu button:
         # back button

--- a/src/gui/screens/__init__.py
+++ b/src/gui/screens/__init__.py
@@ -4,7 +4,7 @@ from .alert import Alert
 from .prompt import Prompt
 from .qralert import QRAlert
 from .progress import Progress
-from .input import PinScreen, InputScreen, DerivationScreen
+from .input import PinScreen, InputScreen, DerivationScreen, NumericScreen
 from .mnemonic import MnemonicScreen, NewMnemonicScreen, RecoverMnemonicScreen
 from .transaction import TransactionScreen
 from .settings import DevSettings

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -313,3 +313,78 @@ class DerivationScreen(Screen):
                 self.ta.add_text(c)
         else:
             self.ta.add_text(c)
+
+class NumericScreen(Screen):
+    NUMERIC_CHARSET = [
+        "1",
+        "2",
+        "3",
+        "\n",
+        "4",
+        "5",
+        "6",
+        "\n",
+        "7",
+        "8",
+        "9",
+        "\n",
+        lv.SYMBOL.LEFT,
+        "0",
+        lv.SYMBOL.OK,
+        "",
+    ]
+
+    def __init__(
+        self,
+        title="Enter account number",
+        note="Default account is 0",
+        current_val='0'
+    ):
+        super().__init__()
+        self.title = add_label(title, scr=self, y=PADDING, style="title")
+        if note is not None:
+            self.note = add_label(note, scr=self, style="hint")
+            self.note.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
+
+        self.kb = lv.btnm(self)
+        self.kb.set_map(self.NUMERIC_CHARSET)
+        self.kb.set_width(HOR_RES)
+        self.kb.set_height(VER_RES // 2)
+        self.kb.align(self, lv.ALIGN.IN_BOTTOM_MID, 0, 0)
+
+        lbl = add_label('', style="title", scr=self)
+        lbl.set_y(PADDING + 150)
+        lbl.set_width(40)
+        lbl.set_x(PADDING)
+
+        self.ta = lv.ta(self)
+        self.ta.set_text("")
+        self.ta.set_width(HOR_RES - 2 * PADDING - 40)
+        self.ta.set_x(PADDING + 40)
+        self.ta.set_y(PADDING + 150)
+        self.ta.set_cursor_type(lv.CURSOR.HIDDEN)
+        self.ta.set_one_line(True)
+
+        if current_val and current_val != "0":
+            self.ta.add_text(current_val)
+
+        self.kb.set_event_cb(self.cb)
+
+    def cb(self, obj, event):
+        if event != lv.EVENT.RELEASED:
+            return
+        c = obj.get_active_btn_text()
+        if c is None:
+            return
+        account = self.ta.get_text()
+        if len(account) == 0:
+            last = '0'
+        else:
+            last = account[-1]
+        if c[0] == lv.SYMBOL.LEFT:
+            self.ta.del_char()
+        elif c[0] == lv.SYMBOL.OK:
+            self.set_value(self.ta.get_text())
+            self.ta.set_text("")
+        else:
+            self.ta.add_text(c)

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -337,14 +337,13 @@ class NumericScreen(Screen):
     def __init__(
         self,
         title="Enter account number",
-        note="Default account is 0",
         current_val='0'
     ):
         super().__init__()
         self.title = add_label(title, scr=self, y=PADDING, style="title")
-        if note is not None:
-            self.note = add_label(note, scr=self, style="hint")
-            self.note.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
+
+        self.note = add_label("Current account number: %s" % current_val, scr=self, style="hint")
+        self.note.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
 
         self.kb = lv.btnm(self)
         self.kb.set_map(self.NUMERIC_CHARSET)
@@ -364,10 +363,6 @@ class NumericScreen(Screen):
         self.ta.set_y(PADDING + 150)
         self.ta.set_cursor_type(lv.CURSOR.HIDDEN)
         self.ta.set_one_line(True)
-
-        if current_val and current_val != "0":
-            self.ta.add_text(current_val)
-
         self.kb.set_event_cb(self.cb)
 
     def cb(self, obj, event):


### PR DESCRIPTION
The Master public keys screen already allows some popular default paths and custom derivations, so this PR is just a small convenience suggestion. I added a button there to specify the BIP44 account which will be used to derive the default xpubs, so the user don't need to do it manually for every account with the custom derivation option.

<img width="592" alt="Screen Shot 2020-10-29 at 10 07 57" src="https://user-images.githubusercontent.com/10667901/97541968-ac52d880-19ce-11eb-9ff5-a8277ba50941.png">

<img width="592" alt="Screen Shot 2020-10-29 at 10 08 06" src="https://user-images.githubusercontent.com/10667901/97541979-b1178c80-19ce-11eb-92e2-26daef6c1cdf.png">

