### PR TITLE
[WIP] MicroPython upgrade to v1.25

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "f469-disco"]
 	path = f469-disco
-	url = https://github.com/diybitcoinhardware/f469-disco
+	url = https://github.com/miketlk/f469-disco.git
+	branch = micropython-upgrade
 [submodule "bootloader"]
 	path = bootloader
 	url = https://github.com/cryptoadvance/specter-bootloader

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,50 @@
-FROM python:3.9.15@sha256:b5f024fa682187ef9305a2b5d2c4bb583bef83356259669fc80273bb2222f5ed
-ENV LANG C.UTF-8
+# syntax=docker/dockerfile:1.6
+FROM python:3.9.23-bookworm@sha256:dc01447eea126f97459cbcb0e52a5863fcc84ff53462650ae5a28277c175f49d
 
+ENV LANG=C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
+ARG TOOLCHAIN_VER=14.3.rel1
+ARG TARGETARCH
+ARG TARGET_DIR="/opt/arm-toolchain"
 
-# ARM Embedded Toolchain
-# Integrity is checked using the MD5 checksum provided by ARM at https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
-RUN curl -sSfL -o arm-toolchain.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&rev=05382cca172144e1ae191e7c3dc96118&hash=3ACFE672E449EBA7A21773EE284A88BC7DFA5044" && \
-    echo 2b9eeccc33470f9d3cda26983b9d2dc6 arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
-    md5sum --check /tmp/arm-toolchain.md5 && rm /tmp/arm-toolchain.md5 && \
-    tar xf arm-toolchain.tar.bz2 -C /opt && \
-    rm arm-toolchain.tar.bz2
+# Minimal deps for download/verify/extract
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl xz-utils grep coreutils \
+    && rm -rf /var/lib/apt/lists/*
 
-# Adding GCC to PATH and defining rustup/cargo home directories
-ENV PATH=/opt/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH
+# Default to Arm's blob storage mirror
+ARG TOOLCHAIN_MIRROR=armkeil.blob.core.windows.net/developer/Files/downloads/gnu
 
-# Installing python requirements
+# Pin Arm GNU Toolchain per-arch with SHA256 sums
+ENV TOOLCHAIN_SHA256_AMD64=8f6903f8ceb084d9227b9ef991490413014d991874a1e34074443c2a72b14dbd
+ENV TOOLCHAIN_SHA256_ARM64=2d465847eb1d05f876270494f51034de9ace9abe87a4222d079f3360240184d3
+
+# Arm GNU Toolchain (arm-none-eabi), host-aware, SHA-256 verified, cached download
+RUN --mount=type=cache,target=/root/.cache \
+    set -eux; \
+    case "$TARGETARCH" in \
+      amd64)  host="x86_64"; TOOLCHAIN_SHA256="$TOOLCHAIN_SHA256_AMD64" ;; \
+      arm64)  host="aarch64"; TOOLCHAIN_SHA256="$TOOLCHAIN_SHA256_ARM64" ;; \
+      *) echo "Unsupported arch: $TARGETARCH" && exit 1 ;; \
+    esac; \
+    file="arm-gnu-toolchain-${TOOLCHAIN_VER}-${host}-arm-none-eabi.tar.xz"; \
+    url="https://${TOOLCHAIN_MIRROR}/${TOOLCHAIN_VER}/binrel/${file}"; \
+    dest="/root/.cache/$file"; \
+    if [ ! -f "$dest" ]; then \
+      echo "Downloading $url"; \
+      curl -fSL --retry 5 --retry-all-errors -C - -o "$dest" "$url"; \
+    else \
+      echo "Using cached $dest"; \
+    fi; \
+    echo "${TOOLCHAIN_SHA256}  $dest" | sha256sum -c -; \
+    tar -xJf "$dest" -C /opt; \
+    ln -s /opt/arm-gnu-toolchain-${TOOLCHAIN_VER}-${host}-arm-none-eabi ${TARGET_DIR}
+
+ENV PATH="${TARGET_DIR}/bin:${PATH}"
+
+# Python deps
 COPY bootloader/tools/requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN python -m pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /app
-
 CMD ["/usr/bin/env", "bash", "./build_firmware.sh"]

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ unix: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/unix
 	@echo Building binary with frozen files
 	make -C $(MPY_DIR)/ports/unix \
 		USER_C_MODULES=$(USER_C_MODULES) \
-		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) && \
+		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) \
 		CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' && \
 	cp $(MPY_DIR)/ports/unix/build-standard/micropython $(TARGET_DIR)/micropython_unix
 
@@ -78,7 +78,7 @@ all: mpy-cross disco unix
 clean:
 	rm -rf $(TARGET_DIR)
 	make -C $(MPY_DIR)/mpy-cross clean
-	rm -rf $(MPY_DIR)/mpy-cross/mpy-cross
+	rm -rf $(MPY_DIR)/mpy-cross/build
 	make -C $(MPY_DIR)/ports/unix \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) clean

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ unix: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/unix
 	make -C $(MPY_DIR)/ports/unix \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) && \
-	cp $(MPY_DIR)/ports/unix/micropython $(TARGET_DIR)/micropython_unix
+		CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' && \
+	cp $(MPY_DIR)/ports/unix/build-standard/micropython $(TARGET_DIR)/micropython_unix
 
 simulate: unix
 	$(TARGET_DIR)/micropython_unix simulate.py
@@ -77,7 +78,7 @@ all: mpy-cross disco unix
 clean:
 	rm -rf $(TARGET_DIR)
 	make -C $(MPY_DIR)/mpy-cross clean
-	rm $(MPY_DIR)/mpy-cross/mpy-cross
+	rm -rf $(MPY_DIR)/mpy-cross/mpy-cross
 	make -C $(MPY_DIR)/ports/unix \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) clean

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mpy-cross: $(TARGET_DIR) $(MPY_DIR)/mpy-cross/Makefile
 	@echo Building cross-compiler
 	make -C $(MPY_DIR)/mpy-cross \
 	DEBUG=$(DEBUG) && \
-	cp $(MPY_DIR)/mpy-cross/mpy-cross $(TARGET_DIR)
+	cp $(MPY_DIR)/mpy-cross/build/mpy-cross $(TARGET_DIR)
 
 # disco board with bitcoin library
 disco: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32
@@ -32,6 +32,7 @@ disco: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32
 		USE_DBOOT=$(USE_DBOOT) \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_DISCO) \
+		CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' \
 		DEBUG=$(DEBUG) && \
 	arm-none-eabi-objcopy -O binary \
 		$(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.elf \
@@ -48,6 +49,7 @@ debug: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32
 		USE_DBOOT=$(USE_DBOOT) \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_DEBUG) \
+		CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' \
 		DEBUG=$(DEBUG) && \
 	arm-none-eabi-objcopy -O binary \
 		$(MPY_DIR)/ports/stm32/build-STM32F469DISC/firmware.elf \
@@ -75,6 +77,7 @@ all: mpy-cross disco unix
 clean:
 	rm -rf $(TARGET_DIR)
 	make -C $(MPY_DIR)/mpy-cross clean
+	rm $(MPY_DIR)/mpy-cross/mpy-cross
 	make -C $(MPY_DIR)/ports/unix \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) clean

--- a/docs/build.md
+++ b/docs/build.md
@@ -76,8 +76,8 @@ To make the SDL2 library available to your C/C++ toolchain, ensure that Homebrew
 
 ```sh
 export LDFLAGS="-L/opt/homebrew/lib $LDFLAGS"
-export CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"
-export CFLAGS="-I/opt/homebrew/include $CFLAGS"
+export CPPFLAGS="-idirafter /opt/homebrew/include $CPPFLAGS"
+export CFLAGS="-idirafter /opt/homebrew/include $CFLAGS"
 ```
 
 #### Windows

--- a/docs/build.md
+++ b/docs/build.md
@@ -14,35 +14,60 @@ The easiest way to get all necessary tools is to run `nix-shell` from the root o
 
 To compile the firmware for the board you will need `arm-none-eabi-gcc` compiler.
 
-**Debian/Ubuntu**:
+#### Debian/Ubuntu
+
 ```sh
 sudo apt-get install build-essential gcc-arm-none-eabi binutils-arm-none-eabi gdb-multiarch openocd
 ```
 
-**Archlinux**:
+#### Archlinux
+
 ```sh
 sudo pacman -S arm-none-eabi-gcc arm-none-eabi-binutils openocd base-devel python-case
 ```
 You might need change default gcc flag settings with `CFLAGS_EXTRA="-w"`. Export it or set the variable before of `make`
 to avoid warnings being raised as errors.
 
-**MacOS**:
+#### MacOS
+
 ```sh
 brew install arm-none-eabi-gcc
 ```
 
-On **Windows**: Install linux subsystem and follow Linux instructions.
+#### Windows
+
+Install the Linux subsystem and follow Linux instructions. The recommended distribution as of this writing is **Ubuntu 22.04 LTS**.  It can be installed using the following command in the **administrator's PowerShell**:
+
+```sh
+# Install Ubuntu 22.04 as WSL Linux environment
+wsl --install -d Ubuntu-22.04
+# Start new instance of Ubuntu 22.04 (if multiple distros are present in system)
+wsl -d Ubuntu-22.04
+```
+
+To install all the dependencies on Windows, make sure the **universe** repository is enabled and the package list is up to date. If not, here is a quick fix:
+
+```sh
+# Uncomment all lines in /etc/apt/sources.list that begin with # deb
+sudo sed -i 's/^# deb/deb/' /etc/apt/sources.list
+# Enable universe repository
+sudo add-apt-repository universe
+# Update package list
+sudo apt update
+```
 
 ### Prerequisities: Simulator
 
 You may need to install SDL2 library to simulate the screen of the device.
 
-**Linux**:
+#### Linux
+
 ```sh
 sudo apt install libsdl2-dev
 ```
 
-**MacOS**:
+#### MacOS
+
 ```sh
 brew install sdl2
 ```
@@ -55,10 +80,20 @@ export CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"
 export CFLAGS="-I/opt/homebrew/include $CFLAGS"
 ```
 
-**Windows**:
+#### Windows
+
 - `sudo apt install libsdl2-dev` on Linux side.
 - install and launch [Xming](https://sourceforge.net/projects/xming/) on Windows side
 - set `export DISPLAY=:0` on linux part
+
+[VcXsrv](https://github.com/marchaesen/vcxsrv) is another viable option for running X11 applications on Windows. Here is an example environment that should be configured on the WSL side:
+
+```sh
+export LIBGL_ALWAYS_INDIRECT=0
+export LIBGL_ALWAYS_SOFTWARE=true
+export DISPLAY=127.0.0.1:0
+export XDG_RUNTIME_DIR=/mnt/wslg/runtime-dir
+```
 
 ## Build
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -29,15 +29,6 @@ to avoid warnings being raised as errors.
 **MacOS**:
 ```sh
 brew install arm-none-eabi-gcc
-brew install sdl2
-```
-
-To make the SDL2 library available to your C/C++ toolchain, ensure that Homebrew’s include and library paths are added to the compiler and linker flags. If they are not already set, you can add the following lines to your shell profile (commonly `~/.zprofile` or `~/.bash_profile`) or configure them in another way before making the Unix build:
-
-```sh
-export LDFLAGS="-L/opt/homebrew/lib $LDFLAGS"
-export CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"
-export CFLAGS="-I/opt/homebrew/include $CFLAGS"
 ```
 
 On **Windows**: Install linux subsystem and follow Linux instructions.
@@ -54,6 +45,14 @@ sudo apt install libsdl2-dev
 **MacOS**:
 ```sh
 brew install sdl2
+```
+
+To make the SDL2 library available to your C/C++ toolchain, ensure that Homebrew’s include and library paths are added to the compiler and linker flags. If they are not already set, you can add the following lines to your shell profile (commonly `~/.zprofile` or `~/.bash_profile`) or configure them in another way before making the Unix build:
+
+```sh
+export LDFLAGS="-L/opt/homebrew/lib $LDFLAGS"
+export CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"
+export CFLAGS="-I/opt/homebrew/include $CFLAGS"
 ```
 
 **Windows**:

--- a/docs/build.md
+++ b/docs/build.md
@@ -28,8 +28,16 @@ to avoid warnings being raised as errors.
 
 **MacOS**:
 ```sh
-brew tap ArmMbed/homebrew-formulae
 brew install arm-none-eabi-gcc
+brew install sdl2
+```
+
+To make the SDL2 library available to your C/C++ toolchain, ensure that Homebrew’s include and library paths are added to the compiler and linker flags. If they are not already set, you can add the following lines to your shell profile (commonly `~/.zprofile` or `~/.bash_profile`) or configure them in another way before making the Unix build:
+
+```sh
+export LDFLAGS="-L/opt/homebrew/lib $LDFLAGS"
+export CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"
+export CFLAGS="-I/opt/homebrew/include $CFLAGS"
 ```
 
 On **Windows**: Install linux subsystem and follow Linux instructions.

--- a/docs/reproducible-build.md
+++ b/docs/reproducible-build.md
@@ -28,11 +28,17 @@ Get signatures from the description of the github release and enter one by one i
 
 After adding signatures binaries in the `release` folder should be exactly the same as in github release. Hashes of the binaries will be saved to `release/sha256.txt`.
 
-# Apple M1 users
+# Simplified build without signing
 
-For Apple M1 add a plafrom flag to the docker commands:
+If you just need a HEX file without bootloader and signatures you can use this command:
 
 ```sh
-docker build -t diy . --platform linux/x86_64
-docker run --platform linux/amd64 -ti -v `pwd`:/app diy
+docker run -ti -v `pwd`:/app diy bash -c "make clean && make disco"
+```
+
+This will generate the binaries of the main firmware, which can be flashed into the Discovery board via ST-LINK or ROM bootloader.
+
+```txt
+bin/specter-diy.bin
+bin/specter-diy.hex
 ```


### PR DESCRIPTION
## 🚧 Work in Progress – Early Draft
This pull request is opened early to:

- Share current progress
- Gather feedback from contributors
- Discuss implementation approaches

💡 Note: This PR is not ready for review or merging. Some parts may be incomplete, untested, or non-buildable at this stage. Feel free to comment on design decisions, request clarifications, or suggest alternatives.

## Summary

This PR upgrades the `specter-diy` project to support MicroPython v1.25. The majority of compatibility changes were implemented in the `f469-disco` submodule and its nested user C modules. This PR updates the submodule reference and makes necessary adjustments to the build system and documentation to reflect the MicroPython API changes introduced in v1.25.

### IMPORTANT: This draft PR has temporary submodule pointers to my own forks that must be fixed before merging!

## Changes

* Updated `f469-disco` submodule to latest commit compatible with MicroPython v1.25
* Updated build scripts to ensure compatibility with MicroPython's v1.25 engine and compiler
* TODO: Review and update Python scripts and CI jobs that rely on MicroPython internals or output structure
* TODO: Update documentation (`README.md`, `docs/`) to reflect new module requirements, build commands, or known issues

## Testing

* TODO: Confirm clean build of the full firmware against MicroPython v1.25
* TODO: Smoke test key functionality on STM32F469I-DISCO hardware with optional Specter Shield
* TODO: Validate that `f469-disco` submodule functions (QR, display, etc.) are callable from Specter firmware

## Checklist

* [ ] Code builds without errors
* [ ] Tests added or updated
* [ ] Documentation updated if necessary
* [ ] Code reviewed for security and edge cases