### PR TITLE
Add SD card file deletion from file picker

### DIFF
--- a/src/hosts/sd.py
+++ b/src/hosts/sd.py
@@ -68,36 +68,69 @@ class SDHost(Host):
             return fname
         return fname[:18]+"..."+fname[-12:]
 
-    async def select_file(self, extensions):
-        files = sum([
-            [
-                f[0] for f in os.ilistdir(self.sdpath)
-                if f[0].lower().endswith(ext)
-                and f[1] == 0x8000
-            ] for ext in extensions
-        ], [])
-        
+    async def delete_file(self, files):
         if len(files) == 0:
-            raise HostError("\n\nNo matching files found on the SD card\nAllowed: %s" % ", ".join(extensions))
-        # elif len(files) == 1:
-        #     return self.sdpath+"/"+ files[0]
-        
-        files.sort()
-        buttons = []
-        for ext in extensions:
-            title = [(None, ext+" files")]
-            barr = [
-                (self.sdpath+"/"+f, self.truncate(f))
-                for f in files
-                if f.lower().endswith(ext)
-            ]
-            if len(barr) == 0:
-                buttons += [(None, "%s files - No files" % ext)]
-            else:
-                buttons += title + barr
-        
-        fname = await self.manager.gui.menu(buttons, title="Select a file", last=(None, "Cancel"))
-        return fname
+            return
+        buttons = [
+            (self.sdpath+"/"+f, self.truncate(f))
+            for f in files
+        ]
+        fname = await self.manager.gui.menu(
+            buttons,
+            title="Delete SD card file",
+            note="Select a file to delete.",
+            last=(None, "Cancel"),
+        )
+        if fname is None:
+            return
+        confirm = await self.manager.gui.prompt(
+            "Delete file?",
+            "Delete %s from the SD card?\n\nThis cannot be undone." % fname.split("/")[-1],
+        )
+        if not confirm:
+            return
+        os.remove(fname)
+        platform.sync()
+        await self.manager.gui.alert(
+            "Deleted",
+            "%s was deleted from the SD card." % fname.split("/")[-1],
+        )
+
+    async def select_file(self, extensions):
+        while True:
+            files = sum([
+                [
+                    f[0] for f in os.ilistdir(self.sdpath)
+                    if f[0].lower().endswith(ext)
+                    and f[1] == 0x8000
+                ] for ext in extensions
+            ], [])
+
+            if len(files) == 0:
+                raise HostError("\n\nNo matching files found on the SD card\nAllowed: %s" % ", ".join(extensions))
+            # elif len(files) == 1:
+            #     return self.sdpath+"/"+ files[0]
+
+            files.sort()
+            buttons = []
+            for ext in extensions:
+                title = [(None, ext+" files")]
+                barr = [
+                    (self.sdpath+"/"+f, self.truncate(f))
+                    for f in files
+                    if f.lower().endswith(ext)
+                ]
+                if len(barr) == 0:
+                    buttons += [(None, "%s files - No files" % ext)]
+                else:
+                    buttons += title + barr
+            buttons += [(None, None), ("__delete_file__", "Delete file...")]
+
+            fname = await self.manager.gui.menu(buttons, title="Select a file", last=(None, "Cancel"))
+            if fname == "__delete_file__":
+                await self.delete_file(files)
+                continue
+            return fname
 
     def completed_filename(self, filename):
         suffix = "" if self.parent is None else ("."+hexlify(self.parent.fingerprint).decode())

--- a/test/tests_native/test_sdhost_delete.py
+++ b/test/tests_native/test_sdhost_delete.py
@@ -1,0 +1,76 @@
+import asyncio
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+from native_support import setup_native_stubs
+
+
+sys.platform = "linux"
+setup_native_stubs()
+
+microur = types.ModuleType("microur")
+microur_decoder = types.ModuleType("microur.decoder")
+microur_util = types.ModuleType("microur.util")
+microur_decoder.FileURDecoder = type("FileURDecoder", (), {})
+microur_util.cbor = object()
+sys.modules["microur"] = microur
+sys.modules["microur.decoder"] = microur_decoder
+sys.modules["microur.util"] = microur_util
+
+from hosts.sd import SDHost
+
+
+class DummyGUI:
+    def __init__(self):
+        self.menus = []
+        self.prompts = []
+        self.alerts = []
+        self._menu_responses = ["__delete_file__", None]
+
+    async def menu(self, buttons, **kwargs):
+        self.menus.append((buttons, kwargs))
+        if kwargs.get("title") == "Delete SD card file":
+            return buttons[0][0]
+        return self._menu_responses.pop(0)
+
+    async def prompt(self, title, msg):
+        self.prompts.append((title, msg))
+        return True
+
+    async def alert(self, title, msg):
+        self.alerts.append((title, msg))
+
+
+class DummyManager:
+    def __init__(self):
+        self.gui = DummyGUI()
+
+
+class SDHostDeleteTest(unittest.TestCase):
+    def test_delete_file_from_select_menu(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            keep_path = os.path.join(tmp, "keep.psbt")
+            delete_path = os.path.join(tmp, "delete.psbt")
+            with open(keep_path, "wb") as f:
+                f.write(b"keep")
+            with open(delete_path, "wb") as f:
+                f.write(b"delete")
+
+            host = SDHost("/tmp", sdpath=tmp)
+            host.manager = DummyManager()
+
+            selected = asyncio.run(host.select_file([".psbt"]))
+
+            self.assertIsNone(selected)
+            self.assertTrue(os.path.exists(keep_path))
+            self.assertFalse(os.path.exists(delete_path))
+            self.assertEqual(host.manager.gui.prompts[0][0], "Delete file?")
+            self.assertEqual(host.manager.gui.alerts[0][0], "Deleted")
+            self.assertEqual(len(host.manager.gui.menus), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `Delete file...` action to the SD card file picker
- show a second file-selection screen for deletion and require explicit confirmation before removing the file
- sync the filesystem after deletion and return to the picker so users can continue opening files
- add native test coverage for the delete flow

Closes #359

## Tests
- `PYTHONPATH='test;src' python -m unittest discover -s test\tests_native`