### PR TITLE
chore: Get build back to work and some CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+jobs:
+  build:
+    name: Build Firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Cache Nix store
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/nix
+            /nix/store
+          key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-keys: |
+            nix-${{ runner.os }}-
+
+      - name: Build Unix simulator
+        run: nix develop -c make unix
+
+      - name: Build STM32F469 Discovery firmware
+        run: nix develop -c make disco
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-binaries
+          path: |
+            bin/specter-diy.bin
+            bin/specter-diy.hex

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ release
 .idea
 .vscode
 .DS_Store
+.direnv

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,11 +6,35 @@ Clone the repository recursively `git clone https://github.com/cryptoadvance/spe
 
 ## Prerequisities
 
+There are multiple ways to get all necessary tools. The recommended way is to use the Nix flake with direnv.
+If that's too complicated for you, you can use the traditional `nix-shell` or install the tools manually (which mighty be tricky to get the dependencies right).
+
+### Nix flake (Recommended)
+
+The easiest way to get all necessary tools is to use the Nix flake from the root of the repository. You need to have [Nix](https://nixos.org/) (on Mac use [determinate](https://github.com/DeterminateSystems/nix-installer)) with flakes enabled.
+Install direnv with `brew install direnv` (on Mac) or `sudo apt install direnv` (on Linux).
+
+Make sure that [flakes are enabled](https://nixos.wiki/wiki/Flakes) in your Nix config.
+
+```sh
+# Enter development shell
+nix develop
+
+# Or use with direnv for automatic activation
+direnv allow
+```
+
+
 ### Nix shell
 
-The easiest way to get all necessary tools is to run `nix-shell` from the root of the repository. You need to have [Nix](https://nixos.org/) installed.
+Alternatively, you can use the traditional `shell.nix`:
 
-### Prerequisities: Board
+```sh
+nix-shell
+```
+You'll need to have [Nix](https://nixos.org/) installed as well.
+
+### Prerequisities (Manually): Board
 
 To compile the firmware for the board you will need `arm-none-eabi-gcc` compiler.
 
@@ -34,7 +58,7 @@ brew install arm-none-eabi-gcc
 
 On **Windows**: Install linux subsystem and follow Linux instructions.
 
-### Prerequisities: Simulator
+### Prerequisities (Manually): Simulator
 
 You may need to install SDL2 library to simulate the screen of the device.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -11,10 +11,10 @@ If that's too complicated for you, you can use the traditional `nix-shell` or in
 
 ### Nix flake (Recommended)
 
-The easiest way to get all necessary tools is to use the Nix flake from the root of the repository. You need to have [Nix](https://nixos.org/) (on Mac use [determinate](https://github.com/DeterminateSystems/nix-installer)) with flakes enabled.
+The easiest way to get all necessary tools is to use the Nix flake from the root of the repository. You need to have [Nix](https://nixos.org/) (on Mac use [determinate](https://github.com/DeterminateSystems/nix-installer)) with flakes enabled. This only works with Nix >2.7 (check with `nix --version`).
 Install direnv with `brew install direnv` (on Mac) or `sudo apt install direnv` (on Linux).
 
-Make sure that [flakes are enabled](https://nixos.wiki/wiki/Flakes) in your Nix config.
+Make sure that [flakes are enabled](https://nixos.wiki/wiki/Flakes) in your Nix config. On Linux systems, your user might need to be added to the nix-users group.
 
 ```sh
 # Enter development shell

--- a/docs/build.md
+++ b/docs/build.md
@@ -79,6 +79,8 @@ brew install sdl2
 
 ## Build
 
