### PR TITLE
add basic taproot support

### DIFF
--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -273,6 +273,8 @@ class WalletManager(BaseApp):
             platform.delete_recursively(self.tempdir)
         else:
             psbt = PSBT.read_from(stream, compress=True)
+        # verify non_witness_utxo hashes
+        psbt.verify(ignore_missing=True)
         # check if all utxos are there and if there are custom sighashes
         sighash = SIGHASH.ALL
         custom_sighashes = []

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -338,6 +338,10 @@ class WalletManager(BaseApp):
             out_psbt = PSBT(psbt.tx)
             sigsEnd = 0
             for i, inp in enumerate(psbt.inputs):
+                if inp.final_scriptwitness:
+                    sigsEnd += 1
+                    out_psbt.inputs[i].final_scriptwitness = inp.final_scriptwitness
+                    continue
                 sigsEnd += len(list(inp.partial_sigs.keys()))
                 out_psbt.inputs[i].partial_sigs = inp.partial_sigs
             del psbt

--- a/src/apps/wallets/wallet.py
+++ b/src/apps/wallets/wallet.py
@@ -284,7 +284,9 @@ class Wallet:
 
     @property
     def full_policy(self):
-        if self.descriptor.is_segwit:
+        if self.descriptor.is_taproot:
+            p = "Taproot\n"
+        elif self.descriptor.is_segwit:
             p = "Nested Segwit\n" if self.descriptor.is_wrapped else "Native Segwit\n"
         else:
             p = "Legacy\n"

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -40,6 +40,10 @@ class XpubApp(BaseApp):
         if show_all:
             buttons += [
                 (
+                    "m/86h/%dh/%dh" % (coin, self.account),
+                    "Single Taproot\nm/86h/%dh/%dh" % (coin, self.account)
+                ),
+                (
                     "m/84h/%dh/%dh" % (coin, self.account),
                     "Single Native Segwit\nm/84h/%dh/%dh" % (coin, self.account)
                 ),
@@ -110,6 +114,7 @@ class XpubApp(BaseApp):
         derivations = [
             ('bip49', "p2wpkh", "m/49'/%d'/%d'" % (coin, self.account)),
             ('bip84', "p2sh-p2wpkh", "m/84'/%d'/%d'" % (coin, self.account)),
+            ('bip86', "p2tr", "m/86'/%d'/%d'" % (coin, self.account)),
             ('bip44', "p2pkh", "m/44'/%d'/%d'" % (coin, self.account)),
             ('bip48_2', "p2wsh", "m/48'/%d'/%d'/2'" % (coin, self.account)),
             ('bip48_1', "p2sh-p2wsh", "m/48'/%d'/%d'/1'" % (coin, self.account)),
@@ -203,6 +208,7 @@ class XpubApp(BaseApp):
         net = NETWORKS[self.network]
         descriptors = OrderedDict({
             "zpub": ("wpkh(%s%s/{0,1}/*)" % (prefix, xpub), "Native Segwit"),
+            "taproot": ("tr(%s%s/{0,1}/*)" % (prefix, xpub), "Taproot"),
             "ypub": ("sh(wpkh(%s%s/{0,1}/*))" % (prefix, xpub), "Nested Segwit"),
             "legacy": ("pkh(%s%s/{0,1}/*)" % (prefix, xpub), "Legacy"),
             # multisig is not supported yet - requires cosigners app
@@ -217,6 +223,18 @@ class XpubApp(BaseApp):
             buttons = [
                 (None, "Recommended"),
                 descriptors.pop("zpub"),
+                (None, "Other"),
+            ]
+        elif "/86h/" in derivation:
+            buttons = [
+                (None, "Recommended"),
+                descriptors.pop("taproot"),
+                (None, "Other"),
+            ]
+        elif "/44h/" in derivation:
+            buttons = [
+                (None, "Recommended"),
+                descriptors.pop("legacy"),
                 (None, "Other"),
             ]
         else:
@@ -236,6 +254,8 @@ class XpubApp(BaseApp):
                 name_suggestion = "Native %d" % self.account
             elif menuitem.startswith("sh(wpkh("):
                 name_suggestion = "Nested %d" % self.account
+            if menuitem.startswith("tr("):
+                name_suggestion = "Taproot %d" % self.account
             else:
                 name_suggestion = "Wallet %d" % self.account
             nn = name_suggestion


### PR DESCRIPTION
For now single-sig only.
Some specs for psbt in taproot are not final yet, so no support for tap script trees yet.
Most changes were made in `embit` - see https://github.com/diybitcoinhardware/embit/pull/17

- [x] bip86 xpub, wallet creation
- [x] psbt signing with schnorr
- [ ] address verification via USB
- [ ] add integration tests for taproot
- [ ] fix broken integration tests for legacy