### PR TITLE
Changed 'enter Bip-39 Password' to 'Enter Passphrase'

### DIFF
--- a/src/specter.py
+++ b/src/specter.py
@@ -340,7 +340,7 @@ class Specter:
         ]
         if self.keystore.storage_button is not None:
             buttons.append((1, self.keystore.storage_button))
-        buttons.append((2, "Enter Passphrase"))
+        buttons.append((2, "Enter passphrase"))
         if hasattr(self.keystore, "show_mnemonic"):
             buttons.append((3, "Show recovery phrase"))
         buttons.extend([(None, "Security"), (4, "Device settings")])  # delimiter

--- a/src/specter.py
+++ b/src/specter.py
@@ -340,7 +340,7 @@ class Specter:
         ]
         if self.keystore.storage_button is not None:
             buttons.append((1, self.keystore.storage_button))
-        buttons.append((2, "Enter BIP-39 password"))
+        buttons.append((2, "Enter Passphrase"))
         if hasattr(self.keystore, "show_mnemonic"):
             buttons.append((3, "Show recovery phrase"))
         buttons.extend([(None, "Security"), (4, "Device settings")])  # delimiter


### PR DESCRIPTION
Changed "enter Bip-39 Password" to "Enter passphrase" for better user understanding.

to find in: src/specter.py in the line 343