+All build commands might need a prefix like `nix develop -c` or need to be run from `nix develop` shell. If you use direnv, you don't need to do anything, apart from an initial `direnv allow`.
+
 To build custom bootloader and firmware that you will be able to sign check out the bootloader doc on [self-signed firmware](https://github.com/cryptoadvance/specter-bootloader/blob/master/doc/selfsigned.md). To wipe flash and remove protections on the device with the secure bootloader check out [this doc](https://github.com/cryptoadvance/specter-bootloader/blob/master/doc/remove_protection.md).
 
 To build an open firmware (no bootloader and signature verifications) run `make disco`. The result is the `bin/specter-diy.bin` file that you can copy-paste to the board over miniUSB.

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,29 +2,36 @@
 
 ## Compiling the code yourself
 
-We use this build as a platform for Specter: https://github.com/diybitcoinhardware/f469-disco
-
-To compile the firmware you will need `arm-none-eabi-gcc` compiler.
-
-On MacOS install it using brew: `brew install arm-none-eabi-gcc`
-
-On Debian: `sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi gdb-arm-none-eabi openocd`
-
-On Arch Linux: `sudo pacman -S arm-none-eabi-gcc arm-none-eabi-binutils arm-none-eabi-gdb arm-none-eabi-newlib openocd`
-
-Run `make disco` to get the binary or `make unix` to compile the simulator. They will be in the `bin` folder.
-
-`specter-diy.bin` file is the firmware that you need to copy to the device.
-
-The easiest way to start developing is to use a [simulator](./simulator.md), and when you are done - try it on a real hardware.
+See the [build documentation](build.md) for instructions on how to compile the code.
 
 ## Enabling developer mode
 
 By default developer mode and USB communication are turned off. This means that when you connect the board to the computer it will NOT mount the `PYBFLASH` anymore and there will be no way to connect to debug shell.
 
-To turn on the developer mode get to the main screen (enter PIN code, generate recovery phrase, enter password), and then go to **Settings - Security - turn on Developer mode - Save**.
 
-Now the board will restart and get mounted to the computer as before. You can also connect to the board over miniUSB and get to interactive console (baudrate 115200). You can use `screen` or `putty` or `minicom` for that, i.e. `screen /dev/tty.usbmodem14403 115200`.
+~~To turn on the developer mode get to the main screen (enter PIN code, generate recovery phrase, enter password), and then go to **Settings - Security - turn on Developer mode - Save**.~~
+(Currently deactivated for securtiy reasons)
+
+~~Now the board will restart and get mounted to the computer as before. You can also connect to the board over miniUSB and get to interactive console (baudrate 115200). You can use `screen` or `putty` or `minicom` for that, i.e. `screen /dev/tty.usbmodem14403 115200`.~~
+
+In order to connect to the board, modify those lines in [boot.py](https://github.com/cryptoadvance/specter-diy/blob/2f51e152bcdb184cf719792e6c5f972214e3dd36/boot/main/boot.py#L33-L40) like this:
+```python
+# configure usb from start if you want, 
+# otherwise will be configured after PIN
+pyb.usb_mode("VCP+MSC") # debug mode with USB and mounted storages from start
+#pyb.usb_mode("VCP") # debug mode with USB from start
+# disable at start
+# pyb.usb_mode(None)
+```
+
+and after flashing, you can connect with something like:
+```
+# Linux
+screen /dev/ttyACM0 115200 # or maybe ttyACM1 or ttyACM2
+# Mac
+screen /dev/tty.usbmodem14403 115200`.
+```
+
 
 ## Writing a simple app
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +52,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Specter DIY development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [ 
+            pkgs.buildPackages.gcc-arm-embedded-9
+            pkgs.buildPackages.python39
+            pkgs.openocd
+            pkgs.stlink
+            pkgs.SDL2
+          ];
+          hardeningDisable = ["all"];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
   outputs = { self, nixpkgs, flake-utils }:

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils,  ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,8 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/nixos-22.05.tar.gz";
+    sha256 = "154x9swf494mqwi4z8nbq2f0sp8pwp4fvx51lqzindjfbb9yxxv5";
+  }) {}
+}:
   pkgs.mkShell {
     nativeBuildInputs = [ 
       pkgs.buildPackages.gcc-arm-embedded-9

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,19 @@
-{ pkgs ? import (fetchTarball {
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url =
+        lock.nodes.flake-compat.locked.url
+          or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }
+).shellNix
     url = "https://github.com/NixOS/nixpkgs/archive/nixos-22.05.tar.gz";
     sha256 = "154x9swf494mqwi4z8nbq2f0sp8pwp4fvx51lqzindjfbb9yxxv5";
   }) {}


### PR DESCRIPTION
fixes #295 and #296 

* created `flake.nix` and updated `shell.nix`. Both now use `nixpkgs` `22.05` which effectively pins the dependencies, especially `gcc-arm-embedded-9` which is even no longer available on a recent `nixpkgs`
* Updated `development.md` and `build.md`
* Created a github-actions workflow which is building the `unix` and `disco` target after installing the dependencies via the flake. The binaries are uploaded and are available 90 days. The workflow kicks in for PRs to main/master and merges to main/master.

We're not using the newest dependencies from nix here, as on the main branch, we're currently dependent on the gcc-arm-embedded-9 which is no longer available in 25.05.
We're pretty behind! However, Mike is currently bringing all the dependencies up to date in 
https://github.com/cryptoadvance/specter-diy/pull/304 and there we'll pin to the latest version.