### PR TITLE
Improve documentation and in-app messaging when Specter-Javacard is bricked due to wrong PIN attempts (Plus review behavior)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,6 +59,10 @@ With the secure element you will have three options:
 
 At the moment, we have implementation for the first two options. Last seems to be the most secure, but then you need to trust proprietary crypto implementation. The second option saves the private key on the secure element under pin protection, and it can be encrypted, so the secure element never knows the private keys.
 
+## *What happens if I lock my Specter-Javacard by entering the wrong PIN too many times?*
+
+When the Specter-Javacard applet reaches its PIN retry limit the card is permanently locked and the applet becomes unusable. The only recovery is to uninstall the Specter-Javacard applet and then install it again. This reset process cannot be performed directly on the Specter-DIY hardware, but you can complete it with a SeedSigner device or any computer that has a USB smartcard reader.
+
 # Troubleshooting questions
 
 # I can't flash my device via Mini-USB ?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,7 +61,7 @@ At the moment, we have implementation for the first two options. Last seems to b
 
 ## *What happens if I lock my Specter-Javacard by entering the wrong PIN too many times?*
 
-When the Specter-Javacard applet reaches its PIN retry limit the card is permanently locked and the applet becomes unusable. The only recovery is to uninstall the Specter-Javacard applet and then install it again. This reset process cannot be performed directly on the Specter-DIY hardware, but you can complete it with a SeedSigner device or any computer that has a USB smartcard reader.
+When the Specter-Javacard applet reaches its PIN retry limit the card is permanently locked and the applet becomes unusable. The only recovery is to uninstall the Specter-Javacard applet and then install it again. This reset process cannot be performed directly on the Specter-DIY hardware, but you can complete it with the [SeedSigner smartcard-compatible fork](https://github.com/3rdIteration/seedsigner) or any computer that has a USB smartcard reader.
 
 # Troubleshooting questions
 

--- a/src/gui/async_gui.py
+++ b/src/gui/async_gui.py
@@ -156,9 +156,9 @@ class AsyncGUI:
         await self.load_screen(alert)
         return await alert.result()
 
-    async def error(self, msg, popup=False):
+    async def error(self, msg, popup=False, button_text="OK"):
         """Shows an error"""
-        alert = Alert("Error!", msg, button_text="OK")
+        alert = Alert("Error!", msg, button_text=button_text)
         if popup:
             await self.open_popup(alert)
         else:

--- a/src/keystore/memorycard.py
+++ b/src/keystore/memorycard.py
@@ -16,7 +16,9 @@ import lvgl as lv
 
 SMARTCARD_BLOCKED_MESSAGE = (
     "No more PIN attempts!\n"
-    "Wipe!\n"
+    "\n"
+    "Inserted Specter-Javacard is bricked...\n"
+    "\n"
     "Reinstall the Specter-Javacard applet using the SeedSigner smartcard-compatible fork "
     "or a PC with a USB smartcard reader."
 )

--- a/src/keystore/memorycard.py
+++ b/src/keystore/memorycard.py
@@ -2,6 +2,7 @@ from .core import KeyStoreError, PinError
 from .ram import RAMKeyStore
 from .javacard.applets.memorycard import MemoryCardApplet, SecureError
 from .javacard.util import get_connection
+from platform import CriticalErrorWipeImmediately
 import platform
 from embit import bip39
 from helpers import tagged_hash, aead_encrypt, aead_decrypt
@@ -14,7 +15,8 @@ import lvgl as lv
 
 
 SMARTCARD_BLOCKED_MESSAGE = (
-    "The smartcard is blocked after too many incorrect PIN attempts.\n"
+    "No more PIN attempts!\n"
+    "Wipe!\n"
     "Reinstall the Specter-Javacard applet using the SeedSigner smartcard-compatible fork "
     "or a PC with a USB smartcard reader."
 )
@@ -54,7 +56,7 @@ In this mode device can only operate when the smartcard is inserted!"""
 
 
     def _raise_blocked_card(self):
-        raise PinError(SMARTCARD_BLOCKED_MESSAGE)
+        raise CriticalErrorWipeImmediately(SMARTCARD_BLOCKED_MESSAGE)
 
 
     @classmethod
@@ -122,7 +124,7 @@ In this mode device can only operate when the smartcard is inserted!"""
     def _unlock(self, pin):
         """
         Unlock the keystore, raises PinError if PIN is invalid.
-        Raises PinError if the card is blocked.
+        Raises CriticalErrorWipeImmediately if no attempts left.
         """
         try:
             self.applet.unlock(pin)

--- a/src/specter.py
+++ b/src/specter.py
@@ -73,7 +73,10 @@ class Specter:
             raise exception
         except CriticalErrorWipeImmediately as e:
             # show error
-            await self.gui.error("Critical error, the device will be wiped.\n\n%s" % e)
+            await self.gui.error(
+                "Critical error, the device will be wiped.\n\n%s" % e,
+                button_text="Wipe Specter Device",
+            )
             self.gui.show_loader(title="Wiping the device...")
             # wipe everything and reboot
             self.wipe()


### PR DESCRIPTION
1. Improved documentation to mention what happens when Specter-Javacard PIN is incorrect and the applet bricked
2. Improved feedback messages on the Specter Device when Specter-Javacard is bricked due to wrong PIN.