### PR TITLE
added extra line for words

### DIFF
--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -188,11 +188,11 @@ class PinScreen(Screen):
             lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 10)
         if note is not None:
             lbl = add_label(note, scr=self, style="hint")
-            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 110)
+            lbl.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 90)
         self.get_word = get_word
         if get_word is not None:
             self.words = add_label(get_word(b""), scr=self)
-            self.words.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 140)
+            self.words.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 120)
         btnm = lv.btnm(self)
         # shuffle numbers to make sure
         # no constant fingerprints left on screen


### PR DESCRIPTION
Added extra room for a second line of words when using a longer (>6-7) PIN. 
Problem remains for even longer (>10-11) pin codes. Maybe a max-length should be considered for the pin code?

<img width="473" alt="Screenshot 2021-05-31 at 15 46 52" src="https://user-images.githubusercontent.com/83808942/120202894-6e00ee80-c227-11eb-8a1c-869982f1700d.png">