### PR TITLE
Add compatibility app to parse arbitrary files / jsons

### DIFF
--- a/src/apps/__init__.py
+++ b/src/apps/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "label",  # allows settings and getting a label for device
     "backup", # creates and loads backups (only loads for now)
     "blindingkeys", # blinding keys for liquid wallets
+    "compatibility", # compatibility layer that converts json/files to Specter format
 ]

--- a/src/apps/compatibility.py
+++ b/src/apps/compatibility.py
@@ -1,0 +1,53 @@
+"""
+This app parses data in various format that are not native to Specter
+and converts to commands that Specter will understand.
+After processing it sends converted command to a corresponding app.
+"""
+from app import BaseApp, AppError
+from io import BytesIO
+import json
+
+class App(BaseApp):
+    name = "compatibility"
+    prefixes = []
+
+    def can_process(self, stream):
+        """Detects if it can process the stream"""
+        c = stream.read(64)
+        # rewind
+        stream.seek(-len(c), 1)
+        # check if it's a json
+        if c.startswith(b"{"):
+            return True
+        return False
+
+    async def process_host_command(self, stream, show_fn):
+        # check if we've got filename, not a stream:
+        if isinstance(stream, str):
+            with open(stream, "rb") as f:
+                obj = json.load(f)
+        else:
+            obj = json.load(stream)
+        if "descriptor" in obj:
+            # this is wallet export json (Specter Desktop, FullyNoded and others)
+            return await self.parse_software_wallet_json(obj, show_fn)
+        raise AppError("Failed parsing data")
+
+    async def parse_software_wallet_json(self, obj, show_fn):
+        if "descriptor" not in obj:
+            raise AppError("Invalid wallet json")
+        # get descriptor without checksum
+        desc = obj["descriptor"].split("#")[0]
+        # replace /0/* to /{0,1}/* to add change descriptor
+        desc = desc.replace("/0/*", "/{0,1}/*")
+        label = obj.get("label", "Imported wallet")
+        s, _ = await self.communicate(BytesIO(b"listwallets"), app="wallets")
+        names = json.load(s)
+        suggestion = label
+        i = 0
+        while suggestion in names:
+            suggestion = "%s (%d)" % (label, i)
+            i += 1
+        data = "addwallet %s&%s" % (suggestion, desc)
+        stream = BytesIO(data.encode())
+        return await self.communicate(stream, app="wallets", show_fn=show_fn)

--- a/src/apps/compatibility.py
+++ b/src/apps/compatibility.py
@@ -6,6 +6,80 @@ After processing it sends converted command to a corresponding app.
 from app import BaseApp, AppError
 from io import BytesIO
 import json
