### PR TITLE
UX upgrades to new key screen and easier display of recovery phrase

### DIFF
--- a/src/gui/screens/mnemonic.py
+++ b/src/gui/screens/mnemonic.py
@@ -7,7 +7,7 @@ from .screen import Screen
 
 
 class MnemonicScreen(Screen):
-    def __init__(self, mnemonic="", title="Your recovery phrase", note=None):
+    def __init__(self, mnemonic="", title="Your recovery phrase:", note=None):
         super().__init__()
         self.title = add_label(title, scr=self, style="title")
         if note is not None:
@@ -30,7 +30,7 @@ class NewMnemonicScreen(MnemonicScreen):
         wordlist,
         fixer,
         title="Your recovery phrase:",
-        note="Write it down and never show to anybody.",
+        note="Write it down and never show it to anybody.",
     ):
         self.fixer = fixer
         self.wordlist = wordlist
@@ -42,11 +42,11 @@ class NewMnemonicScreen(MnemonicScreen):
         self.table.set_click(True)
 
         self.close_label.set_text(lv.SYMBOL.LEFT + " Back")
-        self.next_button = add_button(scr=self, callback=on_release(self.confirm))
+        self.done_button = add_button(scr=self, callback=on_release(self.confirm))
 
-        self.next_label = lv.label(self.next_button)
-        self.next_label.set_text("Next " + lv.SYMBOL.RIGHT)
-        align_button_pair(self.close_button, self.next_button)
+        self.done_label = lv.label(self.done_button)
+        self.done_label.set_text(lv.SYMBOL.OK + " Done")
+        align_button_pair(self.close_button, self.done_button)
 
         # toggle switch 12-24 words
         lbl = lv.label(self)
@@ -99,7 +99,7 @@ class NewMnemonicScreen(MnemonicScreen):
         word = self.table.words[idx]
         self.instruction.set_text(
             "Changing word number %d:\n%s (%d in wordlist)"
-            % (idx+1, word.upper(), self.wordlist.index(word))
+            % (idx+1, word.upper(), self.wordlist.index(word)+1)
         )
         # hide switch
         if not self.switch.get_hidden():
@@ -132,7 +132,7 @@ class NewMnemonicScreen(MnemonicScreen):
             self.table.set_mnemonic(self.fixer(mnemonic))
             self.instruction.set_text(
                 "Changing word number %d:\n%s (%d in wordlist)"
-                % (idx+1, word.upper(), self.wordlist.index(word))
+                % (idx+1, word.upper(), self.wordlist.index(word)+1)
             )
         self.kb.set_event_cb(cb)
 

--- a/src/keystore/flash.py
+++ b/src/keystore/flash.py
@@ -245,7 +245,6 @@ class FlashKeyStore(RAMKeyStore):
             (0, "Save key to flash"),
             (1, "Load key from flash"),
             (2, "Delete key from flash"),
-            (3, "Show recovery phrase"),
         ]
 
         # we stay in this menu until back is pressed
@@ -275,5 +274,4 @@ class FlashKeyStore(RAMKeyStore):
                         "Success!", "Your key is deleted from flash.", button_text="OK"
                     )
                 )
-            elif menuitem == 3:
-                await self.show_mnemonic()
+                

--- a/src/keystore/flash.py
+++ b/src/keystore/flash.py
@@ -238,7 +238,7 @@ class FlashKeyStore(RAMKeyStore):
         await super().init(show_fn, show_loader)
 
     async def storage_menu(self):
