### PR TITLE
Update build firmware.sh to add no bootloader build by default

### DIFF
--- a/build_firmware.sh
+++ b/build_firmware.sh
@@ -48,6 +48,7 @@ make disco
 cp ./bin/specter-diy.bin ./release/disco-nobootloader.bin
 cp ./bin/specter-diy.hex ./release/disco-nobootloader.hex
 echo -e "Standard firmware without bootloader saved to release/disco-nobootloader.{bin,hex}"
+echo -e "The BIN image can be flashed directly to a development board without the secure bootloader."
 
 echo -e "${INFO}
 ═════════════════════ Adding signature to the binary ══════════════════════

--- a/docs/build.md
+++ b/docs/build.md
@@ -123,6 +123,13 @@ To launch a simulator either run `bin/micropython_unix simulate.py` or simly run
 
 If something is not working you can clean up with `make clean`
 
+### Automated build script
+
+The top-level `build_firmware.sh` helper runs the full secure build, including the bootloader and signed upgrade package. It
+also creates `release/disco-nobootloader.{bin,hex}`, which contain the plain firmware without the secure bootloader. The
+`disco-nobootloader.bin` image is identical to the `nix build` output and can be flashed directly to a development board when
+you need a faster iteration loop.
+
 ## Run Unittests
 
 Currently unittests work only on linuxport, and there are... not many... Contributions are very welcome!

--- a/docs/reproducible-build.md
+++ b/docs/reproducible-build.md
@@ -22,6 +22,10 @@ docker build -t diy .
 docker run -ti -v `pwd`:/app diy
 ```
 
+The container runs `./build_firmware.sh`, which now also drops `release/disco-nobootloader.{bin,hex}` alongside the signed
+artifacts. The `disco-nobootloader.bin` image matches the standard `nix build` output and can be flashed directly to a
+development board when you want to skip the secure bootloader during testing.
+
 At the end of the build you will be presented with a base32 encoded hash of the firmware upgrade file that should be signed and asked to provide signatures.
 
 Get signatures from the description of the github release and enter one by one in the same order as provided in the release.


### PR DESCRIPTION
Just bringing the docker file in line with the existing nix dev builds, as we had a few folk here at the DIY retreat who tried to build with docker and didn't get something dev friendly initially