### PR TITLE
Zoom-to-transcribe for seed QRs + BIP-85 encoding choice

### DIFF
--- a/src/apps/bip85.py
+++ b/src/apps/bip85.py
@@ -3,7 +3,7 @@ from binascii import hexlify
 from io import BytesIO
 
 from app import BaseApp, AppError
-from embit import bip85
+from embit import bip85, bip39
 from gui.common import add_button, add_button_pair, align_button_pair
 from gui.decorators import on_release
 from gui.screens import Menu, NumericScreen, QRAlert, Alert, Prompt
@@ -112,8 +112,26 @@ class App(BaseApp):
                 Bip85MnemonicScreen(mnemonic=mnemonic, title=title, note=note)
             )
             if action == Bip85MnemonicScreen.QR:
+                enc = await show_screen(
+                    Menu([(1, "SeedQR (digits)"), (2, "Compact SeedQR (binary)"), (3, "Plaintext")],
+                         last=(255, None),
+                         title="Select encoding format",
+                         note="Compact QR is smaller but not human-readable\n")
+                )
+                if enc == 1:
+                    nums = [bip39.WORDLIST.index(w) for w in mnemonic.split()]
+                    qr_msg = "".join([("000"+str(n))[-4:] for n in nums])
+                    msg = qr_msg
+                elif enc == 2:
+                    qr_msg = bip39.mnemonic_to_bytes(mnemonic)
+                    msg = hexlify(qr_msg).decode()
+                elif enc == 3:
+                    qr_msg = mnemonic
+                    msg = mnemonic
+                else:
+                    return True
                 await show_screen(
-                    QRAlert(title=title, message=mnemonic, note=note)
+                    QRAlert(title=title, message=msg, qr_message=qr_msg, note=note, transcribe=True)
                 )
             elif action == Bip85MnemonicScreen.SD:
                 fname = "bip85-%s-mnemonic-%d-%d.txt" % (

--- a/src/apps/blindingkeys/app.py
+++ b/src/apps/blindingkeys/app.py
@@ -31,7 +31,8 @@ class BlindingKeysApp(BaseApp):
     async def menu(self, show_screen, show_all=False):
         await show_screen(QRAlert("Standard SLIP-77 blinding key",
                 self.keystore.slip77_key.wif(NETWORKS[self.network]),
-                note="Blinding private key allows your software wallet\nto track your balance."
+                note="Blinding private key allows your software wallet\nto track your balance.",
+                transcribe=True
                 ))
         return False
 

--- a/src/gui/screens/__init__.py
+++ b/src/gui/screens/__init__.py
@@ -8,3 +8,4 @@ from .input import PinScreen, InputScreen, DerivationScreen, NumericScreen
 from .mnemonic import MnemonicScreen, NewMnemonicScreen, RecoverMnemonicScreen
 from .transaction import TransactionScreen
 from .settings import DevSettings
+from .qr_transcribe import QRTranscribeScreen

--- a/src/gui/screens/qr_transcribe.py
+++ b/src/gui/screens/qr_transcribe.py
@@ -1,0 +1,249 @@
+import lvgl as lv
+import math
+import qrcode
+
+from .screen import Screen
+from ..common import add_label, add_button, HOR_RES
+from ..decorators import on_release
+from qr_transcribe_logic import (
+    adaptive_grid_size, iter_zone_modules, next_zone, zone_bounds, clamp_zone,
+)
+
+
+BTNSIZE = 50
+NAV_Y_CENTER = 600
+DPAD_CENTER_X = 135
+MINIMAP_CENTER_X = 340
+MINIMAP_CELL = 12
+MINIMAP_GAP = 2
+ZONE_AREA_SIDE = 400
+ZONE_AREA_Y = 130
+N_MIN = 2
+N_MAX = 6
+N_BTN_SIZE = 50
+
+
+class QRTranscribeScreen(Screen):
+    """Full-screen view that zooms into one zone of a QR code at a time.
+
+    Used for hand-transcribing seed-class QRs onto paper. Each module of
+    the zone is drawn as a small lv.obj coloured black (dark module) or
+    white (light module) inside a fixed 400x400 container. Axis labels
+    along the top + left make the row/col coordinates explicit.
+    """
+
+    def __init__(self, qr_text):
+        super().__init__()
+        self._qr_text = qr_text
+        self._raw = bytearray(qrcode.encode(qr_text))
+        self._s = int(math.sqrt(len(self._raw) * 8))
+        self._n = adaptive_grid_size(self._s)
+        self._zone_r = 0
+        self._zone_c = 0
+
+        self.title = add_label("Transcribe", scr=self, style="title")
+        self.zone_label = add_label("", scr=self, style="hint")
+        self.zone_label.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
+
+        # Cell + label styles. Allocated once, reused across renders.
+        self._dark_style = lv.style_t()
+        self._dark_style.body.main_color = lv.color_make(0x00, 0x00, 0x00)
+        self._dark_style.body.grad_color = lv.color_make(0x00, 0x00, 0x00)
+        self._dark_style.body.opa = lv.OPA.COVER
+        self._dark_style.body.radius = 0
+        self._dark_style.body.border.width = 0
+
+        self._light_style = lv.style_t()
+        self._light_style.body.main_color = lv.color_make(0xFF, 0xFF, 0xFF)
+        self._light_style.body.grad_color = lv.color_make(0xFF, 0xFF, 0xFF)
+        self._light_style.body.opa = lv.OPA.COVER
+        self._light_style.body.radius = 0
+        self._light_style.body.border.width = 0
+
+        self._bg_style = lv.style_t()
+        self._bg_style.body.main_color = lv.color_make(0xFF, 0xFF, 0xFF)
+        self._bg_style.body.grad_color = lv.color_make(0xFF, 0xFF, 0xFF)
+        self._bg_style.body.opa = lv.OPA.COVER
+        self._bg_style.body.radius = 0
+        self._bg_style.body.border.width = 0
+
+        self._label_style = lv.style_t()
+        lv.style_copy(self._label_style, lv.style_plain)
+        self._label_style.text.color = lv.color_make(0x00, 0x00, 0x00)
+        self._label_style.body.opa = lv.OPA.TRANSP
+
+        # White background pane that holds the cells. Rebuilt by _render_zone.
+        self._zone_container = None
+
+        self.btn_n_dec = lv.btn(self)
+        lv.label(self.btn_n_dec).set_text("-")
+        self.btn_n_dec.set_size(N_BTN_SIZE, N_BTN_SIZE)
+        self.btn_n_dec.set_pos(20, 10)
+        self.btn_n_dec.set_event_cb(on_release(lambda: self._change_n(-1)))
+
+        self.btn_n_inc = lv.btn(self)
+        lv.label(self.btn_n_inc).set_text("+")
+        self.btn_n_inc.set_size(N_BTN_SIZE, N_BTN_SIZE)
+        self.btn_n_inc.set_pos(HOR_RES - 20 - N_BTN_SIZE, 10)
+        self.btn_n_inc.set_event_cb(on_release(lambda: self._change_n(+1)))
+
+        self.n_label = add_label("", scr=self, style="hint")
+        self.n_label.align(self.btn_n_dec, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
+
+        self._create_arrows()
+        self._create_minimap()
+        self._render_zone()
+
+        self.close_button = add_button(
+            "Done",
+            on_release(lambda: self.set_value(None)),
+            scr=self,
+            y=720,
+        )
+
+    def _create_arrows(self):
+        self.btn_up = lv.btn(self)
+        lv.label(self.btn_up).set_text(lv.SYMBOL.UP)
+        self.btn_up.set_size(BTNSIZE, BTNSIZE)
+        self.btn_up.set_event_cb(on_release(lambda: self._move("up")))
+
+        self.btn_down = lv.btn(self)
+        lv.label(self.btn_down).set_text(lv.SYMBOL.DOWN)
+        self.btn_down.set_size(BTNSIZE, BTNSIZE)
+        self.btn_down.set_event_cb(on_release(lambda: self._move("down")))
+
+        self.btn_left = lv.btn(self)
+        lv.label(self.btn_left).set_text(lv.SYMBOL.LEFT)
+        self.btn_left.set_size(BTNSIZE, BTNSIZE)
+        self.btn_left.set_event_cb(on_release(lambda: self._move("left")))
+
+        self.btn_right = lv.btn(self)
+        lv.label(self.btn_right).set_text(lv.SYMBOL.RIGHT)
+        self.btn_right.set_size(BTNSIZE, BTNSIZE)
+        self.btn_right.set_event_cb(on_release(lambda: self._move("right")))
+
+        self.btn_up.set_pos(DPAD_CENTER_X - BTNSIZE // 2, NAV_Y_CENTER - BTNSIZE - 5)
+        self.btn_down.set_pos(DPAD_CENTER_X - BTNSIZE // 2, NAV_Y_CENTER + BTNSIZE + 5)
+        self.btn_left.set_pos(DPAD_CENTER_X - BTNSIZE * 3 // 2 - 5, NAV_Y_CENTER - BTNSIZE // 2)
+        self.btn_right.set_pos(DPAD_CENTER_X + BTNSIZE // 2 + 5, NAV_Y_CENTER - BTNSIZE // 2)
+
+    def _create_minimap(self):
+        size = self._n * MINIMAP_CELL + (self._n - 1) * MINIMAP_GAP
+        self._minimap_container = lv.obj(self)
+        self._minimap_container.set_size(size, size)
+        self._minimap_container.set_pos(
+            MINIMAP_CENTER_X - size // 2, NAV_Y_CENTER - size // 2
+        )
+        self._mm_active_style = lv.style_t()
+        self._mm_active_style.body.main_color = lv.color_hex(0x3B82F6)
+        self._mm_active_style.body.grad_color = lv.color_hex(0x3B82F6)
+        self._mm_active_style.body.opa = 255
+        self._mm_inactive_style = lv.style_t()
+        self._mm_inactive_style.body.main_color = lv.color_hex(0xDDDDDD)
+        self._mm_inactive_style.body.grad_color = lv.color_hex(0xDDDDDD)
+        self._mm_inactive_style.body.opa = 255
+        self._minimap_cells = []
+        for r in range(self._n):
+            row = []
+            for c in range(self._n):
+                cell = lv.obj(self._minimap_container)
+                cell.set_size(MINIMAP_CELL, MINIMAP_CELL)
+                cell.set_pos(
+                    c * (MINIMAP_CELL + MINIMAP_GAP),
+                    r * (MINIMAP_CELL + MINIMAP_GAP),
+                )
+                row.append(cell)
+            self._minimap_cells.append(row)
+
+    def _update_minimap(self):
+        for r in range(self._n):
+            for c in range(self._n):
+                style = (self._mm_active_style
+                         if (r == self._zone_r and c == self._zone_c)
+                         else self._mm_inactive_style)
+                self._minimap_cells[r][c].set_style(style)
+
+    def _update_button_states(self):
+        for btn, ok in (
+            (self.btn_up,    self._zone_r > 0),
+            (self.btn_down,  self._zone_r < self._n - 1),
+            (self.btn_left,  self._zone_c > 0),
+            (self.btn_right, self._zone_c < self._n - 1),
+            (self.btn_n_dec, self._n > N_MIN),
+            (self.btn_n_inc, self._n < N_MAX),
+        ):
+            btn.set_state(lv.btn.STATE.REL if ok else lv.btn.STATE.INA)
+
+    def _render_zone(self):
+        # Tear down the previous zone subtree so a stale grid never lingers.
+        if self._zone_container is not None:
+            self._zone_container.delete()
+        self._zone_container = lv.obj(self)
+        self._zone_container.set_style(self._bg_style)
+        self._zone_container.set_size(ZONE_AREA_SIDE, ZONE_AREA_SIDE)
+        self._zone_container.align(self, lv.ALIGN.IN_TOP_MID, 0, ZONE_AREA_Y)
+
+        r0, c0, r1, c1 = zone_bounds(self._s, self._n, self._zone_r, self._zone_c)
+        zone_h = r1 - r0
+        zone_w = c1 - c0
+        # Reserve one cell-width along the top + left edges for axis numbers.
+        cell = ZONE_AREA_SIDE // (max(zone_h, zone_w) + 1)
+        grid_w = zone_w * cell
+        grid_h = zone_h * cell
+        ox = (ZONE_AREA_SIDE - grid_w + cell) // 2
+        oy = (ZONE_AREA_SIDE - grid_h + cell) // 2
+
+        # Column numbers along the top: absolute QR column index (1..s).
+        for zc in range(zone_w):
+            lbl = lv.label(self._zone_container)
+            lbl.set_style(0, self._label_style)
+            lbl.set_text(str(c0 + zc + 1))
+            lbl.set_size(cell, cell)
+            lbl.set_pos(ox + zc * cell, oy - cell)
+            lbl.set_align(lv.label.ALIGN.CENTER)
+
+        # Row numbers along the left: absolute QR row index (1..s).
+        for zr in range(zone_h):
+            lbl = lv.label(self._zone_container)
+            lbl.set_style(0, self._label_style)
+            lbl.set_text(str(r0 + zr + 1))
+            lbl.set_size(cell, cell)
+            lbl.set_pos(ox - cell, oy + zr * cell + (cell // 4))
+            lbl.set_align(lv.label.ALIGN.CENTER)
+
+        # Module cells: one lv.obj per module. Each gets a 1px gap on each
+        # side via (cell - 2) sizing so adjacent dark modules show as
+        # discrete dots, not a connected blob.
+        for zr, zc, dark in iter_zone_modules(
+            self._raw, self._s, self._n, self._zone_r, self._zone_c
+        ):
+            obj = lv.obj(self._zone_container)
+            obj.set_size(cell - 2, cell - 2)
+            obj.set_pos(ox + zc * cell + 1, oy + zr * cell + 1)
+            obj.set_style(self._dark_style if dark else self._light_style)
+
+        self.zone_label.set_text(
+            "Row %d, Col %d of %dx%d"
+            % (self._zone_r + 1, self._zone_c + 1, self._n, self._n)
+        )
+        self.n_label.set_text("N = %d" % self._n)
+        self._update_minimap()
+        self._update_button_states()
+
+    def _move(self, direction):
+        new_r, new_c = next_zone(self._n, self._zone_r, self._zone_c, direction)
+        if (new_r, new_c) == (self._zone_r, self._zone_c):
+            return
+        self._zone_r, self._zone_c = new_r, new_c
+        self._render_zone()
+
+    def _change_n(self, delta):
+        new_n = self._n + delta
+        if new_n < N_MIN or new_n > N_MAX:
+            return
+        self._n = new_n
+        self._zone_r, self._zone_c = clamp_zone(self._n, self._zone_r, self._zone_c)
+        # Rebuild minimap (its grid size changes with N).
+        self._minimap_container.delete()
+        self._create_minimap()
+        self._render_zone()

--- a/src/gui/screens/qralert.py
+++ b/src/gui/screens/qralert.py
@@ -1,5 +1,8 @@
+import asyncio
 import lvgl as lv
+
 from .alert import Alert
+from .qr_transcribe import QRTranscribeScreen
 from ..common import add_qrcode, add_button
 from ..decorators import on_release
 
@@ -22,8 +25,18 @@ class QRAlert(Alert):
         self.qr.align(self.page, lv.ALIGN.IN_TOP_MID, 0, 20)
         self.message.align(self.qr, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
         if transcribe:
-            btn = add_button("Toggle transcribe", on_release(self.toggle_transcribe), scr=self)
+            btn = add_button("Transcribe", on_release(self._open_transcribe), scr=self)
             btn.align(self.message, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
 
-    def toggle_transcribe(self):
-        self.qr.spacing = 0 if self.qr.spacing else 3
+    def _open_transcribe(self):
+        asyncio.create_task(self._transcribe_loop())
+
+    async def _transcribe_loop(self):
+        # qr.get_text() returns the original payload (not the bcur-frame text)
+        scr = QRTranscribeScreen(self.qr.get_text())
+        lv.scr_load(scr)
+        try:
+            await scr.result()
+        finally:
+            lv.scr_load(self)
+            scr.del_async()

--- a/src/qr_transcribe_logic.py
+++ b/src/qr_transcribe_logic.py
@@ -1,0 +1,80 @@
+"""Pure logic for the QR transcribe screen.
+
+Kept LVGL-free and outside `gui.screens` so unit tests can import it
+without pulling in the framebuffer-dependent screen package.
+"""
+
+
+def adaptive_grid_size(s):
+    """Pick an N x N grid so each zone holds ~12-18 modules per side.
+
+    Argument s is the bitmap side length returned by qrcode.encode()
+    (the QR plus quiet-zone border, padded to byte stride).
+    """
+    if s <= 28:
+        return 2
+    if s <= 44:
+        return 3
+    if s <= 60:
+        return 4
+    return 5
+
+
+def zone_bounds(s, n, zone_r, zone_c):
+    """Return (r0, c0, r1, c1) bitmap-row/col slice for the given zone.
+
+    The last row and last column absorb any remainder so the whole
+    bitmap is covered. Coordinates are 0-indexed; r1/c1 are exclusive.
+    """
+    step = s // n
+    r0 = zone_r * step
+    c0 = zone_c * step
+    r1 = s if zone_r == n - 1 else r0 + step
+    c1 = s if zone_c == n - 1 else c0 + step
+    return (r0, c0, r1, c1)
+
+
+def module_at(raw, s, r, c):
+    """Return 0 or 1 for the bit at (row, col) of an SxS 1-bit bitmap.
+
+    `raw` is a bytes/bytearray packed MSB-first, row-major, as produced
+    by the qrcode usermod's qrcode.encode().
+    """
+    idx = r * s + c
+    byte = raw[idx >> 3]
+    return (byte >> (7 - (idx & 7))) & 1
+
+
+def next_zone(n, zone_r, zone_c, direction):
+    """Move one step in the given direction, clamped at the N x N edges."""
+    if direction == "up":
+        return (max(0, zone_r - 1), zone_c)
+    if direction == "down":
+        return (min(n - 1, zone_r + 1), zone_c)
+    if direction == "left":
+        return (zone_r, max(0, zone_c - 1))
+    if direction == "right":
+        return (zone_r, min(n - 1, zone_c + 1))
+    return (zone_r, zone_c)
+
+
+def iter_zone_modules(raw, s, n, zone_r, zone_c):
+    """Yield (zone_row, zone_col, is_dark) for each module in the zone.
+
+    zone_row and zone_col are 0-indexed within the zone (zone-local).
+    is_dark is 1 if the QR has a dark module at the absolute position
+    (r0 + zone_row, c0 + zone_col), else 0.
+    """
+    r0, c0, r1, c1 = zone_bounds(s, n, zone_r, zone_c)
+    for zr in range(r1 - r0):
+        for zc in range(c1 - c0):
+            yield zr, zc, module_at(raw, s, r0 + zr, c0 + zc)
+
+
+def clamp_zone(n, zone_r, zone_c):
+    """Clamp a zone index to [0, n-1] in each axis.
+
+    Used when the user reduces N from the transcribe screen and the
+    current (zone_r, zone_c) would now be off the grid.
+    """
+    return min(zone_r, n - 1), min(zone_c, n - 1)

--- a/test/tests/__init__.py
+++ b/test/tests/__init__.py
@@ -4,3 +4,4 @@ from .test_sign import *
 from .test_revault import *
 from .test_compatibility import *
 from .test_helpers import *
+from .test_qr_transcribe import *

--- a/test/tests/test_qr_transcribe.py
+++ b/test/tests/test_qr_transcribe.py
@@ -1,0 +1,98 @@
+from unittest import TestCase
+from qr_transcribe_logic import (
+    adaptive_grid_size, zone_bounds, module_at, next_zone,
+    iter_zone_modules, clamp_zone,
+)
+
+
+class QRTranscribeLogicTest(TestCase):
+    def test_adaptive_grid_size(self):
+        """Grid size N is chosen so each zone holds ~12-18 modules per side."""
+        # S values correspond to the byte-stride sizes returned by qrcode.encode()
+        # for QR versions 1, 2, 5, 8, 13 respectively.
+        self.assertEqual(adaptive_grid_size(28), 2)   # v1 (21 modules)
+        self.assertEqual(adaptive_grid_size(36), 3)   # v2 (25 modules)
+        self.assertEqual(adaptive_grid_size(44), 3)   # v4 (33 modules)
+        self.assertEqual(adaptive_grid_size(52), 4)   # v5 (37 modules)
+        self.assertEqual(adaptive_grid_size(60), 4)   # v8 (49 modules)
+        self.assertEqual(adaptive_grid_size(68), 5)   # v10 (57 modules)
+        self.assertEqual(adaptive_grid_size(76), 5)   # v13 (69 modules)
+
+    def test_zone_bounds_even_split(self):
+        """When S is divisible by N, zones are equally sized."""
+        # S=28, N=2: each zone is 14 wide
+        self.assertEqual(zone_bounds(28, 2, 0, 0), (0, 0, 14, 14))
+        self.assertEqual(zone_bounds(28, 2, 0, 1), (0, 14, 14, 28))
+        self.assertEqual(zone_bounds(28, 2, 1, 0), (14, 0, 28, 14))
+        self.assertEqual(zone_bounds(28, 2, 1, 1), (14, 14, 28, 28))
+
+    def test_zone_bounds_remainder_absorbed_by_edge(self):
+        """When S is not divisible by N, the last row/column zone is wider."""
+        # S=44, N=3: floor(44/3) = 14; first two zones are 14, last is 16
+        self.assertEqual(zone_bounds(44, 3, 0, 0), (0, 0, 14, 14))
+        self.assertEqual(zone_bounds(44, 3, 0, 1), (0, 14, 14, 28))
+        self.assertEqual(zone_bounds(44, 3, 0, 2), (0, 28, 14, 44))
+        self.assertEqual(zone_bounds(44, 3, 2, 2), (28, 28, 44, 44))
+
+    def test_module_at_reads_packed_bits(self):
+        """module_at reads a single bit from the qrcode.encode() output buffer.
+
+        The buffer is packed left-to-right, top-to-bottom; bit 0 is the
+        MSB of byte 0.
+        """
+        # 8x8 bitmap: row 0 = 0b10000000, row 1 = 0b01000000, ...
+        # so module_at(buf, 8, r, c) == 1 iff r == c
+        buf = bytearray(b"\x80\x40\x20\x10\x08\x04\x02\x01")
+        for r in range(8):
+            for c in range(8):
+                self.assertEqual(
+                    module_at(buf, 8, r, c),
+                    1 if r == c else 0,
+                    "module_at mismatch at (%d, %d)" % (r, c),
+                )
+
+    def test_next_zone_clamps_at_edges(self):
+        """Direction strings move (r, c); past-edge moves are no-ops."""
+        # interior — moves freely
+        self.assertEqual(next_zone(4, 1, 1, "up"),    (0, 1))
+        self.assertEqual(next_zone(4, 1, 1, "down"),  (2, 1))
+        self.assertEqual(next_zone(4, 1, 1, "left"),  (1, 0))
+        self.assertEqual(next_zone(4, 1, 1, "right"), (1, 2))
+        # at edges — clamped
+        self.assertEqual(next_zone(4, 0, 0, "up"),    (0, 0))
+        self.assertEqual(next_zone(4, 0, 0, "left"),  (0, 0))
+        self.assertEqual(next_zone(4, 3, 3, "down"),  (3, 3))
+        self.assertEqual(next_zone(4, 3, 3, "right"), (3, 3))
+
+    def test_iter_zone_modules_full_diagonal(self):
+        """Generator yields (zone_row, zone_col, is_dark) for each module."""
+        # 8x8 bitmap with bit set iff r == c: 0x80 0x40 0x20 0x10 ...
+        raw = bytearray(b"\x80\x40\x20\x10\x08\x04\x02\x01")
+        # Zone (0, 0) of a 2x2 grid: top-left 4x4, diagonal r==c
+        triples = list(iter_zone_modules(raw, 8, 2, 0, 0))
+        self.assertEqual(len(triples), 16)
+        for zr, zc, dark in triples:
+            expected = 1 if zr == zc else 0
+            self.assertEqual(dark, expected,
+                             "mismatch at zone (%d, %d)" % (zr, zc))
+
+    def test_iter_zone_modules_uneven_last_zone(self):
+        """Remainder is absorbed by the last zone; iterator yields zone_h*zone_w items."""
+        # s=44, n=3: floor(44/3)=14, last column/row absorbs remainder of 2.
+        # Zone (2, 2): rows 28..44 (16), cols 28..44 (16) -> 256 items.
+        raw = bytes(44 * 44 // 8)
+        triples = list(iter_zone_modules(raw, 44, 3, 2, 2))
+        self.assertEqual(len(triples), 16 * 16)
+        # Zone (0, 2): rows 0..14, cols 28..44 -> 14*16 = 224 items.
+        triples = list(iter_zone_modules(raw, 44, 3, 0, 2))
+        self.assertEqual(len(triples), 14 * 16)
+
+    def test_clamp_zone(self):
+        """Clamp zone (r, c) to [0, n-1]; in-range values pass through."""
+        # In-range -> unchanged
+        self.assertEqual(clamp_zone(3, 0, 0), (0, 0))
+        self.assertEqual(clamp_zone(3, 2, 1), (2, 1))
+        # Out-of-range -> clamped to n-1
+        self.assertEqual(clamp_zone(3, 4, 4), (2, 2))
+        self.assertEqual(clamp_zone(2, 5, 0), (1, 0))
+        self.assertEqual(clamp_zone(6, 5, 5), (5, 5))  # in-range edge


### PR DESCRIPTION
## Summary

Adds a **Transcribe** button to the seed-class QR exports (main mnemonic, BIP-85 derived mnemonic, SLIP-77 blinding key) that opens a full-screen zoomed view of one zone of the QR at a time, so the user can hand-copy the code onto paper. Also adds the SeedQR / Compact SeedQR / Plaintext encoding menu to BIP-85 mnemonic exports, matching what the main recovery-phrase flow already offers.

## Why

Seed QRs are dense and copying one onto paper without a magnifier is error-prone. The previous "Toggle transcribe" feature only widened the cell spacing slightly; the user still had to read the whole code from a single 320 px display.

The new screen splits the QR into an adaptive N×N grid (default chosen so each zone holds ~12-18 modules per side) and renders one zone at a time as discrete black-on-white dots with row/column axis labels. The user pans through the grid with a D-pad and tracks position via a mini-map.

For BIP-85 specifically, the QR export used to show only the plaintext mnemonic — the main seed flow already offers SeedQR (digits) and Compact SeedQR (binary) as alternatives. The PR brings the BIP-85 flow to parity.

## What changes

### Commit 1: `Add QR zoom-to-transcribe screen for hand-copying seed-class QRs`

- **`src/qr_transcribe_logic.py`** (new) — pure logic, no LVGL imports: `adaptive_grid_size`, `zone_bounds`, `module_at`, `next_zone`, `iter_zone_modules`, `clamp_zone`. All six covered by unit tests in `test/tests/test_qr_transcribe.py`.
- **`src/gui/screens/qr_transcribe.py`** (new) — `QRTranscribeScreen`: 400×400 zone area rendered as an `lv.obj` widget grid (1 px gap per cell so adjacent dark modules appear as discrete dots), absolute QR row/col axis labels (1..S), D-pad navigation with edge-clamping, mini-map, N controls (2..6), Done button.
- **`src/gui/screens/qralert.py`** — replaces "Toggle transcribe" with a "Transcribe" button that swaps to the new screen and restores the QRAlert on Done.
- **`src/apps/blindingkeys/app.py`** — passes `transcribe=True` to the SLIP-77 QRAlert.
- Tests: 8 new unit tests covering all six logic functions including the uneven-last-zone case.

### Commit 2: `BIP-85: offer SeedQR / Compact SeedQR / Plaintext on the QR export`

- **`src/apps/bip85.py`** — prompts the user to pick an encoding format (same menu and same encoding math as `keystore/ram.py:show_mnemonic`), then renders the resulting QR with `transcribe=True` so the new Transcribe button is reachable on any format.

## Implementation notes

- An `lv.obj` widget grid (one widget per QR module) is used instead of `lv.canvas` because `lv.canvas` is not rendered by the SDL backend in the unix simulator build. The widget approach works on both SDL and the F469 LTDC framebuffer.
- The whole zone subtree is rebuilt on every zone change / N change. For seed-class QRs (zone sizes typically 10-15) that's 100-225 widgets per render — well within performance budget on the F469.
- All button callbacks go through the existing `on_release` decorator, so every press still feeds touch entropy into the RNG pool.
- The main-seed QRAlert in `keystore/ram.py` already passed `transcribe=True` before this PR, so no change there.

## Screenshots

<img width="600" height="900" alt="v2-grid-fresh" src="https://github.com/user-attachments/assets/1af7fc96-47dd-40e6-a01e-328addaee582" />
<img width="600" height="900" alt="v2-globnum-row1col3" src="https://github.com/user-attachments/assets/23c135f6-054a-4be3-ad20-07362e62ab29" />
<img width="600" height="900" alt="v2-grid-nplus2" src="https://github.com/user-attachments/assets/256857cb-2e17-42fe-9a69-3171ffde1682" />
<img width="600" height="900" alt="v2-globnum-row3col3" src="https://github.com/user-attachments/assets/35fa70c7-569f-4a2b-8cab-1b308a46f57d" />

## Known limitations / discussion

- No error handling if `qrcode.encode()` raises on a payload that doesn't fit in v40. Today only seed-class flows pass `transcribe=True` and those always fit, but a guard + user-facing Alert would be a nice safety net.
- `_transcribe_loop` calls `lv.scr_load` directly rather than going through `AsyncGUI.show_screen`, so `gui.scr` stays pointed at the underlying QRAlert while the transcribe screen is on top. Harmless for the seed-class flows (no concurrent UI activity) but happy to refactor if maintainers prefer.

Built on top of `master` at v1.10.3.