-        """Manage storage and display of the recovery phrase"""
+        """Manage storage"""
         buttons = [
             # id, text
             (None, "Key management"),

--- a/src/keystore/memorycard.py
+++ b/src/keystore/memorycard.py
@@ -313,7 +313,7 @@ In this mode device can only operate when the smartcard is inserted!"""
         await super().init(show_fn, show_loader)
 
     async def storage_menu(self):
-        """Manage storage and display of the recovery phrase"""
+        """Manage storage"""
         enabled = self.connection.isCardInserted()
         buttons = [
             # id, text

--- a/src/keystore/memorycard.py
+++ b/src/keystore/memorycard.py
@@ -321,7 +321,6 @@ In this mode device can only operate when the smartcard is inserted!"""
             (0, "Save key to the card", enabled),
             (1, "Load key from the card", enabled),
             (2, "Delete key from the card", enabled),
-            (3, "Show recovery phrase"),
         ]
 
         # we stay in this menu until back is pressed
@@ -355,5 +354,4 @@ In this mode device can only operate when the smartcard is inserted!"""
                         button_text="OK",
                     )
                 )
-            elif menuitem == 3:
-                await self.show_mnemonic()
+                

--- a/src/keystore/ram.py
+++ b/src/keystore/ram.py
@@ -353,10 +353,10 @@ class RAMKeyStore(KeyStore):
             await self.unlock()
             await self.show(MnemonicScreen(self.mnemonic))
 
-    async def storage_menu(self):
-        """Manage storage and display of the recovery phrase"""
-        # This class can only show mnemonic, can't save
-        await self.show_mnemonic()
+    # async def storage_menu(self):
+    #     """Manage storage and display of the recovery phrase"""
+    #     # This class can only show mnemonic, can't save
+    #     await self.show_mnemonic()
         """
         # Example:
         buttons = [
@@ -365,7 +365,6 @@ class RAMKeyStore(KeyStore):
             (0, "Save key to flash"),
             (1, "Load key from flash"),
             (2, "Delete key from flash"),
-            (3, "Show recovery phrase"),
         ]
         # wait for menu selection
         menuitem = await self.show(Menu(buttons, last=(255, None)))

