### PR TITLE
Added cancel button for pin change

### DIFF
--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -258,7 +258,7 @@ class PinScreen(Screen):
     def cb(self, obj, event):
         if event == lv.EVENT.RELEASED:
             c = obj.get_active_btn_text()
-            if c is None:
+            if c is None or c == " ":
                 return
             if c == lv.SYMBOL.CLOSE:
                 self.reset()

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -185,14 +185,14 @@ class PinScreen(Screen):
         if subtitle is not None:
             lbl = add_label(subtitle, scr=self, style="hint")
             lbl.set_recolor(True)
-            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 0)
+            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 10)
         if note is not None:
             lbl = add_label(note, scr=self, style="hint")
-            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 180)
+            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 110)
         self.get_word = get_word
         if get_word is not None:
             self.words = add_label(get_word(b""), scr=self)
-            self.words.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 90)
+            self.words.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 140)
         btnm = lv.btnm(self)
         # shuffle numbers to make sure
         # no constant fingerprints left on screen
@@ -232,7 +232,7 @@ class PinScreen(Screen):
         self.pin.set_one_line(True)
         self.pin.set_text_align(lv.label.ALIGN.CENTER)
         self.pin.set_pwd_show_time(0)
-        self.pin.align(btnm, lv.ALIGN.OUT_TOP_MID, 0, 0)
+        self.pin.align(btnm, lv.ALIGN.OUT_TOP_MID, 0, -80)
 
         self.next_button = add_button(scr=self, callback=on_release(self.submit))
 

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -275,8 +275,6 @@ class PinScreen(Screen):
         return None if v == self.CANCEL_VALUE else v
 
     def submit(self):
-        if self.get_value() == "":
-            return
         self.release()
 
     def cancel(self):

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -107,10 +107,10 @@ class InputScreen(Screen):
     ]
 
     def __init__(
-        self,
-        title="Enter your bip-39 password:",
-        note="It is never stored on the device",
-        suggestion="",
+            self,
+            title="Enter your bip-39 password:",
+            note="It is never stored on the device",
+            suggestion="",
     ):
         super().__init__()
         self.title = add_label(title, scr=self, style="title")
@@ -177,21 +177,22 @@ class InputScreen(Screen):
 
 class PinScreen(Screen):
     network = None
+    CANCEL_VALUE = "*"
 
-    def __init__(self, title="Enter your PIN code", note=None, get_word=None, subtitle=None):
+    def __init__(self, title="Enter your PIN code", note=None, get_word=None, subtitle=None, with_cancel=False):
         super().__init__()
         self.title = add_label(title, scr=self, y=PADDING, style="title")
         if subtitle is not None:
             lbl = add_label(subtitle, scr=self, style="hint")
             lbl.set_recolor(True)
-            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 10)
+            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 0)
         if note is not None:
             lbl = add_label(note, scr=self, style="hint")
             lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 180)
         self.get_word = get_word
         if get_word is not None:
             self.words = add_label(get_word(b""), scr=self)
-            self.words.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 210)
+            self.words.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 90)
         btnm = lv.btnm(self)
         # shuffle numbers to make sure
         # no constant fingerprints left on screen
@@ -202,11 +203,11 @@ class PinScreen(Screen):
                 v = rng.get_random_bytes(1)[0] % len(buttons)
                 btnmap.append(buttons.pop(v))
             btnmap.append("\n")
-        btnmap = btnmap + [lv.SYMBOL.CLOSE, buttons.pop(), lv.SYMBOL.OK, ""]
+        btnmap = btnmap + [lv.SYMBOL.CLOSE, buttons.pop(), " ", ""]
         btnm.set_map(btnmap)
         btnm.set_width(HOR_RES)
         btnm.set_height(HOR_RES)
-        btnm.align(self, lv.ALIGN.IN_BOTTOM_MID, 0, 0)
+        btnm.align(self, lv.ALIGN.IN_BOTTOM_MID, 0, -100)
         # increase font size
         style = lv.style_t()
         lv.style_copy(style, btnm.get_style(lv.btnm.STYLE.BTN_REL))
@@ -231,9 +232,23 @@ class PinScreen(Screen):
         self.pin.set_one_line(True)
         self.pin.set_text_align(lv.label.ALIGN.CENTER)
         self.pin.set_pwd_show_time(0)
-        self.pin.align(btnm, lv.ALIGN.OUT_TOP_MID, 0, -150)
+        self.pin.align(btnm, lv.ALIGN.OUT_TOP_MID, 0, 0)
+
+        self.next_button = add_button(scr=self, callback=on_release(self.submit))
+
+        self.next_label = lv.label(self.next_button)
+        self.next_label.set_text("Next " + lv.SYMBOL.RIGHT)
+
+        if with_cancel:
+            self.cancel_button = add_button(scr=self, callback=on_release(self.cancel))
+
+            self.cancel_label = lv.label(self.cancel_button)
+            self.cancel_label.set_text(lv.SYMBOL.LEFT + " Cancel")
+
+            align_button_pair(self.cancel_button, self.next_button)
 
         btnm.set_event_cb(feed_rng(self.cb))
