### PR TITLE
add single-key taproot support

### DIFF
--- a/src/apps/wallets/wallet.py
+++ b/src/apps/wallets/wallet.py
@@ -301,7 +301,9 @@ class Wallet:
 
     @property
     def full_policy(self):
-        if self.descriptor.is_segwit:
+        if self.descriptor.is_taproot:
+            p = "Taproot\n"
+        elif self.descriptor.is_segwit:
             p = "Nested Segwit\n" if self.descriptor.is_wrapped else "Native Segwit\n"
         else:
             p = "Legacy\n"
@@ -314,7 +316,7 @@ class Wallet:
 
     @property
     def is_miniscript(self):
-        return not (self.descriptor.is_basic_multisig or self.descriptor.is_pkh)
+        return not (self.descriptor.is_basic_multisig or self.descriptor.is_pkh or self.descriptor.is_taproot)
 
     def __str__(self):
         return "%s&%s" % (self.name, self.descriptor)

--- a/src/specter.py
+++ b/src/specter.py
@@ -435,7 +435,10 @@ class Specter:
             "only enable them if you really want to try.\n"
             "Report developers in case of any issues.",
         )
-        liquid, taproot = await self.gui.show_screen()(scr)
+        res = await self.gui.show_screen()(scr)
+        if res is None:
+            return
+        liquid, taproot = res
         # for now only experimental, can be extended
         settings = {
             "experimental": {


### PR DESCRIPTION
You need to enable it in experimental features to get access to the keys and be able to create wallets from xpubs screen.
Tap script tree is not supported yet.

This PR also includes a few minor fixes.