### PR TITLE
add support for wallet creation from xpubs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,7 @@ class BaseApp:
         """path is the folder where this app should store data"""
         maybe_mkdir(path)
         self.path = path
+        self.communicate = None
 
     def can_process(self, stream):
         """Checks if the app can process this stream"""
@@ -39,14 +40,20 @@ class BaseApp:
         stream.seek(len(prefix) + 1)
         return prefix
 
-    def init(self, keystore, network, show_loader):
+    def init(self, keystore, network, show_loader, communicate):
         """
         This method is called when new key is loaded
         or a different network is selected.
+        `show_loader` is a function that is used to display a loader while processing data
+        `communicate` is an async function that allows cross-app communication with another apps.
+        Pass a readable stream to `communicate` function to simulate host command processing.
+        Optionally you can pass a name of the app to communicate with
+        by calling i.e. `await self.communicate(stream, app="wallets")`
         """
         self.keystore = keystore
         self.network = network
         self.show_loader = show_loader
+        self.communicate = communicate
 
     def wipe(self):
         """

--- a/src/apps/getrandom.py
+++ b/src/apps/getrandom.py
@@ -12,7 +12,7 @@ from rng import get_random_bytes
 
 class App(BaseApp):
     """Allows to query random bytes from on-board TRNG."""
-
+    name = "random"
     prefixes = [b"getrandom"]
 
     async def process_host_command(self, stream, show_fn):

--- a/src/apps/label.py
+++ b/src/apps/label.py
@@ -11,7 +11,7 @@ from io import BytesIO
 
 class App(BaseApp):
     """Allows to set a label for the device."""
-
+    name = "label"
     prefixes = [b"getlabel", b"setlabel"]
 
     async def process_host_command(self, stream, show_screen):

--- a/src/apps/signmessage/signmessage.py
+++ b/src/apps/signmessage/signmessage.py
@@ -17,6 +17,7 @@ class MessageApp(BaseApp):
     """
 
     prefixes = [b"signmessage"]
