### PR TITLE
Only show frameindex when displaying an animated QR code if the mode …

### DIFF
--- a/src/gui/components/qrcode.py
+++ b/src/gui/components/qrcode.py
@@ -265,7 +265,12 @@ class QRCode(lv.obj):
         if self.encoder:
             payload = self.encoder[self.idx]
             self._set_text(payload)
-            note = "Part %d of %d." % (self.idx + 1, len(self.encoder))
+            if self.encoder.is_infinite:
+                note = ""
+            else:
+                frameCount = len(self.encoder)
+                currentFrame = self.idx + 1
+                note = "Part %d of %d." % (currentFrame, frameCount)
         else:
             self._set_text(self._text)
             note = ""


### PR DESCRIPTION
…is not infinite (to avoid showing the frameindex in crypto-psbt mode where it does not make sense).