### PR TITLE
Use PSBTView - RAM efficient PSBT implementation

### DIFF
--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -294,11 +294,13 @@ class WalletManager(BaseApp):
                 return self.tempdir+"/signed_b64"
             return
 
+        self.show_loader(title="Parsing transaction...")
         psbtv = PSBTView.view(stream, compress=True)
         # check if all utxos are there and if there are custom sighashes
         sighash = SIGHASH.ALL
         custom_sighashes = []
         for i in range(psbtv.num_inputs):
+            self.show_loader(title="Parsing input %d of %d..." % (i+1, psbtv.num_inputs))
             inp = psbtv.input(i)
             inp.verify(ignore_missing=True)
             if (not inp.is_verified) and inp.witness_utxo is None and inp.non_witness_utxo is None:
@@ -355,7 +357,7 @@ class WalletManager(BaseApp):
             with open(self.tempdir+"/sigs", "wb") as sig_stream:
                 sig_count = 0
                 for i in range(psbtv.num_inputs):
-                    self.show_loader(title="Signing input %d of %d" % (i, psbtv.num_inputs))
+                    self.show_loader(title="Signing input %d of %d" % (i+1, psbtv.num_inputs))
                     inp = psbtv.input(i)
                     for w, _ in wallets:
                         if w is None:
@@ -576,6 +578,7 @@ class WalletManager(BaseApp):
         }
         # detect wallet for all inputs
         for i in range(psbtv.num_inputs):