+from helpers import read_until
+from bitcoin import bip32
+from binascii import unhexlify
+
+CC_TYPES = {"BIP45": "sh", "P2WSH-P2SH": "sh-wsh", "P2WSH": "wsh"}
+
+# functions that are app-agnostic, helps to test parsing
+def parse_software_wallet_json(obj):
+    """Parse software export json"""
+    if "descriptor" not in obj:
+        raise AppError("Invalid wallet json")
+    # get descriptor without checksum
+    desc = obj["descriptor"].split("#")[0]
+    # replace /0/* to /{0,1}/* to add change descriptor
+    desc = desc.replace("/0/*", "/{0,1}/*")
+    label = obj.get("label", "Imported wallet")
+    return label, desc
+
+
+def parse_cc_wallet_txt(stream):
+    """Parse coldcard wallet format"""
+    name = "Imported wallet"
+    script_type = None
+    sigs_required = None
+    global_derivation = None
+    sigs_total = None
+    cosigners = []
+    current_derivation = None
+    # cycle until we read everything
+    char = b"\n"
+    while char is not None:
+        line, char = read_until(stream, b"\r\n", max_len=300)
+        # skip comments
+        while char is not None and (line.startswith(b"#") or len(line.strip()) == 0):
+            # BW comment on derivation
+            if line.startswith(b"# derivation:"):
+                current_derivation = bip32.parse_path(line.split(b":")[1].decode().strip())
+            line, char = read_until(stream, b"\r\n", max_len=300)
+        if b":" not in line:
+            continue
+        arr = line.split(b":")
+        if len(arr) > 2:
+            raise AppError("Invalid file format")
+        k, v = [a.strip().decode() for a in arr]
+        if k == "Name":
+            name = v
+        elif k == "Policy":
+            nums = [int(num) for num in v.split(" of ")]
+            assert len(nums) == 2
+            m, n = nums
+            assert m > 0 and n >= m
+            sigs_required = m
+            sigs_total = n
+        elif k == "Format":
+            assert v in CC_TYPES
+            script_type = CC_TYPES[v]
+        elif k == "Derivation":
+            der = bip32.parse_path(v)
+            if len(cosigners) == 0:
+                global_derivation = der
+            else:
+                current_derivation = der
+        # fingerprint
+        elif len(k) == 8:
+            cosigners.append((unhexlify(k), current_derivation or global_derivation, bip32.HDKey.from_string(v)))
+            current_derivation = None
+    assert None not in [global_derivation, sigs_total, sigs_required, script_type, name]
+    assert len(cosigners) == sigs_total
+    xpubs = ["[%s]%s/{0,1}/*" % (bip32.path_to_str(der, fingerprint=fgp), xpub) for fgp, der, xpub in cosigners]
+    desc = "sortedmulti(%d,%s)" % (sigs_required, ",".join(xpubs))
+    for sc in reversed(script_type.split("-")):
+        desc = "%s(%s)" % (sc, desc)
+    return name, desc
+
 
 class App(BaseApp):
     name = "compatibility"
@@ -13,11 +87,14 @@ class App(BaseApp):
 
     def can_process(self, stream):
         """Detects if it can process the stream"""
-        c = stream.read(64)
+        c = stream.read(16)
         # rewind
         stream.seek(-len(c), 1)
         # check if it's a json
         if c.startswith(b"{"):
+            return True
+        # looks like coldcard wallet format
+        if c.startswith(b"#") or c.startswith(b"Name:"):
             return True
         return False
 
@@ -25,22 +102,21 @@ class App(BaseApp):
         # check if we've got filename, not a stream:
         if isinstance(stream, str):
             with open(stream, "rb") as f:
-                obj = json.load(f)
-        else:
+                return await self.process_host_command(f, show_fn)
+        # processing stream now
+        c = stream.read(16)
+        # rewind
+        stream.seek(-len(c), 1)
+        if c.startswith(b"{"):
             obj = json.load(stream)
-        if "descriptor" in obj:
-            # this is wallet export json (Specter Desktop, FullyNoded and others)
-            return await self.parse_software_wallet_json(obj, show_fn)
+            if "descriptor" in obj:
+                # this is wallet export json (Specter Desktop, FullyNoded and others)
+                return await self.parse_software_wallet_json(obj, show_fn)
+        elif c.startswith(b"#") or c.startswith(b"Name:"):
+            return await self.parse_cc_wallet_txt(stream, show_fn)
         raise AppError("Failed parsing data")
 
-    async def parse_software_wallet_json(self, obj, show_fn):
-        if "descriptor" not in obj:
-            raise AppError("Invalid wallet json")
-        # get descriptor without checksum
-        desc = obj["descriptor"].split("#")[0]
-        # replace /0/* to /{0,1}/* to add change descriptor
-        desc = desc.replace("/0/*", "/{0,1}/*")
-        label = obj.get("label", "Imported wallet")
+    async def get_wallet_name_suggestion(self, label):
         s, _ = await self.communicate(BytesIO(b"listwallets"), app="wallets")
         names = json.load(s)
         suggestion = label
@@ -48,6 +124,18 @@ class App(BaseApp):
         while suggestion in names:
             suggestion = "%s (%d)" % (label, i)
             i += 1
