### PR TITLE
Verify gap limit (large derivation indexes)

### DIFF
--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -368,7 +368,7 @@ class WalletManager(BaseApp):
                 name = "Unknown wallet"
             else:
                 name = w.name
-            amount = wallets[w]
+            amount = wallets[w].get("amount", 0)
             spends.append('%.8f %s\nfrom "%s"' % (amount / 1e8, unit, name))
         title = "Inputs:\n" + "\n".join(spends)
         return await show_screen(TransactionScreen(title, meta))
@@ -620,7 +620,7 @@ class WalletManager(BaseApp):
         fee = 0
 
         # here we will store all wallets that we detect in inputs
-        # {wallet: amount}
+        # {wallet: {"amount": amount, "gaps": [gaps]}}
         wallets = {}
         meta = {
             "inputs": [{} for i in range(psbtv.num_inputs)],
@@ -652,6 +652,7 @@ class WalletManager(BaseApp):
             # first we check already detected wallet owns the input
             # as in most common case all inputs are owned by the same wallet.
             wallet = None
+            gaps = None
             for w in wallets:
                 # pass rangeproof offset if it's in the scope
                 if w and w.fill_scope(inp, fingerprint):
@@ -664,14 +665,23 @@ class WalletManager(BaseApp):
                     if w.fill_scope(inp, fingerprint):
                         wallet = w
                         break
+            if wallet:
+                gaps = [g for g in wallet.gaps] # copy
+                res = wallet.get_derivation(inp.bip32_derivations)
+                if res:
+                    idx, branch_idx = res
+                    gaps[branch_idx] = max(gaps[branch_idx], idx+wallet.GAP_LIMIT+1)
             # add wallet to tx wallets dict
             if wallet not in wallets:
-                wallets[wallet] = 0
+                wallets[wallet] = {"amount": 0, "gaps": gaps}
+            else:
+                if wallets[wallet]["gaps"] is not None and gaps is not None:
+                    wallets[wallet]["gaps"] = [max(g1,g2) for g1,g2 in zip(gaps, wallets[wallet]["gaps"])]
 
             value = inp.utxo.value
             fee += value
 
-            wallets[wallet] = wallets.get(wallet, 0) + value
+            wallets[wallet]["amount"] = wallets.get(wallet, {}).get("amount") + value
             metainp.update({
                 "label": wallet.name if wallet else "Unknown wallet",
                 "value": value,
@@ -718,8 +728,23 @@ class WalletManager(BaseApp):
             })
             if wallet:
                 metaout["label"] = wallet.name
-            out.write_to(fout, version=psbtv.version)
+                res = wallet.get_derivation(out.bip32_derivations)
+                if res:
+                    idx, branch_idx = res
+                    branch_txt = ""
+                    if branch_idx == 1:
+                        "change "
+                    elif branch_idx > 1:
+                        "branch %d " % branch_idx
+                    metaout["label"] = "%s %s#%d" % (wallet.name, branch_txt, idx)
+                    if wallet in wallets:
+                        allowed_idx = wallets[wallet]["gaps"][branch_idx]
+                    else:
+                        allowed_idx = wallet.gaps[branch_idx]
+                    if allowed_idx <= idx:
+                        metaout["warning"] = "Derivation index is by %d larger than last known used index %d!" % (idx-allowed_idx+wallet.GAP_LIMIT, allowed_idx-wallet.GAP_LIMIT)
 
+            out.write_to(fout, version=psbtv.version)
         meta["fee"] = fee
         return wallets, meta
 

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -625,6 +625,7 @@ class WalletManager(BaseApp):
         meta = {
             "inputs": [{} for i in range(psbtv.num_inputs)],
             "outputs": [{} for i in range(psbtv.num_outputs)],
+            "default_asset": "BTC" if self.network == "main" else "tBTC",
         }
 
         fingerprint = self.keystore.fingerprint

--- a/src/gui/screens/transaction.py
+++ b/src/gui/screens/transaction.py
@@ -51,6 +51,7 @@ class TransactionScreen(Prompt):
         style_warning = lv.style_t()
         lv.style_copy(style_warning, self.message.get_style(0))
         style_warning.text.color = lv.color_hex(0xFF9A00)
+        style_warning.text.font = lv.font_roboto_22
 
         self.style = style
         self.style_secondary = style_secondary
@@ -59,7 +60,7 @@ class TransactionScreen(Prompt):
         num_change_outputs = 0
         for out in meta["outputs"]:
             # first only show destination addresses
-            if out["change"]:
+            if out["change"] and not out.get("warning", ""):
                 num_change_outputs += 1
                 continue
             obj = self.show_output(out, obj)
@@ -77,7 +78,6 @@ class TransactionScreen(Prompt):
 
             obj = fee
 
-        # warning label for address gap limit
         if "warnings" in meta and len(meta["warnings"]) > 0:
             text = "WARNING!\n" + "\n".join(meta["warnings"])
             self.warning = add_label(text, scr=self.page)
@@ -133,11 +133,20 @@ class TransactionScreen(Prompt):
             addrlbl.set_text(format_addr(out["address"], words=4))
             addrlbl.align(lbl, lv.ALIGN.OUT_BOTTOM_LEFT, 0, 5)
             addrlbl.set_x(60)
-            if "label" in out:
+            if out.get("label", ""):
                 addrlbl.set_style(0, style_secondary)
             else:
                 addrlbl.set_style(0, style_primary)
             lbl = addrlbl
+            if "warning" in out:
+                text = out["warning"]
+                warning = add_label(text, scr=self.page2)
+                warning.set_align(lv.label.ALIGN.LEFT)
+                warning.set_width(380)
+                warning.set_style(0, self.style_warning)
+                warning.align(addrlbl, lv.ALIGN.OUT_BOTTOM_LEFT, 0, 10)
+                warning.set_x(60)
+                lbl = warning
 
         if meta.get("fee"):
             idxlbl = lv.label(self.page2)

--- a/src/specter.py
+++ b/src/specter.py
@@ -316,24 +316,26 @@ class Specter:
         return self.settingsmenu
 
     async def select_network(self):
-        buttons = [
-            (None, "Production"),
-            ("main", "Mainnet"),
-        ]
-        if self.is_liquid_enabled:
-            buttons.extend([
-                ("liquidv1", "Liquid"),
-            ])
-        buttons.extend([
-            (None, "Testnets"),
-            ("test", "Testnet"),
-            ("signet", "Signet"),
-            ("regtest", "Regtest"),
-        ])
-        if self.is_liquid_enabled:
-            buttons.extend([
+        if not self.is_liquid_enabled:
+            buttons = [
+                (None, "Production"),
+                ("main", "Mainnet"),
+                (None, "Testnets"),
+                ("test", "Testnet"),
+                ("signet", "Signet"),
+                ("regtest", "Regtest"),
+            ]
+        else:
+            buttons = [
+                (None, "Production"),
+                ("main", "Bitcoin Mainnet"),
+                ("liquidv1", "Liquid Mainnet"),
+                (None, "Testnets"),
+                ("test", "Testnet"),
+                ("signet", "Signet"),
+                ("regtest", "Regtest"),
                 ("elementsregtest", "Liquid Regtest"),
-            ])
+            ]
         # wait for menu selection
         menuitem = await self.gui.menu(buttons, last=(255, None))
         if menuitem != 255:


### PR DESCRIPTION
Wallets store info about the largest indexes they have seen while signing transactions. So if the transaction has addresses with extrelemy large derivation indexes (m/0/999999 for example) we warn about that. Default gap limit is set to 20 that is common for light wallets.

![image](https://user-images.githubusercontent.com/1706012/130830187-72c9f4c9-c810-4b27-b551-a48547c9fe12.png)