--- a/src/keystore/ram.py
+++ b/src/keystore/ram.py
@@ -19,10 +19,7 @@ class RAMKeyStore(KeyStore):
     _set_pin, _unlock, _change_pin and other pin-related methods.
     """
 
-    # Button to go to storage menu
-    # Menu should be implemented in async storage_menu function
-    # Here we only have a single option - to show mnemonic
-    storage_button = "Show mnemonic"
+    storage_button = None
 
     def __init__(self):
         # bip39 mnemonic
@@ -352,39 +349,3 @@ class RAMKeyStore(KeyStore):
             self.lock()
             await self.unlock()
             await self.show(MnemonicScreen(self.mnemonic))
-
-    # async def storage_menu(self):
-    #     """Manage storage and display of the recovery phrase"""
-    #     # This class can only show mnemonic, can't save
-    #     await self.show_mnemonic()
-        """
-        # Example:
-        buttons = [
-            # id, text
-            (None, "Key management"),
-            (0, "Save key to flash"),
-            (1, "Load key from flash"),
-            (2, "Delete key from flash"),
-        ]
-        # wait for menu selection
-        menuitem = await self.show(Menu(buttons, last=(255, None)))
-
-        # process the menu button:
-        # back button
-        if menuitem == 255:
-            pass
-        elif menuitem == 0:
-            await self.save_mnemonic()
-            await self.show(Alert("Success!",
-                                 "Your key is stored in flash now."))
-        elif menuitem == 1:
-            await self.load_mnemonic()
-            await self.show(Alert("Success!",
-                                 "Your key is loaded."))
-        elif menuitem == 2:
-            await self.delete_mnemonic()
-            await self.show(Alert("Success!",
-                                 "Your key is deleted from flash."))
-        elif menuitem == 3:
-            await self.show(MnemonicScreen(self.mnemonic))
-        """

--- a/src/keystore/sdcard.py
+++ b/src/keystore/sdcard.py
@@ -128,7 +128,7 @@ class SDKeyStore(FlashKeyStore):
             return True
 
     async def storage_menu(self):
-        """Manage storage and display of the recovery phrase"""
+        """Manage storage"""
         buttons = [
             # id, text
             (None, "Manage keys on SD card and internal flash"),

--- a/src/keystore/sdcard.py
+++ b/src/keystore/sdcard.py
@@ -135,8 +135,6 @@ class SDKeyStore(FlashKeyStore):
             (0, "Save key"),
             (1, "Load key"),
             (2, "Delete key"),
-            (None, "Other"),
-            (3, "Show recovery phrase"),
         ]
 
         # we stay in this menu until back is pressed
@@ -162,5 +160,4 @@ class SDKeyStore(FlashKeyStore):
                     await self.show(
                         Alert("Success!", "Your key is deleted.", button_text="OK")
                     )
-            elif menuitem == 3:
-                await self.show_mnemonic()
+                    

--- a/src/specter.py
+++ b/src/specter.py
@@ -277,7 +277,7 @@ class Specter:
         ]
         if self.keystore.storage_button is not None:
             buttons.append((0, self.keystore.storage_button))
-        buttons.extend([(2, "Enter BIP-39 password"), (None, "Security")])  # delimiter
+        buttons.extend([(2, "Enter BIP-39 password"), (3, "Show recovery phrase"), (None, "Security")])  # delimiter
         buttons.extend([(4, "Device settings")])
         # wait for menu selection
         menuitem = await self.gui.menu(buttons, last=(255, None), note="Firmware version %s" % get_version())
@@ -295,6 +295,8 @@ class Specter:
             self.keystore.set_mnemonic(password=pwd)
             for app in self.apps:
                 app.init(self.keystore, self.network, self.gui.show_loader)
+        elif menuitem == 3:
+            await self.keystore.show_mnemonic()
         elif menuitem == 4:
             await self.update_devsettings()
         elif menuitem == 5:

--- a/src/specter.py
+++ b/src/specter.py
@@ -276,9 +276,11 @@ class Specter:
             (None, "Key management"),
         ]
         if self.keystore.storage_button is not None:
-            buttons.append((0, self.keystore.storage_button))
-        buttons.extend([(2, "Enter BIP-39 password"), (3, "Show recovery phrase"), (None, "Security")])  # delimiter
-        buttons.extend([(4, "Device settings")])
+            buttons.append((1, self.keystore.storage_button))
+        buttons.append((2, "Enter BIP-39 password"))
+        if hasattr(self.keystore, "show_mnemonic"):
+            buttons.append((3, "Show recovery phrase"))
+        buttons.extend([(None, "Security"), (4, "Device settings")])  # delimiter
         # wait for menu selection
         menuitem = await self.gui.menu(buttons, last=(255, None), note="Firmware version %s" % get_version())
 
@@ -286,7 +288,7 @@ class Specter:
         # back button
         if menuitem == 255:
             return self.mainmenu
-        elif menuitem == 0:
+        elif menuitem == 1:
             await self.keystore.storage_menu()
         elif menuitem == 2:
             pwd = await self.gui.get_input()


### PR DESCRIPTION
1. Generate new key
- New word numbering, words from the BIP39 wordlist are now displayed from 1-2048 instead of 0-2047
- "Next button" replaced by a "done button" to make clear that there is no other step.

<img width="480" alt="grafik" src="https://user-images.githubusercontent.com/70536101/121227413-d1c09280-c88b-11eb-83a2-cda8c45932e4.png">

<img width="480" alt="grafik" src="https://user-images.githubusercontent.com/70536101/121227440-d8e7a080-c88b-11eb-9f5a-7a1a931a9cd6.png">


2. Display of recovery phrase
-  Thus far, the display of the recovery phrase was a bit hidden, moved it one level higher to the settings screen. 

<img width="470" alt="grafik" src="https://user-images.githubusercontent.com/70536101/121226944-5c54c200-c88b-11eb-8de9-e091133d8e0a.png">