+
 
     def reset(self):
         self.pin.set_text("")
@@ -247,8 +262,6 @@ class PinScreen(Screen):
                 return
             if c == lv.SYMBOL.CLOSE:
                 self.reset()
-            elif c == lv.SYMBOL.OK:
-                self.release()
             else:
                 self.pin.add_text(c)
                 # add new anti-phishing word
@@ -260,6 +273,15 @@ class PinScreen(Screen):
     def get_value(self):
         return self.pin.get_text()
 
+    def submit(self):
+        if self.get_value() == "":
+            return
+        self.release()
+
+    def cancel(self):
+        # obj.del_async()
+        self.pin.set_text(self.CANCEL_VALUE)
+        self.set_value(None)
 
 class DerivationScreen(Screen):
     PATH_CHARSET = [
@@ -339,6 +361,7 @@ class DerivationScreen(Screen):
         else:
             self.ta.add_text(c)
 
+
 class NumericScreen(Screen):
     NUMERIC_CHARSET = [
         "1",
@@ -360,9 +383,9 @@ class NumericScreen(Screen):
     ]
 
     def __init__(
-        self,
-        title="Enter account number",
-        current_val='0'
+            self,
+            title="Enter account number",
+            current_val='0'
     ):
         super().__init__()
         self.title = add_label(title, scr=self, y=PADDING, style="title")

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -271,7 +271,8 @@ class PinScreen(Screen):
                     self.words.set_text(cur_words)
 
     def get_value(self):
-        return self.pin.get_text()
+        v = self.pin.get_text()
+        return None if v == self.CANCEL_VALUE else v
 
     def submit(self):
         if self.get_value() == "":

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -281,7 +281,7 @@ class PinScreen(Screen):
     def cancel(self):
         # obj.del_async()
         self.pin.set_text(self.CANCEL_VALUE)
-        self.set_value(None)
+        self.release()
 
 class DerivationScreen(Screen):
     PATH_CHARSET = [

--- a/src/keystore/ram.py
+++ b/src/keystore/ram.py
@@ -331,7 +331,7 @@ class RAMKeyStore(KeyStore):
     async def change_pin(self):
         # get_auth_word function can generate words from part of the PIN
         old_pin = await self.get_pin(title="First enter your old PIN code", with_cancel=True)
-        if old_pin == PinScreen.CANCEL_VALUE:
+        if old_pin is None:
             return
 
         # check pin - will raise if not valid

--- a/src/keystore/ram.py
+++ b/src/keystore/ram.py
@@ -279,16 +279,18 @@ class RAMKeyStore(KeyStore):
             self.show_loader("Verifying PIN code...")
             self._unlock(pin)
 
-    async def get_pin(self, title="Enter your PIN code"):
+    async def get_pin(self, title="Enter your PIN code", with_cancel=False):
         """
         Async version of the PIN screen.
         Waits for an event that is set in the callback.
         """
+
         scr = PinScreen(
             title=title,
             note="Do you recognize these words?",
             get_word=self.get_auth_word,
             subtitle=self.pin_subtitle,
+            with_cancel=with_cancel
         )
         return await self.show(scr)
 
@@ -328,7 +330,10 @@ class RAMKeyStore(KeyStore):
 
     async def change_pin(self):
         # get_auth_word function can generate words from part of the PIN
-        old_pin = await self.get_pin(title="First enter your old PIN code")
+        old_pin = await self.get_pin(title="First enter your old PIN code", with_cancel=True)
+        if old_pin == PinScreen.CANCEL_VALUE:
+            return
+
         # check pin - will raise if not valid
         self.show_loader("Verifying PIN code...")
         self._unlock(old_pin)
@@ -336,7 +341,7 @@ class RAMKeyStore(KeyStore):
         self.show_loader("Setting new PIN code...")
         self._change_pin(old_pin, new_pin)
         await self.show(
-            Alert("Success!", "PIN code is sucessfully changed!", button_text="OK")
+            Alert("Success!", "PIN code is successfully changed!", button_text="OK")
         )
 
     async def show_mnemonic(self):


### PR DESCRIPTION
Added a cancel button for 'Change device PIN' screen. 
Moved the 'confirm' button in initial PIN screen to bottom of screen for consistency.
Disabled submit when no value is entered to prevent unnecessary failed PIN attempts.

<img width="481" alt="Screenshot 2021-05-08 at 09 06 23" src="https://user-images.githubusercontent.com/83808942/117530317-be947b80-afdc-11eb-9317-974a3d2d48d4.png">

<img width="480" alt="Screenshot 2021-05-08 at 09 13 13" src="https://user-images.githubusercontent.com/83808942/117531648-d28fab80-afe3-11eb-9f42-6c7b4e71267a.png">


Edit: Fixed element positions