-        data = "addwallet %s&%s" % (suggestion, desc)
+        return suggestion
+
+    async def parse_software_wallet_json(self, obj, show_fn):
+        label, desc = parse_software_wallet_json(obj)
+        label = await self.get_wallet_name_suggestion(label)
+        data = "addwallet %s&%s" % (label, desc)
+        stream = BytesIO(data.encode())
+        return await self.communicate(stream, app="wallets", show_fn=show_fn)
+
+    async def parse_cc_wallet_txt(self, stream, show_fn):
+        label, desc = parse_cc_wallet_txt(stream)
+        label = await self.get_wallet_name_suggestion(label)
+        data = "addwallet %s&%s" % (label, desc)
         stream = BytesIO(data.encode())
         return await self.communicate(stream, app="wallets", show_fn=show_fn)

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -136,3 +136,30 @@ def b2a_base64_stream(sin, sout):
         if len(chunk) == 0:
             break
         sout.write(b2a_base64(chunk).strip())
+
+
+def read_until(s, chars=b"\n\r", max_len=100):
+    """Reads from stream until one of the chars"""
+    res = b""
+    chunk = b""
+    while True:
+        chunk = s.read(1)
+        if len(chunk) == 0:
+            return res, None
+        if chunk in chars:
+            return res, chunk
+        res += chunk
+        if len(res) > max_len:
+            return None, None
+
+def seek_to(s, chars=b"\n"):
+    """Seeks stream to one of the chars"""
+    off = 0
+    chunk = b""
+    while True:
+        chunk = s.read(1)
+        off += len(chunk)
+        if len(chunk) == 0:
+            return off, None
+        if chunk in chars:
+            return off, chunk

