### PR TITLE
Update xpubs.py

### DIFF
--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -70,6 +70,11 @@ class XpubApp(BaseApp):
                     "m/48h/%dh/%dh/1h" % (coin, self.account),
                     "Multisig Nested Segwit\nm/48h/%dh/%dh/1h" % (coin, self.account),
                 ),
+                (None, "Deprecated"),
+                (
+                    "m/44h/%dh/%dh" % (coin, self.account),
+                    "Single Legacy\nm/44h/%dh/%dh" % (coin, self.account)
+                ),
             ])
         # wait for menu selection
         menuitem = await show_screen(Menu(buttons, last=(255, None),


### PR DESCRIPTION
Adding Single Legacy xpubs. 
Trezor and other HD wallets solely used it before, so OG users may want to access it. 
And "Enter custom derivation" using m/44/0/0  does not get hardened public key.
Adding "Deprecated" though.