+            self.show_loader(title="Detecting wallet for input %d of %d..." % (i+1, psbtv.num_inputs))
             inp = psbtv.input(i)
             found = False
             meta["inputs"][i] = {
@@ -616,6 +619,7 @@ class WalletManager(BaseApp):
 
         # check change outputs
         for i in range(psbtv.num_outputs):
+            self.show_loader(title="Detecting wallet for output %d of %d..." % (i+1, psbtv.num_outputs))
             out = psbtv.output(i)
             for w in wallets:
                 if w is None:

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -273,6 +273,8 @@ class WalletManager(BaseApp):
             platform.delete_recursively(self.tempdir)
         else:
             psbt = PSBT.read_from(stream, compress=True)
+        # verify non_witness_utxo hashes
+        psbt.verify(ignore_missing=True)
         # check if all utxos are there and if there are custom sighashes
         sighash = SIGHASH.ALL
         custom_sighashes = []

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -208,18 +208,31 @@ class WalletManager(BaseApp):
             with open(self.tempdir+"/raw", "rb") as f:
                 res = await self.sign_psbt(f, show_screen, encoding=RAW_STREAM)
             if res is not None:
-                if isinstance(res, str):
-                    with open(res, "rb") as f:
-                        data, hsh = bcur_encode(f.read(), upper=True)
-                else:
-                    data, hsh = bcur_encode(res.read(), upper=True)
-                bcur_res = (b"UR:BYTES/" + hsh + "/" + data)
+                # bcur-encode to temp data file
+                with open(self.tempdir+"/bcur_data", "wb") as fout:
+                    if isinstance(res, str):
+                        with open(res, "rb") as fin:
+                            l, hsh = bcur_encode_stream(fin, fout, upper=True)
+                    else:
+                        l, hsh = bcur_encode_stream(res, fout, upper=True)
+                # add prefix and hash
+                with open(self.tempdir+"/bcur_full", "wb") as fout:
+                    fout.write(b"UR:BYTES/")
+                    fout.write(hsh)
+                    fout.write(b"/")
+                    with open(self.tempdir+"/bcur_data", "rb") as fin:
+                        b = bytearray(100)
+                        while True:
+                            l = fin.readinto(b)
+                            if l == 0:
+                                break
+                            fout.write(b, l)
                 obj = {
                     "title": "Transaction is signed!",
                     "message": "Scan it with your wallet",
                 }
                 gc.collect()
-                return BytesIO(bcur_res), obj
+                return self.tempdir+"/bcur_full", obj
             return
         elif cmd == LIST_WALLETS:
             wnames = json.dumps([w.name for w in self.wallets])

--- a/src/gui/components/qrcode.py
+++ b/src/gui/components/qrcode.py
@@ -4,6 +4,7 @@ import qrcode
 import math
 import gc
 import asyncio
+import platform
 
 qr_style = lv.style_t()
 qr_style.body.main_color = lv.color_hex(0xFFFFFF)
@@ -124,7 +125,7 @@ class QRCode(lv.obj):
         self.note.align(self, lv.ALIGN.IN_BOTTOM_MID, 0, 0)
 
     def set_text(self, text="Text"):
-        if self._text != text:
+        if platform.simulator and self._text != text:
             print("QR on screen:", text)
         self._text = text
         self.idx = None

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -129,4 +129,4 @@ def b2a_base64_stream(sin, sout):
         chunk = sin.read(48) # 16 quants 3 bytes each
         if len(chunk) == 0:
             break
-        sout.write(b2a_base64(chunk))
+        sout.write(b2a_base64(chunk).strip())

--- a/src/hosts/qr.py
+++ b/src/hosts/qr.py
@@ -468,7 +468,12 @@ class QRHost(Host):
             return stream
 
     async def send_data(self, stream, meta):
-        response = stream.read().decode()
+        # if it's str - it's a file
+        if isinstance(stream, str):
+            with open(stream, "r") as f:
+                response = f.read()
+        else:
+            response = stream.read().decode()
         title = "Your data:"
         note = None
         if "title" in meta:

--- a/src/hosts/usb.py
+++ b/src/hosts/usb.py
@@ -80,12 +80,20 @@ class USBHost(Host):
             self.respond(b"error: User cancelled")
         else:
             stream, meta = res
-            # loop until we read everything
+            # if it's str - it's a filename
+            if isinstance(stream, str):
+                with open(stream, "rb") as f:
+                    self._send_data(f)
+            else:
+                self._send_data(stream)
+
+    def _send_data(self, stream):
+        # loop until we read everything
+        chunk = stream.read(32)
+        while len(chunk) > 0:
+            self.usb.write(chunk)
             chunk = stream.read(32)
-            while len(chunk) > 0:
-                self.usb.write(chunk)
-                chunk = stream.read(32)
-            self.respond(b"")
+        self.respond(b"")
 
     def respond(self, data):
         self.usb.write(data)

--- a/src/keystore/ram.py
+++ b/src/keystore/ram.py
@@ -65,6 +65,9 @@ class RAMKeyStore(KeyStore):
     def sign_psbt(self, psbt, sighash=SIGHASH.ALL):
         psbt.sign_with(self.root, sighash)
 
+    def sign_input(self, psbtv, i, sig_stream, sighash=SIGHASH.ALL, extra_scope_data=None):
+        return psbtv.sign_input(i, self.root, sig_stream, sighash=sighash, extra_scope_data=extra_scope_data)
+
     def sign_hash(self, derivation, msghash: bytes):
         return self.root.derive(derivation).key.sign(msghash)
 

--- a/src/platform.py
+++ b/src/platform.py
@@ -4,7 +4,7 @@ import os
 import pyb
 import gc
 
-simulator = sys.platform != "pyboard"
+simulator = (sys.platform in ["linux", "darwin"])
 
 try:
     import config


### PR DESCRIPTION
This PR switches from in-memory PSBT implementation to PSBTView - an implementation that only loads currently processed scope from a trusted stream.

PSBT is loaded from the host to the SDRAM first. SDRAM is a separate chip present on the board and it is not mapped to the stack or heap of Micropython to avoid leaking secrets to external chip before user authentication.
But as soon as the PIN code is verified we can consider SDRAM semi-trusted and use it for PSBT storage.

Handling 10-input transactions was already a problem on master. I tested 100 inputs transactions and signed them without any problems with this PR.