### PR TITLE
fix: don't let delete_mnemonic report success when deletion failed

### DIFF
--- a/src/keystore/flash.py
+++ b/src/keystore/flash.py
@@ -302,8 +302,10 @@ class FlashKeyStore(RAMKeyStore):
         except Exception as e:
             print(e)
             raise KeyStoreError("Failed to delete file '%s'" % file)
-        finally:
-            return True
+        # NOTE: no `return` in a `finally` block here - a return inside
+        # finally executes while an exception is propagating and silently
+        # discards it, so a failed delete would still report success.
+        return True
 
     async def get_input(
             self,

--- a/src/keystore/sdcard.py
+++ b/src/keystore/sdcard.py
@@ -162,7 +162,12 @@ class SDKeyStore(FlashKeyStore):
         finally:
             if platform.sdcard.is_present and file.startswith(self.sdpath):
                 platform.sdcard.unmount()
-            return True
+        # NOTE: this return must stay OUTSIDE the finally block - a return
+        # inside finally executes while an exception is propagating and
+        # silently discards it, so a failed delete would still report
+        # success. The unmount above belongs to the finally (it must run
+        # on every path); the success return does not.
+        return True
 
     async def storage_menu(self):
         """Manage storage, return True if new key was loaded"""

--- a/test/tests_native/__init__.py
+++ b/test/tests_native/__init__.py
@@ -1,1 +1,2 @@
 from .test_wallet_manager_parsing import *
+from .test_delete_mnemonic import *

--- a/test/tests_native/test_delete_mnemonic.py
+++ b/test/tests_native/test_delete_mnemonic.py
@@ -1,0 +1,109 @@
+"""
+Regression tests: delete_mnemonic() must not swallow deletion failures.
+
+Both FlashKeyStore.delete_mnemonic() and SDKeyStore.delete_mnemonic() had
+their `return True` inside the `finally` block of the delete path. A
+return inside finally executes while the KeyStoreError raised in the
+except block is propagating - and silently discards it. The UI therefore
+reported "Your key is deleted." even when the deletion had failed and
+the file was still sitting on the internal flash or the SD card.
+
+These tests fail against the old structure (the exception never reaches
+the caller) and pass with the fix (success return moved out of finally).
+"""
+import sys
+
+if sys.implementation.name != "micropython":
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+import os
+from unittest import TestCase
+
+import platform
+from keystore.core import KeyStoreError
+from keystore.flash import FlashKeyStore
+from keystore.sdcard import SDKeyStore
+from tests.util import clear_testdir
+
+
+def _run(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _DeleteMnemonicBase(TestCase):
+    keystore_cls = None
+
+    def _target_path(self):
+        raise NotImplementedError
+
+    def setUp(self):
+        clear_testdir()
+        platform.maybe_mkdir("testdir")
+        self.ks = self.keystore_cls()
+        self.target = self._target_path()
+        with open(self.target, "wb") as f:
+            f.write(b"encrypted-key-material")
+
+        async def fake_select_file():
+            return self.target
+
+        self.ks.select_file = fake_select_file
+
+    def tearDown(self):
+        if platform.file_exists(self.target):
+            os.remove(self.target)
+        clear_testdir()
+
+    def test_failed_delete_raises_instead_of_reporting_success(self):
+        real_remove = os.remove
+        calls = []
+
+        def failing_remove(path):
+            calls.append(path)
+            raise OSError("simulated I/O failure")
+
+        os.remove = failing_remove
+        try:
+            with self.assertRaises(KeyStoreError):
+                _run(self.ks.delete_mnemonic())
+        finally:
+            os.remove = real_remove
+        self.assertEqual(calls, [self.target])
+        # the file must provably still be there
+        self.assertTrue(platform.file_exists(self.target))
+
+    def test_successful_delete_returns_true_and_removes_file(self):
+        res = _run(self.ks.delete_mnemonic())
+        self.assertIs(res, True)
+        self.assertFalse(platform.file_exists(self.target))
+
+    def test_cancelled_selection_returns_false(self):
+        async def cancel_select_file():
+            return None
+
+        self.ks.select_file = cancel_select_file
+        res = _run(self.ks.delete_mnemonic())
+        self.assertIs(res, False)
+        self.assertTrue(platform.file_exists(self.target))
+
+
+class FlashDeleteMnemonicTest(_DeleteMnemonicBase):
+    keystore_cls = FlashKeyStore
+
+    def _target_path(self):
+        return "testdir/reckless.mykey"
+
+
+class SDCardDeleteMnemonicTest(_DeleteMnemonicBase):
+    keystore_cls = SDKeyStore
+
+    def _target_path(self):
+        return platform.fpath("/sd") + "/specterdiy00112233.mykey"


### PR DESCRIPTION
## Summary

Security hardening: both `FlashKeyStore.delete_mnemonic()` and `SDKeyStore.delete_mnemonic()` had their `return True` inside the `finally` block of the delete path. A `return` inside `finally` executes *while* the `KeyStoreError` raised in the `except` block is still propagating — and silently discards it.

**Consequence:** when a deletion failed (I/O error, card removed mid-operation, read-only filesystem, …), the error never reached the caller, and the UI showed *"Your key is deleted."* while the key file was still sitting on the internal flash or the SD card — the exact opposite of what a user needs to hear when they are trying to get rid of key material.

## Fix

Move the success `return True` out of the `finally` block in both classes:

- `FlashKeyStore.delete_mnemonic()` (internal flash): drop the `finally` entirely, return after the try/except.
- `SDKeyStore.delete_mnemonic()` (flash + SD): the SD unmount stays in `finally` (it must run on every path); only the success return moves out.

On failure the `KeyStoreError` now propagates and is shown as an error (caught by `Specter.handle_exception` → `gui.alert`); on success nothing changes.

## Tests

New `test/tests_native/test_delete_mnemonic.py`, for both keystores:

- **failure path**: patched `os.remove` raising → `KeyStoreError` reaches the caller, and the file is provably still present (fails against the old structure, where the exception was discarded and `True` returned)
- **success path**: returns `True`, file is gone
- **cancel path**: picker cancelled → returns `False`, file untouched

`python3 test/run_native_tests.py`: 11/11 pass.

## Notes

- Same pattern exists in the Schnuartz fork; submitted here per the disclosure note in that fork's PR.
- Reviewer notes: this is a minimal, behavior-preserving fix for the exception-swallowing `return` in `finally`. A pre-existing mount/unmount asymmetry on the `File not found.` path in `SDKeyStore.delete_mnemonic()` (mount happens before the `file_exists` check, but the raise bypasses the `finally` unmount) is out of scope and not changed here.