### PR TITLE
Proper usb response

### DIFF
--- a/src/apps/backup.py
+++ b/src/apps/backup.py
@@ -3,9 +3,6 @@ Backup app - can load secrets from a text file or qr code that starts with
 bip39: <recovery phrase>
 """
 from app import BaseApp, AppError
-from io import BytesIO
-from binascii import hexlify
-from rng import get_random_bytes
 from embit import bip39
 from gui.screens import Prompt
 from gui.components.mnemonic import MnemonicTable
@@ -30,6 +27,7 @@ class App(BaseApp):
         table = MnemonicTable(scr)
         table.align(scr.message, lv.ALIGN.OUT_BOTTOM_MID, 0, 30)
         table.set_mnemonic(mnemonic)
-        if await show_fn(scr):
+        confirm = await show_fn(scr)
+        if confirm:
             self.keystore.set_mnemonic(mnemonic)
-        return None
+        return confirm

--- a/src/apps/blindingkeys/app.py
+++ b/src/apps/blindingkeys/app.py
@@ -45,7 +45,7 @@ class BlindingKeysApp(BaseApp):
                        "Send master blinding private key\nto the host?\n\n"
                        "Host is requesting your\nSLIP-77 blinding key.\n\n"
                        "It will be able to watch your funds and unblind transactions.")):
-                return
+                return False
             return BytesIO(self.keystore.slip77_key.wif(NETWORKS[self.network])), {}
         raise AppError("Unknown command")
 

--- a/src/apps/signmessage/signmessage.py
+++ b/src/apps/signmessage/signmessage.py
@@ -72,7 +72,7 @@ class MessageApp(BaseApp):
         )
         res = await show_screen(scr)
         if res is False:
-            return None
+            return False
         sig = self.sign_message(derivation_path, message)
         # for GUI we can also return an object with helpful data
         pub = self.keystore.get_xpub(derivation_path).get_public_key()

--- a/src/apps/wallets/app.py
+++ b/src/apps/wallets/app.py
@@ -3,7 +3,6 @@ import platform
 from .manager import WalletManager
 from .liquid.manager import LWalletManager
 from helpers import is_liquid
-import gc
 
 class WalletsApp(BaseApp):
     # This is a dummy app that can switch between Bitcoin and Liquid wallet managers

--- a/src/apps/wallets/liquid/manager.py
+++ b/src/apps/wallets/liquid/manager.py
@@ -136,7 +136,7 @@ class LWalletManager(WalletManager):
                 asset = bytes(reversed(unhexlify(hexasset)))
                 self.assets[asset] = assetlbl
                 self.save_assets()
-            return BytesIO(b"success"), {}
+            return True
         elif cmd == DUMP_ASSETS:
             return BytesIO(self.assets_json()), {}
         else:

--- a/src/apps/wallets/manager.py
+++ b/src/apps/wallets/manager.py
@@ -208,7 +208,7 @@ class WalletManager(BaseApp):
                     "message": "Scan it with your wallet",
                 }
                 return res, obj
-            return
+            return False
         if cmd == SIGN_BCUR:
             # move to the end of UR:BYTES/
             stream.seek(9, 1)
@@ -231,7 +231,7 @@ class WalletManager(BaseApp):
                     "message": "Scan it with your wallet",
                 }
                 return res, obj
-            return
+            return False
         elif cmd == LIST_WALLETS:
             wnames = json.dumps([w.name for w in self.wallets])
             return BytesIO(wnames.encode()), {}
@@ -239,10 +239,10 @@ class WalletManager(BaseApp):
             # read content, it's small
             desc = stream.read().decode().strip()
             w = self.parse_wallet(desc)
-            res = await self.confirm_new_wallet(w, show_screen)
-            if res:
+            confirm = await self.confirm_new_wallet(w, show_screen)
+            if confirm:
                 self.add_wallet(w)
-            return
+            return bool(confirm)
         elif cmd == VERIFY_ADDRESS:
             data = stream.read().decode().replace("bitcoin:", "")
             # should be of the form addr?index=N or similar
@@ -257,7 +257,7 @@ class WalletManager(BaseApp):
                     break
             w, _ = self.find_wallet_from_address(addr, index=idx)
             await show_screen(WalletScreen(w, self.network, idx))
-            return
+            return True
         elif cmd == DERIVE_ADDRESS:
             arr = stream.read().split(b" ")
             redeem_script = None

--- a/src/hosts/qr.py
+++ b/src/hosts/qr.py
@@ -3,7 +3,6 @@ import pyb
 import time
 import asyncio
 from platform import simulator, config, delete_recursively
-from io import BytesIO
 import gc
 from gui.screens.settings import HostSettings
 from gui.screens import Alert

--- a/src/hosts/sd.py
+++ b/src/hosts/sd.py
@@ -1,9 +1,8 @@
 from .core import Host, HostError
 from platform import fpath
-from io import BytesIO
 import os
 import platform
-from binascii import b2a_base64, a2b_base64, hexlify
+from binascii import hexlify
 from helpers import a2b_base64_stream
 
 class SDHost(Host):
@@ -70,7 +69,13 @@ class SDHost(Host):
         return fname[:18]+"..."+fname[-12:]
 
     async def select_file(self, extensions):
-        files = sum([[f[0] for f in os.ilistdir(self.sdpath) if f[0].lower().endswith(ext) and f[1] == 0x8000] for ext in extensions], [])
+        files = sum([
+            [
+                f[0] for f in os.ilistdir(self.sdpath)
+                if f[0].lower().endswith(ext)
+                and f[1] == 0x8000
+            ] for ext in extensions
+        ], [])
         
         if len(files) == 0:
             raise HostError("\n\nNo matching files found on the SD card\nAllowed: %s" % ", ".join(extensions))
@@ -81,7 +86,11 @@ class SDHost(Host):
         buttons = []
         for ext in extensions:
             title = [(None, ext+" files")]
-            barr = [(self.sdpath+"/"+f, self.truncate(f)) for f in files if f.lower().endswith(ext)]
+            barr = [
+                (self.sdpath+"/"+f, self.truncate(f))
+                for f in files
+                if f.lower().endswith(ext)
+            ]
             if len(barr) == 0:
                 buttons += [(None, "%s files - No files" % ext)]
             else:

--- a/src/hosts/usb.py
+++ b/src/hosts/usb.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 from errors import BaseError
 from .core import Host, HostError
 import sys
@@ -65,7 +64,7 @@ class USBHost(Host):
         platform.delete_recursively(self.path)
 
     async def process_command(self, stream):
-        if self.manager == None:
+        if self.manager is None:
             raise HostError("Device is busy")
         # all commands are pretty short
         b = stream.read(20)
@@ -76,8 +75,10 @@ class USBHost(Host):
         stream.seek(0)
         # res should be a stream as well
         res = await self.manager.process_host_request(stream)
-        if res is None:
+        if res is None or res is False:
             self.respond(b"error: User cancelled")
+        elif res is True:
+            self.respond(b"success")
         else:
             stream, meta = res
             # if it's str - it's a filename
@@ -148,7 +149,7 @@ class USBHost(Host):
         return self.path + "/data"
 
     async def update(self):
-        if self.manager == None:
+        if self.manager is None:
             return await asyncio.sleep_ms(100)
         if self.usb is None:
             return await asyncio.sleep_ms(100)

--- a/src/specter.py
+++ b/src/specter.py
@@ -324,7 +324,7 @@ class Specter:
             if stream is not None:
                 # check against all apps
                 res = await self.process_host_request(stream, popup=False)
-                if res is not None:
+                if res not in [True, False, None]:
                     await host.send_data(*res)
         else:
             print(menuitem)

--- a/test/tests/test_wallets.py
+++ b/test/tests/test_wallets.py
@@ -8,7 +8,7 @@ class WalletsTest(TestCase):
 
     def test_descriptors(self):
         """Test initial config creation"""
-        k = "[8cce63f8/84h/1h/0h]tpubDCZWxJ6kKqRHep5a2XycxrXRaTES1vs3ysfV7sdv5uhkaEgxBEdVbyQT46m3NcaLJqVNd41TYqDyQfvweLLXGmkxdHRnhxuJPf7BAWMXni2/{0,1}/*"
+        k = "[8cce63f8/84h/1h/0h]tpubDCZWxJ6kKqRHep5a2XycxrXRaTES1vs3ysfV7sdv5uhkaEgxBEdVbyQT46m3NcaLJqVNd41TYqDyQfvweLLXGmkxdHRnhxuJPf7BAWMXni2/<0;1>/*"
         descriptors = [
             "wpkh(%s)" % k,
             "sh(wpkh(%s))" % k,


### PR DESCRIPTION
Close https://github.com/cryptoadvance/specter-diy/issues/254

Now if the USB request from the host doesn't require any return data, and it was executed successfully (confirmed by the user), device sends back "success" string. Previously it was always sending "error: User cancelled".
