### PR TITLE
ur:crypto-psbt support

### DIFF
--- a/boot/main/boot.py
+++ b/boot/main/boot.py
@@ -56,11 +56,11 @@ pyb.ExtInt(pyb.Pin('B1'), pyb.ExtInt.IRQ_FALLING, pyb.Pin.PULL_NONE, pwrcb)
 # configure usb from start if you want, 
 # otherwise will be configured after PIN
 # pyb.usb_mode("VCP+MSC") # debug mode with USB and mounted storages from start
-# pyb.usb_mode("VCP") # debug mode with USB from start
+pyb.usb_mode("VCP") # debug mode with USB from start
 # disable at start
-pyb.usb_mode(None)
-os.dupterm(None,0)
-os.dupterm(None,1)
+# pyb.usb_mode(None)
+# os.dupterm(None,0)
+# os.dupterm(None,1)
 
 # inject version and i2c to platform module
 import platform

--- a/boot/main/boot.py
+++ b/boot/main/boot.py
@@ -56,11 +56,11 @@ pyb.ExtInt(pyb.Pin('B1'), pyb.ExtInt.IRQ_FALLING, pyb.Pin.PULL_NONE, pwrcb)
 # configure usb from start if you want, 
 # otherwise will be configured after PIN
 # pyb.usb_mode("VCP+MSC") # debug mode with USB and mounted storages from start
-pyb.usb_mode("VCP") # debug mode with USB from start
+# pyb.usb_mode("VCP") # debug mode with USB from start
 # disable at start
-# pyb.usb_mode(None)
-# os.dupterm(None,0)
-# os.dupterm(None,1)
+pyb.usb_mode(None)
+os.dupterm(None,0)
+os.dupterm(None,1)
 
 # inject version and i2c to platform module
 import platform

--- a/src/hosts/qr.py
+++ b/src/hosts/qr.py
@@ -364,6 +364,7 @@ class QRHost(Host):
                 return self.process_normal(f)
 
     def process_bcur2(self, f):
+        gc.collect()
         if self.decoder.read_part(f):
             fname = self.path + "/data.txt"
             with self.decoder.result() as b:

--- a/src/hosts/qr.py
+++ b/src/hosts/qr.py
@@ -297,6 +297,7 @@ class QRHost(Host):
         if self.parts is not None:
             del self.parts
             self.parts = None
+        del self.decoder
         self.decoder = None
         gc.collect()
         if self.cancelled:
@@ -371,6 +372,7 @@ class QRHost(Host):
                 msglen = cbor.read_bytes_len(b)
                 with open(fname, "wb") as fout:
                     read_write(b, fout)
+            gc.collect()
             return True
         return False
 

--- a/src/specter.py
+++ b/src/specter.py
@@ -534,7 +534,7 @@ class Specter:
                     if app.can_process(stream):
                         matching_apps.append(app)
             if len(matching_apps) == 0:
-                raise HostError("Can't find matching app for this request")
+                raise HostError("Can't find matching app for this request:\n\n %r" % stream.read(100))
             # TODO: if more than one - ask which one to use
             if len(matching_apps) > 1:
                 raise HostError(


### PR DESCRIPTION
Modern ur:crypto-psbt standard support for QR codes. Experimental.
Close #89.
I had to write it from scratch as implementation from foundation devices uses too much memory.
Tested with small to mid-size transactions (up to 10 inputs) - works in most cases.
Sometimes it fails on large txs for mysterious reasons - decoder probably because of uart buffer overwrite, not sure why encoder fails. I need to investigate further.
Anyways, for most common txs it works, so makes sense to gather information when it fails and under what conditions.