### PR TITLE
Documentation update: Elaborated on how to verify binaries

### DIFF
--- a/docs/binary_verification.md
+++ b/docs/binary_verification.md
@@ -1,0 +1,103 @@
+# Verifying the released binaries
+
+This guide explains how to verify the integrity of Specter firmware binaries on the command line of your OS.
+
+## Files needed to verify
+- `initial_firmware_v<version>.bin` - Binary with secure bootloader. Use for upgrading from versions below 1.4.0 or first-time upload
+- `specter_upgrade_v<version>.bin` - For regular upgrades (after you have once done a first-time upload)
+- `sha256.signed.txt` - Contains the expected hashes of the binaries, which are signed by the specter team
+
+> **Note:** Replace `<version>` with your actual firmware version (e.g., 1.9.0)
+
+Download these files for the release you want to use from the Specter DIY repository: https://github.com/cryptoadvance/specter-diy/releases 
+
+## Linux Verification
+
+### Prerequisites
+```bash
+# GPG is usually pre-installed. If not:
+sudo apt-get install gnupg      # Debian/Ubuntu
+sudo dnf install gnupg2         # Fedora
+```
+
+### Verification Steps
+
+**1. Import Stepan's PGP key:**
+```bash
+curl -s https://stepansnigirev.com/ss-specter-release.asc | gpg --import
+```
+
+**2. Verify the signature of sha256.signed.txt:**
+```bash
+gpg --verify sha256.signed.txt
+```
+✓ Look for "Good signature from" message
+
+**3. Verify the hash of the binary:**
+```bash
+sha256sum -c sha256.signed.txt --ignore-missing
+```
+✓ Should show "OK" for the binary file(s)
+
+## macOS Verification
+
+### Prerequisites
+```bash
+# Install GPG via Homebrew
+brew install gnupg
+```
+
+### Verification Steps
+
+**1. Import Stepan's PGP key:**
+```bash
+curl -s https://stepansnigirev.com/ss-specter-release.asc | gpg --import
+```
+
+**2. Verify the signature of sha256.signed.txt:**
+```bash
+gpg --verify sha256.signed.txt
+```
+✓ Look for "Good signature from" message
+
+**3. Verify the hash of the binary:**
+```bash
+shasum -a 256 -c sha256.signed.txt --ignore-missing
+```
+✓ Should show "OK" for the binary file(s)
+
+---
+
+## Windows Verification
+
+### Prerequisites
+1. Download and install [Gpg4win](https://gpg4win.org/download.html)
+2. After installation, open PowerShell or Command Prompt
+
+### Verification Steps
+
+**1. Import Stepan's PGP key:**
+```powershell
+curl.exe -s https://stepansnigirev.com/ss-specter-release.asc -o stepan-key.asc
+gpg --import stepan-key.asc
+```
+
+**2. Verify the signature of sha256.signed.txt:**
+```powershell
+gpg --verify sha256.signed.txt
+```
+✓ Look for "Good signature from" message
+
+**3. Verify the hash of the binary:**
+
+**Option A - Using CertUtil:**
+```cmd
+certutil -hashfile initial_firmware_v<version>.bin SHA256
+```
+Then manually compare the output with the hash in sha256.signed.txt. They need to be the same.
+
+**Option B - Using PowerShell:**
+```powershell
+(Get-FileHash initial_firmware_v<version>.bin -Algorithm SHA256).Hash.ToLower()
+```
+Then manually compare the output with the hash in sha256.signed.txt. They need to be the same.

--- a/docs/binary_verification.md
+++ b/docs/binary_verification.md
@@ -89,15 +89,9 @@ gpg --verify sha256.signed.txt
 ✓ Look for "Good signature from" message
 
 **3. Verify the hash of the binary:**
-
-**Option A - Using CertUtil:**
 ```cmd
 certutil -hashfile initial_firmware_v<version>.bin SHA256
+certutil -hashfile specter_upgrade_v<version>.bin SHA256
 ```
-Then manually compare the output with the hash in sha256.signed.txt. They need to be the same.
+Then manually compare the outputs with the hashes in sha256.signed.txt. They need to be the same.
 
-**Option B - Using PowerShell:**
-```powershell
-(Get-FileHash initial_firmware_v<version>.bin -Algorithm SHA256).Hash.ToLower()
-```
-Then manually compare the output with the hash in sha256.signed.txt. They need to be the same.

--- a/docs/binary_verification.md
+++ b/docs/binary_verification.md
@@ -11,6 +11,8 @@ This guide explains how to verify the integrity of Specter firmware binaries on 
 
 Download these files for the release you want to use from the Specter DIY repository: https://github.com/cryptoadvance/specter-diy/releases 
 
+---
+
 ## Linux Verification
 
 ### Prerequisites
@@ -38,6 +40,8 @@ gpg --verify sha256.signed.txt
 sha256sum -c sha256.signed.txt --ignore-missing
 ```
 ✓ Should show "OK" for the binary file(s)
+
+---
 
 ## macOS Verification
 

--- a/docs/binary_verification.md
+++ b/docs/binary_verification.md
@@ -2,14 +2,31 @@
 
 This guide explains how to verify the integrity of Specter firmware binaries on the command line of your OS.
 
+## Release signing keys
+
+Different releases are signed by different keys. Import the key that corresponds to the release you want to verify, then check that the imported key's fingerprint matches the one listed below. The concrete import and fingerprint-check commands for your operating system are in the Linux, macOS, and Windows sections.
+
+### Specter Signer 2026 (releases v1.10.3 and newer)
+
+- Owner: k9ert
+- Fingerprint: `9DC3 3CA8 3058 9DE3 B322 5C26 EEF5 756B 2EA4 2349`
+
+### Stepan Snigirev (older releases, such as v1.9.0)
+
+- Fingerprint: `6F16 E354 F833 93D6 E52E C25F 36ED 357A B24B 915F`
+
+### Verify the imported key's fingerprint
+
+A "Good signature" message alone only means the file was signed by *some* key. To be sure it was signed by the intended release key, compare the fingerprint of the imported key with the fingerprint listed above. The sections below show the commands to display the imported key's fingerprint for each operating system.
+
 ## Files needed to verify
 - `initial_firmware_v<version>.bin` - Binary with secure bootloader. Use for upgrading from versions below 1.4.0 or first-time upload
 - `specter_upgrade_v<version>.bin` - For regular upgrades (after you have once done a first-time upload)
-- `sha256.signed.txt` - Contains the expected hashes of the binaries, which are signed by the specter team
+- `sha256.signed.txt` - Contains the expected hashes of the binaries, which are signed by the Specter team
 
 > **Note:** Replace `<version>` with your actual firmware version (e.g., 1.9.0)
 
-Download these files for the release you want to use from the Specter DIY repository: https://github.com/cryptoadvance/specter-diy/releases 
+Download these files for the release you want to use from the Specter DIY repository: https://github.com/cryptoadvance/specter-diy/releases
 
 ---
 
@@ -24,18 +41,39 @@ sudo dnf install gnupg2         # Fedora
 
 ### Verification Steps
 
-**1. Import Stepan's PGP key:**
+**1. Import the release signing key:**
+
+For v1.10.3 and newer:
+```bash
+gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 9DC33CA830589DE3B3225C26EEF5756B2EA42349
+```
+
+For older releases:
 ```bash
 curl -s https://stepansnigirev.com/ss-specter-release.asc | gpg --import
 ```
 
-**2. Verify the signature of sha256.signed.txt:**
+**2. Verify the imported fingerprint:**
+
+For v1.10.3 and newer:
+```bash
+gpg --list-keys --fingerprint 9DC33CA830589DE3B3225C26EEF5756B2EA42349
+```
+
+For older releases:
+```bash
+gpg --list-keys --fingerprint 6F16E354F83393D6E52EC25F36ED357AB24B915F
+```
+
+Compare the displayed fingerprint with the one listed in [Release signing keys](#release-signing-keys).
+
+**3. Verify the signature of sha256.signed.txt:**
 ```bash
 gpg --verify sha256.signed.txt
 ```
 ✓ Look for "Good signature from" message
 
-**3. Verify the hash of the binary:**
+**4. Verify the hash of the binary:**
 ```bash
 sha256sum -c sha256.signed.txt --ignore-missing
 ```
@@ -53,22 +91,61 @@ brew install gnupg
 
 ### Verification Steps
 
-**1. Import Stepan's PGP key:**
+**1. Import the release signing key:**
+
+For v1.10.3 and newer:
+```bash
+gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 9DC33CA830589DE3B3225C26EEF5756B2EA42349
+```
+
+For older releases:
 ```bash
 curl -s https://stepansnigirev.com/ss-specter-release.asc | gpg --import
 ```
 
-**2. Verify the signature of sha256.signed.txt:**
+**2. Verify the imported fingerprint:**
+
+For v1.10.3 and newer:
+```bash
+gpg --list-keys --fingerprint 9DC33CA830589DE3B3225C26EEF5756B2EA42349
+```
+
+For older releases:
+```bash
+gpg --list-keys --fingerprint 6F16E354F83393D6E52EC25F36ED357AB24B915F
+```
+
+Compare the displayed fingerprint with the one listed in [Release signing keys](#release-signing-keys).
+
+**3. Verify the signature of sha256.signed.txt:**
 ```bash
 gpg --verify sha256.signed.txt
 ```
 ✓ Look for "Good signature from" message
 
-**3. Verify the hash of the binary:**
+**4. Verify the hash of the binary:**
+
+The version of `shasum` shipped with macOS does not support the `--ignore-missing` flag, so the following two approaches are recommended.
+
+#### Option A: Manual comparison (works on every Mac)
 ```bash
-shasum -a 256 -c sha256.signed.txt --ignore-missing
+shasum -a 256 initial_firmware_v<version>.bin
+shasum -a 256 specter_upgrade_v<version>.bin
+```
+Then manually compare the outputs with the hashes listed in `sha256.signed.txt`. They must be identical.
+
+#### Option B: Use GNU Coreutils
+Install GNU Coreutils via Homebrew:
+```bash
+brew install coreutils
+```
+Then run:
+```bash
+gsha256sum -c sha256.signed.txt --ignore-missing
 ```
 ✓ Should show "OK" for the binary file(s)
+
+> Homebrew installs GNU tools with a `g` prefix by default. If you have added `$(brew --prefix coreutils)/libexec/gnubin` to your `PATH`, the command is `sha256sum` instead of `gsha256sum`.
 
 ---
 
@@ -80,22 +157,43 @@ shasum -a 256 -c sha256.signed.txt --ignore-missing
 
 ### Verification Steps
 
-**1. Import Stepan's PGP key:**
+**1. Import the release signing key:**
+
+For v1.10.3 and newer:
+```powershell
+gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 9DC33CA830589DE3B3225C26EEF5756B2EA42349
+```
+
+For older releases:
 ```powershell
 curl.exe -s https://stepansnigirev.com/ss-specter-release.asc -o stepan-key.asc
 gpg --import stepan-key.asc
 ```
 
-**2. Verify the signature of sha256.signed.txt:**
+**2. Verify the imported fingerprint:**
+
+For v1.10.3 and newer:
+```powershell
+gpg --list-keys --fingerprint 9DC33CA830589DE3B3225C26EEF5756B2EA42349
+```
+
+For older releases:
+```powershell
+gpg --list-keys --fingerprint 6F16E354F83393D6E52EC25F36ED357AB24B915F
+```
+
+Compare the displayed fingerprint with the one listed in [Release signing keys](#release-signing-keys).
+
+**3. Verify the signature of sha256.signed.txt:**
 ```powershell
 gpg --verify sha256.signed.txt
 ```
 ✓ Look for "Good signature from" message
 
-**3. Verify the hash of the binary:**
+**4. Verify the hash of the binary:**
 ```cmd
 certutil -hashfile initial_firmware_v<version>.bin SHA256
 certutil -hashfile specter_upgrade_v<version>.bin SHA256
 ```
-Then manually compare the outputs with the hashes in sha256.signed.txt. They need to be the same.
+Then manually compare the outputs with the hashes in `sha256.signed.txt`. They need to be the same.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,7 @@ With the secure bootloader initial installation of the firmware is slightly diff
 **Note** If you don't want to use binaries from the releases check out the [bootloader documentation](https://github.com/cryptoadvance/specter-bootloader/blob/master/doc/selfsigned.md) that explains how to compile and configure it to use your public keys instead of ours.
 
 - If you are upgrading from versions below `1.4.0` or uploading the firmware for the first time, use the `initial_firmware_<version>.bin` from the [releases](https://github.com/cryptoadvance/specter-diy/releases) page.
-	- Verify the signature of the `sha256.signed.txt` file. Since v1.10.3 it is signed with the **"Specter Signer 2026"** key, controlled by k9ert (fingerprint `9DC3 3CA8 3058 9DE3 B322 5C26 EEF5 756B 2EA4 2349`, [Ubuntu keyserver](http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x9dc33ca830589de3b3225c26eef5756b2ea42349)). Older releases were signed with [Stepan's PGP key](https://stepansnigirev.com/ss-specter-release.asc)
-	- Verify the hash of the `initial_firmware_<version>.bin` against the hash stored in the `sha256.signed.txt`
+	- Verify the [integrity of the downloaded binaries](./binary_verification.md) against the hash in `sha256.signed.txt`
 - If you are upgrading from an empty bootloader or you see the bootloader error message that firmware is not valid, check out the next section - [Flashing signed Specter firmware](#flashing-signed-specter-firmware).
 - Make sure the [power jumper](./assembly.md) of your discovery board is at STLK position
 - Connect the discovery board to your computer via the **miniUSB** cable on the top of the board.


### PR DESCRIPTION
To be more approachable also for not super technical experts, a step by step guide how to verify the hash and signature of the binaries for releases was added

IMPORTANT:
For Linux I have followed the tutorial myself to make sure it works as decribed. Dor Mac and Win the procedure seems plausible, but needs to be verified by users of those OSes.