--- a/src/hosts/sd.py
+++ b/src/hosts/sd.py
@@ -46,7 +46,7 @@ class SDHost(Host):
         """
         self.reset_and_mount()
         try:
-            sd_file = await self.select_file([".psbt", ".txt"])
+            sd_file = await self.select_file([".psbt", ".txt", ".json"])
             if sd_file is None:
                 return
             self.sd_file = sd_file
@@ -73,8 +73,8 @@ class SDHost(Host):
         
         if len(files) == 0:
             raise HostError("\n\nNo matching files found on the SD card\nAllowed: %s" % ", ".join(extensions))
-        elif len(files) == 1:
-            return self.sdpath+"/"+ files[0]
+        # elif len(files) == 1:
+        #     return self.sdpath+"/"+ files[0]
         
         files.sort()
         buttons = []

--- a/src/specter.py
+++ b/src/specter.py
@@ -162,8 +162,8 @@ class Specter:
         for app in self.apps:
             app.init(self.keystore, self.network, self.gui.show_loader, self.cross_app_communicate)
 
-    async def cross_app_communicate(self, stream, app:str=None):
-        return await self.process_host_request(stream, popup=False, appname=app)
+    async def cross_app_communicate(self, stream, app:str=None, show_fn=None):
+        return await self.process_host_request(stream, popup=False, appname=app, show_fn=show_fn)
 
     async def initmenu(self):
         # for every button we use an ID
@@ -531,13 +531,15 @@ class Specter:
         self.GLOBAL = settings
         BaseApp.GLOBAL = settings
 
-    async def process_host_request(self, stream, popup=True, appname=None):
+    async def process_host_request(self, stream, popup=True, appname=None, show_fn=None):
         """
         This method is called whenever we got data from the host.
         It tries to find a proper app and pass the stream with data to it.
         """
         self.gui.show_loader(title="Processing host data...")
         res = None
+        if show_fn is None:
+            show_fn = self.gui.show_screen(popup)
         try:
             matching_apps = []
             if appname is not None:
@@ -559,7 +561,7 @@ class Specter:
                 )
             stream.seek(0)
             app = matching_apps[0]
-            res = await app.process_host_command(stream, self.gui.show_screen(popup))
+            res = await app.process_host_command(stream, show_fn)
         except Exception as e:
             if isinstance(e, BaseError):
                 # error that has a meaningfull message, will be sent to the host

--- a/test/tests/__init__.py
+++ b/test/tests/__init__.py
@@ -2,3 +2,4 @@ from .test_keystore import *
 from .test_wallets import *
 from .test_sign import *
 from .test_revault import *
+from .test_compatibility import *

--- a/test/tests/test_compatibility.py
+++ b/test/tests/test_compatibility.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from apps.compatibility import *
+import json
+from io import BytesIO
+
+WALLET_SOFTWARE = b'{"label": "blah", "blockheight": 0, "descriptor": "wsh(sortedmulti(1,[fb7c1f11/48h/1h/0h/2h]tpubDExnGppazLhZPNadP8Q5Vgee2QcvbyAf9GvGaEY7ALVJREaG2vdTqv1MHRoDtPaYP3y1DGVx7wrKKhsLhs26GY263uE6Wi3qNbi71AHZ6p7/0/*,[33a2bf0c/48h/1h/0h/2h]tpubDF4cAhFDn6XSPhQtFECSkQm35oEzVyHHAiPa4Qy83fBtPw9nFJAodN6xF6nY7y2xKMGc5nbDFZfAac88oaurVzrCUxyhmc9J8W5tg3N5NkS/0/*))#vk844svv", "devices": [{"type": "specter", "label": "ability"}, {"type": "coldcard", "label": "hox"}]}'
+
+COLDCARD_FILE = """
+# Coldcard Multisig setup file (created on Specter Desktop)
+#
+Name: blah
+Policy: 1 of 2
+Derivation: m/48'/1'/0'/2'
+Format: P2WSH
+FB7C1F11: tpubDExnGppazLhZPNadP8Q5Vgee2QcvbyAf9GvGaEY7ALVJREaG2vdTqv1MHRoDtPaYP3y1DGVx7wrKKhsLhs26GY263uE6Wi3qNbi71AHZ6p7
+33A2BF0C: tpubDF4cAhFDn6XSPhQtFECSkQm35oEzVyHHAiPa4Qy83fBtPw9nFJAodN6xF6nY7y2xKMGc5nbDFZfAac88oaurVzrCUxyhmc9J8W5tg3N5NkS
+"""
+
+EXPECTED = ('blah', 'wsh(sortedmulti(1,[fb7c1f11/48h/1h/0h/2h]tpubDExnGppazLhZPNadP8Q5Vgee2QcvbyAf9GvGaEY7ALVJREaG2vdTqv1MHRoDtPaYP3y1DGVx7wrKKhsLhs26GY263uE6Wi3qNbi71AHZ6p7/{0,1}/*,[33a2bf0c/48h/1h/0h/2h]tpubDF4cAhFDn6XSPhQtFECSkQm35oEzVyHHAiPa4Qy83fBtPw9nFJAodN6xF6nY7y2xKMGc5nbDFZfAac88oaurVzrCUxyhmc9J8W5tg3N5NkS/{0,1}/*))')
+
+class CompatibilityTest(TestCase):
+
+    def test_import(self):
+        self.assertEqual(EXPECTED, parse_software_wallet_json(json.load(BytesIO(WALLET_SOFTWARE))))
+        self.assertEqual(EXPECTED, parse_cc_wallet_txt(BytesIO(COLDCARD_FILE.encode())))


### PR DESCRIPTION
This app introduces a compatibility layer between different standards used in industry and Specter-DIY command format.
The first format I added here is "Export to wallet software" format used in Specter-Desktop,  Blue Wallet and a few other software wallets.
Specter-DIY can now understand QR codes / json files containing wallets in the form similar to that:
```
{"label": "random", "blockheight": 0, "descriptor": "wpkh([efb41152/84h/1h/0h]tpubDCVeSJMK2GnUEWbX3wSF9fisCXg6rjADTVfou19hbmphiJoMeBhXZCneXrbBaQFTUPMDcQ3hMgLdeFxgehKnC5nHNu3qMVQJ2fazGDN8TNx/0/*)#xx4n5gxk", "devices": [{"type": "specter", "label": "random"}]}
```

This means Specter-DIY can now add any wallet from Specter-Desktop and other software even if it is not used in these wallets as a signer.
This allows (with some tweaks) to detect what wallet the money go to.
For example Specter-DIY will be able to detect that you are transferring money to your c-lightning node, or to your mobile wallet, if this wallet was imported into DIY as watch-only.

EDIT:
Also adds compatibility with Coldcard / Blue wallet format