### PR TITLE
add allow_empty flag for input screen

### DIFF
--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -113,7 +113,10 @@ class WalletManager(BaseApp):
                     self.delete_wallet(w)
             elif cmd == EDIT:
                 scr = InputScreen(
-                    title="Enter new wallet name", note="", suggestion=w.name
+                    title="Enter new wallet name",
+                    note="",
+                    suggestion=w.name,
+                    allow_empty=False
                 )
                 name = await show_screen(scr)
                 if name is not None and name != w.name and name != "":

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -116,7 +116,7 @@ class WalletManager(BaseApp):
                     title="Enter new wallet name",
                     note="",
                     suggestion=w.name,
-                    allow_empty=False
+                    min_length=1, strip=True
                 )
                 name = await show_screen(scr)
                 if name is not None and name != w.name and name != "":

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -246,7 +246,8 @@ class XpubApp(BaseApp):
                 i += 1
             name = await show_screen(InputScreen(title="Name your wallet",
                     note="",
-                    suggestion=name_suggestion
+                    suggestion=name_suggestion,
+                    allow_empty=False
             ))
             if not name:
                 return

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -247,7 +247,7 @@ class XpubApp(BaseApp):
             name = await show_screen(InputScreen(title="Name your wallet",
                     note="",
                     suggestion=name_suggestion,
-                    allow_empty=False
+                    min_length=1, strip=True
             ))
             if not name:
                 return

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -111,11 +111,16 @@ class InputScreen(Screen):
             title="Enter your bip-39 password:",
             note="It is never stored on the device",
             suggestion="",
-            allow_empty=True,
+            min_length=0,
+            max_length=None,
+            strip=False,
     ):
         super().__init__()
         self.title = add_label(title, scr=self, style="title")
-        self.allow_empty = allow_empty
+        self.min_length = min_length
+        self.max_length = max_length
+        self.strip = strip
+
         if note is not None:
             self.note = add_label(note, scr=self, style="hint")
             self.note.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
@@ -175,6 +180,8 @@ class InputScreen(Screen):
                 if not self.check_text():
                     return
                 self.ta.set_text("")
+                if self.strip:
+                    text = text.strip()
                 self.set_value(text)
             elif c == lv.SYMBOL.LEFT + " Back":
                 self.ta.set_text("")
@@ -185,12 +192,15 @@ class InputScreen(Screen):
                 self.check_text()
 
     def check_text(self):
-        if self.allow_empty:
-            return True
         text = self.ta.get_text()
-        # check if input is empty:
-        if not text.strip():
-            self.warning.set_text("Enter at least one non-space character")
+        if self.strip:
+            text = text.strip()
+        # check if input matches the limits
+        if len(text) < self.min_length:
+            self.warning.set_text("Enter at least %d%s character" % (self.min_length, " non-space" if self.strip else ""))
+            return False
+        if self.max_length and len(text) > self.max_length:
+            self.warning.set_text("Value is too long! Must be between %d and %d characters" % (self.min_length, self.max_length))
             return False
         self.warning.set_text("")
         return True

--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -111,9 +111,11 @@ class InputScreen(Screen):
             title="Enter your bip-39 password:",
             note="It is never stored on the device",
             suggestion="",
+            allow_empty=True,
     ):
         super().__init__()
         self.title = add_label(title, scr=self, style="title")
+        self.allow_empty = allow_empty
         if note is not None:
             self.note = add_label(note, scr=self, style="hint")
             self.note.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
@@ -137,6 +139,9 @@ class InputScreen(Screen):
 
         self.kb.set_event_cb(self.cb)
 
+        self.warning = add_label("", scr=self, style="hint")
+        self.warning.align(self.ta, lv.ALIGN.OUT_BOTTOM_MID, 0, 10)
+
     def cb(self, obj, event):
         if event == lv.EVENT.RELEASED:
             c = obj.get_active_btn_text()
@@ -146,6 +151,7 @@ class InputScreen(Screen):
                 c = " "
             if c == lv.SYMBOL.LEFT:
                 self.ta.del_char()
+                self.check_text()
             elif c == lv.SYMBOL.UP or c == lv.SYMBOL.DOWN:
                 for i, ch in enumerate(self.CHARSET):
                     if ch.isalpha():
@@ -166,14 +172,28 @@ class InputScreen(Screen):
                 self.ta.set_text("")
             elif c[0] == lv.SYMBOL.OK:
                 text = self.ta.get_text()
+                if not self.check_text():
+                    return
                 self.ta.set_text("")
                 self.set_value(text)
             elif c == lv.SYMBOL.LEFT + " Back":
                 self.ta.set_text("")
                 self.set_value(None)
             else:
+                # check if input is empty:
                 self.ta.add_text(c)
+                self.check_text()
 
+    def check_text(self):
+        if self.allow_empty:
+            return True
+        text = self.ta.get_text()
+        # check if input is empty:
+        if not text.strip():
+            self.warning.set_text("Enter at least one non-space character")
+            return False
+        self.warning.set_text("")
+        return True
 
 class PinScreen(Screen):
     network = None

--- a/src/keystore/sdcard.py
+++ b/src/keystore/sdcard.py
@@ -201,7 +201,7 @@ class SDKeyStore(FlashKeyStore):
                  "Give each seed a unique name!",
             suggestion="",
     ):
-        scr = InputScreen(title, note, suggestion, allow_empty=False)
+        scr = InputScreen(title, note, suggestion, min_length=1, strip=True)
         await self.show(scr)
         return scr.get_value()
 

--- a/src/keystore/sdcard.py
+++ b/src/keystore/sdcard.py
@@ -200,7 +200,7 @@ class SDKeyStore(FlashKeyStore):
                  "Give each seed a unique name!",
             suggestion="",
     ):
-        scr = InputScreen(title, note, suggestion)
+        scr = InputScreen(title, note, suggestion, allow_empty=False)
         await self.show(scr)
         return scr.get_value()
 


### PR DESCRIPTION
Now input screen will not accept an empty input or input that only has spaces when renaming wallets and saving seeds.
This does not affect the bip39-password screen as there empty input is the default.

![empty-input](https://user-images.githubusercontent.com/1706012/122641153-b4998880-d103-11eb-9653-9015033b3595.png)
