### PR TITLE
fix processing of \r when importing binary seedqr

### DIFF
--- a/src/hosts/core.py
+++ b/src/hosts/core.py
@@ -142,7 +142,7 @@ class Host:
         """
         self.enabled = False
 
-    async def get_data(self):
+    async def get_data(self, raw=False, chunk_timeout=0.1):
         """Implement how to get transaction from unidirectional host"""
         raise HostError("Data loading is not implemented for this class")
 

--- a/src/hosts/sd.py
+++ b/src/hosts/sd.py
@@ -40,9 +40,9 @@ class SDHost(Host):
                 break
             fout.write(b, l)
 
-    async def get_data(self):
+    async def get_data(self, raw=False, chunk_timeout=0.1):
         """
-        Loads psbt transaction from the SD card.
+        Loads host command from the SD card.
         """
         self.reset_and_mount()
         try:

--- a/src/specter.py
+++ b/src/specter.py
@@ -233,7 +233,7 @@ class Specter:
             last=(255, None))
         if host == 255:
             return
-        stream = await host.get_data()
+        stream = await host.get_data(raw=True)
         if not stream:
             return
         data = stream.read()
@@ -247,7 +247,7 @@ class Specter:
         else:
             mnemonic = data.decode()
             if not bip39.mnemonic_is_valid(mnemonic):
-                raise SpecterError("Invalid data")
+                raise SpecterError("Invalid data: %r" % mnemonic)
         scr = MnemonicPrompt(title="Imported mnemonic:", mnemonic=mnemonic)
         # confirm mnemonic
         if not await self.gui.show_screen()(scr):


### PR DESCRIPTION
Close #211 
Until now we assumed that all messages from the host are text-based and end with `\r` - QR scanner is adding `\r` at the end of the data, so we were using it to split data coming from the scanner when multiple QR codes are scanned one after another.

This approach doesn't work when we start working with binary data. SeedQR integration is the first time we are handling QR codes in binary form.

This PR adds a possibility to tell the scanner that we are not expecting animated QR codes and ask for raw data coming from the scanner without pre-processing.