### PR TITLE
Update input.py

### DIFF
--- a/src/gui/screens/input.py
+++ b/src/gui/screens/input.py
@@ -331,7 +331,7 @@ class DerivationScreen(Screen):
         "\n",
         "Back",
         "0",
-        lv.SYMBOL.CLOSE,
+        "'",
         lv.SYMBOL.OK,
         "",
     ]


### PR DESCRIPTION
Without " ' " character, the bip44 hardened child xpub key from derivation path " m/44'/0'/0' "  is impossible to create, it's different from normal child xpub key from derivation path "m/44/0/0".

We already have lv.SYMBOL.LEFT, 
lv.SYMBOL.CLOSE seems reduntant.