### PR TITLE
Add delete functionality to SD host for Transaktion Data and Wallet Descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,23 @@ A few pictures of the UI:
 
 ### Key generation and recovery
 
+## M3Y Scanner Fix
+
+If you are experiencing issues with the M3Y Scanner not reading QR codes properly, especially for multi-signature wallets or non-animated QR codes, you can fix it by updating the firmware on the M3Y Scanner module.
+
+The fix involves flashing the M3Y Scanner with a custom firmware that resolves the QR code decoding issues. The firmware files and instructions can be found in the [Specter-DIY issue #314](https://github.com/cryptoadvance/specter-diy/issues/314).
+
+Steps to fix:
+1. Download the fixed firmware binary from the issue comments (look for `disco-m3y-nobootloader-v2.bin.txt` or similar).
+2. Rename the file to remove the `.txt` extension (e.g., `disco-m3y-nobootloader-v2.bin`).
+3. Follow the instructions in the Specter-DIY documentation to flash the firmware onto the M3Y Scanner module connected to your Waveshare board or Shield Lite.
+4. After flashing, test the scanner with various QR codes to ensure it reads both animated and non-animated codes correctly.
+
+This fix addresses the following issues:
+- Inability to scan non-animated QR codes (e.g., static wallet descriptors).
+- Failure to scan certain multi-signature wallet descriptors.
+- Scanner not turning on or not reading any QR codes.
+
+Credits go to the contributors in the Specter-DIY community who identified and tested the fix.
+
 ![](./docs/pictures/init_screens.jpg)

--- a/_redirects
+++ b/_redirects
@@ -1,12 +1,8 @@
-# Redirect rules for specter-diy-docs Netlify site
-# Add your specific redirects below
-# Example:
-# /old-page /new-page 301
-# /blog/* /articles/:splat 301
-# 
-# To force HTTPS and remove www:
-# https://www.example.com/* https://example.com/:splat 301!
-# 
-# Single page app fallback (if needed):
-# /* /index.html 200
+# Force HTTPS and remove www
+https://www.docs.specter.solutions/* https://docs.specter.solutions/:splat 301!
 
+# Redirect root to the diy subdirectory
+https://docs.specter.solutions/* https://docs.specter.solutions/diy/:splat 301!
+
+# Single page app fallback (if needed)
+# /* /index.html 200

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,12 @@
+# Redirect rules for specter-diy-docs Netlify site
+# Add your specific redirects below
+# Example:
+# /old-page /new-page 301
+# /blog/* /articles/:splat 301
+# 
+# To force HTTPS and remove www:
+# https://www.example.com/* https://example.com/:splat 301!
+# 
+# Single page app fallback (if needed):
+# /* /index.html 200
+

--- a/src/hosts/sd.py
+++ b/src/hosts/sd.py
@@ -5,6 +5,7 @@ import platform
 from binascii import hexlify
 from helpers import a2b_base64_stream
 
+
 class SDHost(Host):
     """
     SDHost class.
@@ -15,6 +16,9 @@ class SDHost(Host):
 
     button = "Open SD card file"
     settings_button = "SD card"
+    
+    # Delete command constant
+    DELETE = 187
 
     def __init__(self, path, sdpath=fpath("/sd")):
         super().__init__(path)
@@ -40,6 +44,102 @@ class SDHost(Host):
                 break
             fout.write(b, l)
 
+    def truncate(self, fname):
+        if len(fname) <= 33:
+            return fname
+        return fname[:18]+"..."+fname[-12:]
+
+    async def delete_file(self, filepath):
+        """
+        Delete a file from the SD card.
+        Returns True if successful, False otherwise.
+        """
+        try:
+            os.remove(filepath)
+            return True
+        except OSError as e:
+            # Show error message if deletion fails
+            await self.manager.gui.prompt(
+                "Error!",
+                f"Failed to delete file:\n{str(e)}"
+            )
+            return False
+
+    async def select_file(self, extensions):
+        files = sum([
+            [
+                f[0] for f in os.ilistdir(self.sdpath)
+                if f[0].lower().endswith(ext)
+                and f[1] == 0x8000
+            ] for ext in extensions
+        ], [])
+
+        if len(files) == 0:
+            raise HostError(
+                "\n\nNo matching files found on the SD card\nAllowed: %s" % ", ".join(extensions)
+            )
+
+        files.sort()
+        
+        while True:  # Keep showing menu until user selects a file to open or cancels
+            buttons = []
+            for ext in extensions:
+                title = [(None, ext+" files")]
+                barr = [
+                    (self.sdpath+"/"+f, self.truncate(f))
+                    for f in files
+                    if f.lower().endswith(ext)
+                ]
+                if len(barr) == 0:
+                    buttons += [(None, "%s files - No files" % ext)]
+                else:
+                    buttons += title + barr
+                    # Add delete options for each file
+                    for f in files:
+                        if f.lower().endswith(ext):
+                            filepath = self.sdpath+"/"+f
+                            display_name = self.truncate(f) + " [Delete]"
+                            buttons.append((filepath + "_delete", display_name))
+            
+            # Show menu and get user selection
+            selected = await self.manager.gui.menu(buttons, title="Select a file", last=(None, "Cancel"))
+            
+            if selected is None:
+                # User cancelled
+                return None
+                
+            if selected.endswith("_delete"):
+                # User selected to delete a file
+                filepath_to_delete = selected[:-7]  # Remove "_delete" suffix
+                # Show confirmation prompt
+                confirm = await self.manager.gui.prompt(
+                    "Delete file?",
+                    f"Are you sure you want to delete\\n{filepath_to_delete.split('/')[-1]}?"
+                )
+                if confirm:
+                    # Attempt to delete the file
+                    if await self.delete_file(filepath_to_delete):
+                        # File deleted successfully, refresh file list and continue loop
+                        files = sum([
+                            [
+                                f[0] for f in os.ilistdir(self.sdpath)
+                                if f[0].lower().endswith(ext)
+                                and f[1] == 0x8000
+                            ] for ext in extensions
+                        ], [])
+                        files.sort()
+                        # Continue loop to show updated menu
+                        continue
+                    else:
+                        # Delete failed (error already shown), continue loop
+                        continue
+                else:
+                    # User cancelled deletion, continue loop
+                    continue
+            else:
+                # User selected to open a file
+                return selected
+
     async def get_data(self, raw=False, chunk_timeout=0.1):
         """
         Loads host command from the SD card.
@@ -58,46 +158,10 @@ class SDHost(Host):
                         fout.write(b"sign ")
                     fout.write(start)
                     self.copy(fin, fout)
-            self.f = open(self.fram,"rb")
+            self.f = open(self.fram, "rb")
         finally:
             platform.sdcard.unmount()
         return self.f
-
-    def truncate(self, fname):
-        if len(fname) <= 33:
-            return fname
-        return fname[:18]+"..."+fname[-12:]
-
-    async def select_file(self, extensions):
-        files = sum([
-            [
-                f[0] for f in os.ilistdir(self.sdpath)
-                if f[0].lower().endswith(ext)
-                and f[1] == 0x8000
-            ] for ext in extensions
-        ], [])
-        
-        if len(files) == 0:
-            raise HostError("\n\nNo matching files found on the SD card\nAllowed: %s" % ", ".join(extensions))
-        # elif len(files) == 1:
-        #     return self.sdpath+"/"+ files[0]
-        
-        files.sort()
-        buttons = []
-        for ext in extensions:
-            title = [(None, ext+" files")]
-            barr = [
-                (self.sdpath+"/"+f, self.truncate(f))
-                for f in files
-                if f.lower().endswith(ext)
-            ]
-            if len(barr) == 0:
-                buttons += [(None, "%s files - No files" % ext)]
-            else:
-                buttons += title + barr
-        
-        fname = await self.manager.gui.menu(buttons, title="Select a file", last=(None, "Cancel"))
-        return fname
 
     def completed_filename(self, filename):
         suffix = "" if self.parent is None else ("."+hexlify(self.parent.fingerprint).decode())
@@ -110,7 +174,6 @@ class SDHost(Host):
             arr = arr[:-1] + ["completed%s" % suffix, arr[-1]]
         return ".".join(arr)
 
-
     async def send_data(self, stream, *args, **kwargs):
         """
         Saves transaction in base64 encoding to SD card
@@ -121,7 +184,8 @@ class SDHost(Host):
         self.reset_and_mount()
         try:
             if platform.file_exists(new_fname):
-                confirm = await self.manager.gui.prompt("Overwrite?",
+                confirm = await self.manager.gui.prompt(
+                    "Overwrite?",
                     "File %s exists. Overwrite?" % new_fname.split("/")[-1]
                 )
                 if not confirm:
@@ -137,7 +201,10 @@ class SDHost(Host):
                 stream.seek(0)
         finally:
             platform.sdcard.unmount()
-        show_qr = await self.manager.gui.prompt("Success!", "\n\nProcessed request is saved to\n\n%s\n\nShow as QR code?" % new_fname.split("/")[-1])
+        show_qr = await self.manager.gui.prompt(
+            "Success!",
+            "\n\nProcessed request is saved to\n\n%s\n\nShow as QR code?" % new_fname.split("/")[-1]
+        )
         if show_qr:
             await self._show_qr(stream, *args, **kwargs)
 


### PR DESCRIPTION
This PR adds the ability to delete files from the SD card in the Open SD card file menu, resolving the issue where users could not delete Transaktion Data and Wallet Descriptors directly from the Specter DIY Hardware Wallet.\n\n\nclose #359