### PR TITLE
Enhancement: Display of non-legacy addresses and derivation path on message signature screen

### DIFF
--- a/src/apps/signmessage/signmessage.py
+++ b/src/apps/signmessage/signmessage.py
@@ -74,10 +74,9 @@ class MessageApp(BaseApp):
         sig = self.sign_message(derivation_path, message)
         # for GUI we can also return an object with helpful data
         xpub = self.keystore.get_xpub(derivation_path)
-        address = script.p2pkh(xpub.key).address()
         obj = {
-            "title": "Signature for the message:",
-            "note": "using address %s" % address,
+            "title": "Message signature:",
+            "note": "Derivation path: %s" % bip32.path_to_str(derivation_path),   
         }
         return BytesIO(sig), obj
 


### PR DESCRIPTION
### Description
This will enable a better UX with [this upcoming PR in Specter Desktop](https://github.com/cryptoadvance/specter-desktop/pull/1567) to sign messages with Specter Desktop and the DIY. 

### Visuals
https://user-images.githubusercontent.com/70536101/168853480-53a544d8-e2ed-4f77-87a5-a279472a6552.mov