+    name = "message"
 
     async def process_host_command(self, stream, show_screen):
         """

--- a/src/apps/wallets/wallet.py
+++ b/src/apps/wallets/wallet.py
@@ -254,7 +254,9 @@ class Wallet:
     def parse(cls, desc, path=None):
         name = "Untitled"
         if "&" in desc:
-            name, desc = desc.split("&")
+            arr = desc.split("&")
+            desc = arr[-1]
+            name = "&".join(arr[:-1]) # so name with & can be parsed as well
         w = cls.from_descriptor(desc, path)
         w.name = name
         return w

--- a/src/apps/xpubs/screens.py
+++ b/src/apps/xpubs/screens.py
@@ -1,11 +1,12 @@
 """Bitcoin-related screens"""
 import lvgl as lv
-from gui.common import PADDING, styles, add_button
+from gui.common import PADDING, styles, add_button_pair
 from gui.decorators import on_release
 from gui.screens.qralert import QRAlert
 
 
 class XPubScreen(QRAlert):
+    CREATE_WALLET = 0x01 # command to create a wallet
     def __init__(
         self,
         xpub,
@@ -13,8 +14,7 @@ class XPubScreen(QRAlert):
         prefix=None,
         title="Your master public key",
         qr_width=None,
-        button_text="Close",
-        sd=True,
+        button_text="Close"
     ):
         message = xpub
         if slip132 is not None:
@@ -47,12 +47,20 @@ class XPubScreen(QRAlert):
             self.prefix_switch.set_event_cb(on_release(self.toggle_event))
         if slip132 is not None:
             self.slip_switch.set_event_cb(on_release(self.toggle_event))
-
-        if sd:
-            btn = add_button("Save to SD card", on_release(self.save_to_sd), y=610, scr=self)
+        btn = add_button_pair(
+                lv.SYMBOL.SAVE + " Save to SD", on_release(self.save_to_sd),
+                lv.SYMBOL.PLUS + " Create wallet", on_release(self.create_wallet),
+                y=610, scr=self)
 
     def save_to_sd(self):
+        """
+        Returns the xpub in the form we want to save
+        (canonical / slip39, with or without derivation)
+        """
         self.set_value(self.message.get_text())
+
+    def create_wallet(self):
+        self.set_value(self.CREATE_WALLET)
 
     def toggle_event(self):
         msg = self.xpub

--- a/src/specter.py
+++ b/src/specter.py
@@ -154,6 +154,13 @@ class Specter:
                 next_fn = await self.handle_exception(e, self.setup)
                 await next_fn()
 
+    def init_apps(self):
+        for app in self.apps:
+            app.init(self.keystore, self.network, self.gui.show_loader, self.cross_app_communicate)
+
+    async def cross_app_communicate(self, stream, app:str=None):
+        return await self.process_host_request(stream, popup=False, appname=app)
+
     async def initmenu(self):
         # for every button we use an ID
         # to avoid mistakes when editing strings
@@ -176,8 +183,7 @@ class Specter:
             if mnemonic is not None:
                 # load keys using mnemonic and empty password
                 self.keystore.set_mnemonic(mnemonic.strip(), "")
-                for app in self.apps:
-                    app.init(self.keystore, self.network, self.gui.show_loader)
+                self.init_apps()
                 return self.mainmenu
         # recover
         elif menuitem == 1:
@@ -187,8 +193,7 @@ class Specter:
             if mnemonic is not None:
                 # load keys using mnemonic and empty password
                 self.keystore.set_mnemonic(mnemonic, "")
-                for app in self.apps:
-                    app.init(self.keystore, self.network, self.gui.show_loader)
+                self.init_apps()
                 self.current_menu = self.mainmenu
                 return self.mainmenu
         elif menuitem == 2:
@@ -197,8 +202,7 @@ class Specter:
             if not res:
                 return
             # await self.gui.alert("Success!", "Key is loaded from flash!")
-            for app in self.apps:
-                app.init(self.keystore, self.network, self.gui.show_loader)
+            self.init_apps()
             return self.mainmenu
         elif menuitem == 3:
             await self.update_devsettings()
@@ -293,8 +297,7 @@ class Specter:
             if pwd is None:
                 return self.settingsmenu
             self.keystore.set_mnemonic(password=pwd)
-            for app in self.apps:
-                app.init(self.keystore, self.network, self.gui.show_loader)
+            self.init_apps()
         elif menuitem == 4:
             await self.update_devsettings()
         elif menuitem == 5:
@@ -323,8 +326,7 @@ class Specter:
             f.write(net)
         if self.keystore.is_ready:
             # load wallets for this network
-            for app in self.apps:
-                app.init(self.keystore, self.network, self.gui.show_loader)
+            self.init_apps()
 
     def load_network(self, path, network="main"):
         try:
@@ -414,7 +416,7 @@ class Specter:
         for host in self.hosts:
             host.load_settings(self.keystore)
 
-    async def process_host_request(self, stream, popup=True):
+    async def process_host_request(self, stream, popup=True, appname=None):
         """
         This method is called whenever we got data from the host.
         It tries to find a proper app and pass the stream with data to it.
@@ -423,17 +425,22 @@ class Specter:
         res = None
         try:
             matching_apps = []
-            for app in self.apps:
-                stream.seek(0)
-                # check if the app can process this stream
-                if app.can_process(stream):
-                    matching_apps.append(app)
+            if appname is not None:
+                for app in self.apps:
+                    if app.name == appname:
+                        matching_apps.append(app)
+            else:
+                for app in self.apps:
+                    stream.seek(0)
+                    # check if the app can process this stream
+                    if app.can_process(stream):
+                        matching_apps.append(app)
             if len(matching_apps) == 0:
-                raise HostError("Host command is not recognized")
+                raise HostError("Can't find matching app for this request")
             # TODO: if more than one - ask which one to use
             if len(matching_apps) > 1:
                 raise HostError(
-                    "Not sure what app to use... " "There are %d" % len(matching_apps)
+                    "Not sure what app to use...\n\nThere are %d" % len(matching_apps)
                 )
             stream.seek(0)
             app = matching_apps[0]


### PR DESCRIPTION
Now whenever you go to the xpub screen you can save this key to SD card or create a new wallet using this key. If the key derivation follows bip84, bip49 rules DIY will recommend corresponding wallet type, but in principle you can go crazy and even use your multisig xpub in singlesig wallet (but you shouldn't...).

Also this PR adds cross-app communication that may be useful in the future development. Any app can now pretend to be a "host" and ask any other app to do something. All verification and confirmation rules still apply as for communication with the host.

Close https://github.com/cryptoadvance/specter-diy/issues/80

Next: add cosigners app that can store xpubs and derivations of your cosigners and assist in multisig wallet creation process. Creation of custom miniscript wallets is not supported in the GUI yet, but let me know if you want this.