### PR TITLE
Documentation: Add link to udev/README.md to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: https://github.com/cryptoadvance/specter-diy/
 nav:
   - Home:
     - 'Introduction': README.md
+    - 'USB udev rules (Linux)': udev/README.md 
     - 'FAQ': faq.md
     - roadmap.md
   - Hardware:


### PR DESCRIPTION
Because the link is missing in mkdocs, the link to the udev rules in the main README.md breaks when accessing the readme via https://docs.specter.solutions/diy/