### PR TITLE
Reject dead TRNG output with RNG regression tests

### DIFF
--- a/src/rng.py
+++ b/src/rng.py
@@ -8,22 +8,41 @@ entropy_pool = b"7" * 64
 try:
     from os import urandom as get_trng_bytes
 except:
-
     def get_trng_bytes(nbytes):
         with open("/dev/urandom", "rb") as f:
             return f.read(nbytes)
 
 
+class RNGError(Exception):
+    """Raised when the hardware TRNG output fails a basic sanity check."""
+
+
+def _looks_dead(data):
+    """Detect a stalled or failed TRNG.
+
+    rng_get() in the STM32 port returns 0 on timeout (ports/stm32/rng.c),
+    so a dead peripheral surfaces as all-zero output - or, more generally,
+    as a single repeated byte. This is not a proof of health: no cheap
+    check can distinguish a healthy TRNG from a subtly biased one. It only
+    catches the specific failure mode where the peripheral stops
+    responding, which is currently silent.
+
+    The check is skipped for very small requests, where a repeated byte can
+    occur legitimately and is not evidence of failure.
+    """
+    if len(data) < 4:
+        return False
+    return len(set(data)) <= 1
+
+
 # assuming that entropy_pool has some real entropy
 # we can generate bytes using it as well
-# probably not the best way at the moment,
-# but anything is better than nothing
-
-
 def get_random_bytes(nbytes):
     global entropy_pool
     d = get_trng_bytes(nbytes)
-    feed(d)  # why not?
+    if _looks_dead(d):
+        raise RNGError("TRNG returned no entropy")
+    feed(d)
     # if more than 64 - just do trng
     if nbytes > 64:
         return d
@@ -34,8 +53,6 @@ def get_random_bytes(nbytes):
 
 
 # we hash together entropy pool and data we got
-
-
 def feed(data):
     global entropy_pool
     h = hashlib.sha512(entropy_pool)

--- a/test/tests_native/__init__.py
+++ b/test/tests_native/__init__.py
@@ -1,1 +1,2 @@
 from .test_wallet_manager_parsing import *
+from .test_rng import *

--- a/test/tests_native/test_rng.py
+++ b/test/tests_native/test_rng.py
@@ -1,0 +1,56 @@
+import sys
+
+if sys.implementation.name != "micropython":
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+from unittest import TestCase
+
+import rng
+
+
+class RNGSanityCheckTest(TestCase):
+    def setUp(self):
+        self.original_get_trng_bytes = rng.get_trng_bytes
+        self.original_entropy_pool = rng.entropy_pool
+
+    def tearDown(self):
+        rng.get_trng_bytes = self.original_get_trng_bytes
+        rng.entropy_pool = self.original_entropy_pool
+
+    def test_looks_dead_ignores_short_repeated_buffers(self):
+        self.assertFalse(rng._looks_dead(b""))
+        self.assertFalse(rng._looks_dead(b"\x00"))
+        self.assertFalse(rng._looks_dead(b"\x00\x00\x00"))
+        self.assertFalse(rng._looks_dead(b"\xff\xff\xff"))
+
+    def test_looks_dead_rejects_repeated_buffers_from_four_bytes(self):
+        self.assertTrue(rng._looks_dead(b"\x00\x00\x00\x00"))
+        self.assertTrue(rng._looks_dead(b"\xff\xff\xff\xff"))
+        self.assertTrue(rng._looks_dead(b"\x11" * 32))
+
+    def test_looks_dead_allows_non_repeated_buffers(self):
+        self.assertFalse(rng._looks_dead(b"\x00\x00\x00\x01"))
+        self.assertFalse(rng._looks_dead(bytes(range(32))))
+
+    def test_get_random_bytes_raises_before_feeding_dead_output(self):
+        rng.entropy_pool = b"A" * 64
+        rng.get_trng_bytes = lambda nbytes: b"\x00" * nbytes
+
+        try:
+            rng.get_random_bytes(32)
+        except rng.RNGError:
+            pass
+        else:
+            self.fail("Expected RNGError for repeated TRNG output")
+
+        self.assertEqual(rng.entropy_pool, b"A" * 64)
+
+    def test_get_random_bytes_keeps_one_byte_requests_working(self):
+        rng.get_trng_bytes = lambda nbytes: b"\x00" * nbytes
+        self.assertEqual(len(rng.get_random_bytes(1)), 1)
+
+    def test_get_random_bytes_returns_requested_length_for_live_output(self):
+        rng.get_trng_bytes = lambda nbytes: bytes(range(nbytes))
+        self.assertEqual(len(rng.get_random_bytes(32)), 32)


### PR DESCRIPTION
This is an alternative to #372 that includes the same RNG sanity-check fix plus regression tests for the new behavior.

It keeps the application-side check proposed in #372:

- reject all-zero / single-repeated-byte TRNG output for buffers of length >= 4
- keep sub-4-byte requests working, especially the existing `get_random_bytes(1)` keypad-shuffle caller
- raise before feeding dead TRNG output into the entropy pool

Additional test coverage added here:

- `_looks_dead()` ignores short repeated buffers
- `_looks_dead()` rejects repeated buffers from 4 bytes upward
- `_looks_dead()` allows non-repeated buffers
- `get_random_bytes()` raises `RNGError` before changing `entropy_pool` on dead TRNG output
- `get_random_bytes(1)` still works with repeated one-byte output
- normal/non-repeated TRNG output returns the requested length

Verification run locally:

```text
python test/run_native_tests.py
# Ran 11 tests: OK

python -m compileall src test
# OK
```

Context: #370, #372.
