### PR TITLE
Require on-device confirmation for host XPUB requests

### DIFF
--- a/docs/communication.md
+++ b/docs/communication.md
@@ -61,11 +61,76 @@ We use human-readable plain text messages, because we can and they are way easie
 
 The following commands are supported:
 
-- `fingerprint` - returns hex fingerprint of the root key.
-- `xpub <derivation>` - returns xpub with derivation. For hardened derivation both `h` and `'` can be used. For example `xpub m/84h/1h/0h`.
+- `fingerprint` - returns hex fingerprint of the root key. Non-interactive: doesn't require on-device confirmation, so companion software can use it for passive device discovery/identification.
+- `xpub <derivation>` - returns xpub with derivation. For hardened derivation both `h` and `'` can be used. For example `xpub m/84h/1h/0h`. Unlike `fingerprint`, this **requires on-device confirmation** by default (see "XPUB privacy" below) - the device shows the requested path and the resulting xpub and waits for Confirm/Cancel. A cancelled request returns `error: User cancelled` without disclosing the xpub.
+- `xpubauth begin <scope>` / `xpubauth end` - scoped multi-XPUB authorization, letting a host request one bounded set of paths and then retrieve all of them via plain `xpub <derivation>` calls with a single confirmation. See "Scoped multi-XPUB authorization" below.
 - `sign <psbt>` - asks user to confirm transaction signing.
 - `showaddr <type> <derivation> [witness_script_hex]` - show address of `type` with `derivation`. `type` can be `wpkh`, `sh-wpkh`, `pkh`, `sh`, `sh-wsh` or `wsh`. Witness script is required for non-pkh wallets.
 - `importwallet <wallet_name>&<descriptor>` - asks user to confirm adding new `wallet` with `descriptor`.
+
+### XPUB privacy
+
+Any host connected over USB, or any process on the connected computer that can reach the Specter's serial port, can otherwise ask for wallet public keys and enumerate the wallet's addresses and balance without the user noticing. Because of that, a bare `xpub <derivation>` request always requires a physical Confirm/Cancel on the trusted display, showing exactly the derivation path and the resulting xpub that would be shared. This is deliberately different from hardware wallets that export a fixed set of "standard" xpubs silently - Specter's threat model assumes *any* program on the connected computer, not just the wallet software the user intends to use, may be sending these requests.
+
+Requesting many xpubs this way (e.g. wallet/account discovery, or [BIP-0138](https://github.com/bitcoin/bips/blob/master/bip-0138.mediawiki)-style recovery) would mean one confirmation per key, which is impractical. `xpubauth` (below) solves that without giving up the confirm-by-default privacy property.
+
+### Scoped multi-XPUB authorization
+
+`xpubauth begin <scope>` asks the user to approve, once, a bounded, explicitly enumerated set of derivation paths. After approval, `xpub <derivation>` requests that fall inside the approved scope are answered immediately, without another prompt; anything outside the scope keeps requiring the normal individual confirmation described above. `xpubauth end` discards the authorization explicitly. The host does not have to retrieve every path in the scope - stopping early (e.g. as soon as BIP-138 recovery succeeds) is fine.
+
+This is a logical, per-device-session permission, not tied to any particular transport connection - `xpub` requests over USB/simulator each open and close their own connection, so the authorization is tracked by the firmware itself, in RAM, independently of how many separate connections the host makes.
+
+#### Scope grammar
+
+```
+scope     := entry (";" entry)*
+entry     := "m" ("/" component)*
+component := index | range
+index     := digits ["h" | "H" | "'"]
+range     := "{" digits "-" digits "}" ["h" | "H" | "'"]
+```
+
+- Each entry is either an **exact path** (`m/84h/0h/0h`) or a path with **exactly one bounded range component** (`m/84h/0h/{0-9}h`, `m/48h/0h/{0-9}h/2h`). At most one range per entry.
+- A range's two numbers are inclusive, non-negative, non-hardened child indices; a trailing hardening marker (if present) applies to the whole range. There is no open range, no negative range and no wildcard (`*`) of any kind - every scope denotes a finite, precomputable set of paths, and the firmware rejects anything that isn't before displaying or allocating anything for it.
+- Multiple entries are separated by `;`, e.g. `m/84h/0h/{0-9}h;m/86h/0h/{0-9}h`.
+- Both `h`/`H` and `'` are accepted for hardened components and are equivalent - the device parses every path (both scope entries and later `xpub` requests) into normalized BIP32 integers and matches on that normalized form, never on raw text.
+- Duplicate or overlapping entries (e.g. `m/84h/0h/{0-9}h` together with `m/84h/0h/5h`) make the whole `begin` request invalid - overlap is rejected rather than silently merged, so the displayed and enforced count are always identical.
+- For recognizable standard purposes (`44h`, `48h`, `49h`, `84h`, `86h`, `87h`), the coin-type component must be a fixed value matching the network active on the device at the time of the request (see "Network binding" below); a scope mixing e.g. a mainnet and a testnet-style entry is rejected as a whole. Non-standard/custom paths carry no such implied network semantics and are left alone.
+- Hard limits (named constants in `apps/xpubs/scope.py`): at most 16 entries, at most 8 path components per entry, at most 200 values per range, at most 200 total xpubs per authorization, at most 1024 bytes for the whole `begin` argument. These comfortably cover the ~70-path BIP-138 discovery scope with headroom while keeping worst-case parsing, display and memory use trivial on the STM32F469.
+
+Example - the approximate BIP-138 mainnet discovery scope:
+
+```
+xpubauth begin m/44h/0h/{0-9}h;m/49h/0h/{0-9}h;m/84h/0h/{0-9}h;m/86h/0h/{0-9}h;m/87h/0h/{0-9}h;m/48h/0h/{0-9}h/1h;m/48h/0h/{0-9}h/2h
+```
+
+The device shows the network, the list of allowed path patterns and the maximum possible number of xpubs, then waits for Confirm/Cancel. `success` is returned on confirmation, `error: User cancelled` on cancellation (and no authorization is created either way in that case).
+
+#### Network binding
+
+An authorization is bound to the exact Specter network (`main`, `test`, `signet`, `regtest`, `liquidv1`, `liquidtestnet`, `elementsregtest`, ...) active when it was approved - not just to a BIP44 coin type, since testnet/signet/regtest all share coin type `1h`. Any network change immediately invalidates the authorization; a subsequent `xpub` request for a formerly-authorized path is treated as unauthorized and falls back to the normal individual confirmation. A single authorization can never cover more than one network.
+
+#### Budget and consumption
+
+Every unique xpub covered by an authorization can be retrieved silently **at most once**. A repeat request for an already-used path is treated like any other out-of-scope request and requires normal confirmation again. Once every path covered by the authorization has been used once, it is discarded automatically (no need to call `xpubauth end`). This keeps the exposure of a stale authorization (e.g. host software crashing mid-recovery while the device stays unlocked) tightly bounded: at most one silent export per authorized path, ever.
+
+#### When an authorization is cleared
+
+An authorization exists only in RAM and is never written to flash, SD card or any settings file - a reboot clears it by construction. It is also cleared, immediately, on:
+
+- `xpubauth end`;
+- the device being locked;
+- the active network changing;
+- a new key/seed being loaded, or the current one being replaced (including a passphrase change);
+- every path covered by it having been used once (self-exhaustion, see above);
+- the authorization request itself being cancelled, failing validation, or failing to display.
+
+Starting a new `xpubauth begin` while an authorization is already active never merges or widens the existing permission: the new scope is parsed, validated and shown for a fresh confirmation exactly like any other `begin` request, and only replaces the previous authorization once that confirmation succeeds. If the second request is cancelled or invalid, the original authorization is left untouched.
+
+#### Compatibility
+
+- Older companion software that has never heard of `xpubauth` keeps working unchanged: it just keeps sending individual `xpub <derivation>` requests, each with its own confirmation, exactly as before this feature existed.
+- Newer companion software talking to older firmware that doesn't recognize `xpubauth` gets an `error: ...` response for that command and should fall back to plain per-path `xpub` requests.
 
 ## SD card
 

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -97,6 +97,7 @@ range     := "{" digits "-" digits "}" ["h" | "H" | "'"]
 - Duplicate or overlapping entries (e.g. `m/84h/0h/{0-9}h` together with `m/84h/0h/5h`) make the whole `begin` request invalid - overlap is rejected rather than silently merged, so the displayed and enforced count are always identical.
 - For recognizable standard purposes (`44h`, `48h`, `49h`, `84h`, `86h`, `87h`), the coin-type component must be a fixed value matching the network active on the device at the time of the request (see "Network binding" below); a scope mixing e.g. a mainnet and a testnet-style entry is rejected as a whole. Non-standard/custom paths carry no such implied network semantics and are left alone.
 - Hard limits (named constants in `apps/xpubs/scope.py`): at most 16 entries, at most 8 path components per entry, at most 200 values per range, at most 200 total xpubs per authorization, at most 1024 bytes for the whole `begin` argument. These comfortably cover the ~70-path BIP-138 discovery scope with headroom while keeping worst-case parsing, display and memory use trivial on the STM32F469.
+- The raw `xpubauth` payload is capped (`MAX_SCOPE_COMMAND_LEN`) by the command handler as it is read from the host - before it is decoded to text or handed to the parser - so an over-long line is rejected without first being buffered as a Python string. The plain `xpub <derivation>` request is bounded the same way (`MAX_XPUB_PATH_LEN` in `apps/xpubs/xpubs.py`).
 
 Example - the approximate BIP-138 mainnet discovery scope:
 
@@ -104,7 +105,7 @@ Example - the approximate BIP-138 mainnet discovery scope:
 xpubauth begin m/44h/0h/{0-9}h;m/49h/0h/{0-9}h;m/84h/0h/{0-9}h;m/86h/0h/{0-9}h;m/87h/0h/{0-9}h;m/48h/0h/{0-9}h/1h;m/48h/0h/{0-9}h/2h
 ```
 
-The device shows the network, the list of allowed path patterns and the maximum possible number of xpubs, then waits for Confirm/Cancel. `success` is returned on confirmation, `error: User cancelled` on cancellation (and no authorization is created either way in that case).
+The device shows the network, the list of allowed path patterns and the maximum possible number of xpubs, then waits for Confirm/Cancel. `success` is returned on confirmation, `error: User cancelled` on cancellation. On cancellation no authorization is left active - not the requested one, and not any authorization that happened to be active before this `begin` (see "When an authorization is cleared").
 
 #### Network binding
 
@@ -123,9 +124,10 @@ An authorization exists only in RAM and is never written to flash, SD card or an
 - the active network changing;
 - a new key/seed being loaded, or the current one being replaced (including a passphrase change);
 - every path covered by it having been used once (self-exhaustion, see above);
-- the authorization request itself being cancelled, failing validation, or failing to display.
+- the authorization request itself being cancelled, failing validation, or failing to display;
+- a new `xpubauth begin` request arriving - the existing authorization is dropped immediately, before the new scope is parsed or displayed, regardless of whether the new request is ultimately approved.
 
-Starting a new `xpubauth begin` while an authorization is already active never merges or widens the existing permission: the new scope is parsed, validated and shown for a fresh confirmation exactly like any other `begin` request, and only replaces the previous authorization once that confirmation succeeds. If the second request is cancelled or invalid, the original authorization is left untouched.
+Starting a new `xpubauth begin` while an authorization is already active is **fail-closed**: the existing permission is revoked up front, before the new scope is even parsed. The new scope is then parsed, validated and shown for a fresh confirmation exactly like any other `begin` request, and installed only if that confirmation succeeds. If the new request is cancelled - or malformed - the device is left with **no** authorization at all, never the previous one. A cancelled replacement request therefore cannot silently leave an older, broader permission in force. `begin` never merges, widens or falls back to a prior scope.
 
 #### Compatibility
 

--- a/hwidevice.py
+++ b/hwidevice.py
@@ -77,8 +77,9 @@ class SpecterClient(HardwareWalletClient):
         :param bip32_path: The BIP 32 derivation path
         :return: The extended public key
         """
-        # this should be fast
-        xpub = self.query("xpub %s" % bip32_path, timeout=self.TIMEOUT)
+        # xpub now requires on-device user confirmation and may take
+        # arbitrarily long - wait indefinitely, same as sign_tx()
+        xpub = self.query("xpub %s" % bip32_path)
         hd = ExtendedKey.deserialize(xpub)
         # Specter returns xpub with a prefix
         # for a network currently selected on the device
@@ -202,6 +203,58 @@ class SpecterClient(HardwareWalletClient):
 
     def import_wallet(self, name: str, descriptor: str):
         self.query("addwallet {name} {descriptor}")
+
+    def authorize_xpubs(self, scope: Union[str, list]) -> bool:
+        """
+        Requests a scoped multi-XPUB authorization from the device: a
+        single trusted-display confirmation that approves a bounded,
+        explicitly enumerated set of derivation paths. After it is
+        approved, plain get_pubkey_at_path() calls for paths inside that
+        scope are answered without another on-device prompt; anything
+        outside the scope still prompts individually, exactly like a
+        plain get_pubkey_at_path() call always does.
+
+        :param scope: either a single scope string using the device's
+            grammar (entries separated by ";", each an exact path like
+            "m/84h/0h/0h" or a path with one bounded range component
+            like "m/84h/0h/{0-9}h"), or an iterable of such entries,
+            which will be joined with ";" for you.
+        :return: True if the user approved the authorization.
+
+        Raises ActionCanceledError if the user declined it, and
+        BadArgumentError if the scope was rejected (e.g. too large, or
+        mixing paths for more than one network). Older firmware that
+        predates this command will raise UnavailableActionError or
+        BadArgumentError - catch that and simply keep using
+        get_pubkey_at_path() for each path individually:
+
+            try:
+                client.authorize_xpubs(paths)
+                bulk = True
+            except Exception:
+                bulk = False
+            try:
+                for path in paths_to_query:
+                    xpub = client.get_pubkey_at_path(path)
+                    ...  # e.g. BIP-138 recovery, stopping early on success
+            finally:
+                if bulk:
+                    client.end_xpub_authorization()
+        """
+        if not isinstance(scope, str):
+            scope = ";".join(scope)
+        # no timeout - like get_pubkey_at_path(), this waits on a
+        # physical confirmation that can take arbitrarily long
+        res = self.query("xpubauth begin %s" % scope)
+        return res == "success"
+
+    def end_xpub_authorization(self) -> bool:
+        """
+        Explicitly discards any scoped multi-XPUB authorization created
+        by authorize_xpubs(). Safe to call even if none is active.
+        """
+        res = self.query("xpubauth end")
+        return res == "success"
 
 
 def enumerate(password=""):

--- a/src/app.py
+++ b/src/app.py
@@ -85,18 +85,3 @@ class BaseApp:
 
 class AppError(BaseError):
     NAME = "Application error"
-
-
-class NetworkSwitchRequested(Exception):
-    """
-    An app asks Specter to open the network picker - e.g. the xpub app
-    after refusing a request whose derivation is for a different network
-    than the device is on. Not a BaseError: it's a navigation signal, not
-    a host-facing error. `host_message` is still sent back to the host,
-    since the originating request does not succeed just because the user
-    went to change the network afterwards.
-    """
-
-    def __init__(self, host_message):
-        super().__init__(host_message)
-        self.host_message = host_message

--- a/src/app.py
+++ b/src/app.py
@@ -85,3 +85,18 @@ class BaseApp:
 
 class AppError(BaseError):
     NAME = "Application error"
+
+
+class NetworkSwitchRequested(Exception):
+    """
+    An app asks Specter to open the network picker - e.g. the xpub app
+    after refusing a request whose derivation is for a different network
+    than the device is on. Not a BaseError: it's a navigation signal, not
+    a host-facing error. `host_message` is still sent back to the host,
+    since the originating request does not succeed just because the user
+    went to change the network afterwards.
+    """
+
+    def __init__(self, host_message):
+        super().__init__(host_message)
+        self.host_message = host_message

--- a/src/app.py
+++ b/src/app.py
@@ -64,6 +64,15 @@ class BaseApp:
         """
         delete_recursively(self.path, include_self=True)
 
+    def on_lock(self):
+        """
+        Called when the device is locked.
+        Apps holding volatile, security-sensitive runtime state
+        (e.g. a temporary host permission) should discard it here,
+        since locking/unlocking must not let that state survive.
+        """
+        pass
+
     @property
     def tempdir(self):
         if self.TEMPDIR is None:

--- a/src/apps/xpubs/scope.py
+++ b/src/apps/xpubs/scope.py
@@ -196,6 +196,30 @@ def _overlaps(a, b):
     return True
 
 
+def standard_path_coin_type_mismatch(path, expected_coin_type):
+    """
+    True if `path` (an already-parsed list of ints, e.g. from
+    bip32.parse_path) is a standard-purpose path (44'/48'/49'/84'/86'/87')
+    whose coin-type component does not equal `expected_coin_type` - the
+    hardened BIP44 coin type of the network currently active on the
+    device. This is the same rule _validate_standard_coin_type applies to
+    an xpubauth scope entry, exposed here for a single concrete,
+    non-scoped path (a plain `xpub <path>` request).
+
+    False (nothing to enforce) for anything shorter than 2 components or
+    with a non-standard purpose - such paths carry no implied network
+    semantics.
+    """
+    if len(path) < 2:
+        return False
+    purpose = path[0]
+    if purpose < HARDENED:
+        return False
+    if purpose - HARDENED not in STANDARD_PURPOSES:
+        return False
+    return path[1] != (expected_coin_type + HARDENED)
+
+
 def _validate_standard_coin_type(entry, network_name, expected_coin_type):
     """For recognizable standard purposes (44'/48'/49'/84'/86'/87'), the
     coin-type component must be a fixed value matching the currently

--- a/src/apps/xpubs/scope.py
+++ b/src/apps/xpubs/scope.py
@@ -32,6 +32,14 @@ allocation or a slow/huge confirmation screen.
 from embit import bip32
 
 MAX_SCOPE_LEN = 1024  # raw "begin <scope>" argument, bytes
+# Hard cap on the whole "xpubauth ..." payload (the "begin <scope>" or
+# "end" text after the command prefix) as it is read from the host.
+# Enforced *before* the bytes are decoded to a str or parsed, so a
+# multi-megabyte line from a hostile host cannot be materialized as a
+# Python string first. "begin " is 6 bytes; the extra slack absorbs
+# surrounding whitespace / EOL without ever letting scope_str itself
+# exceed MAX_SCOPE_LEN (parse_scope still rejects anything longer).
+MAX_SCOPE_COMMAND_LEN = MAX_SCOPE_LEN + 32
 MAX_ENTRIES = 16  # scope entries per authorization
 MAX_PATH_DEPTH = 8  # bip32 components per entry
 MAX_RANGE_WIDTH = 200  # (hi - lo + 1) for a single range component

--- a/src/apps/xpubs/scope.py
+++ b/src/apps/xpubs/scope.py
@@ -1,0 +1,276 @@
+"""
+Scoped multi-XPUB authorization.
+
+Lets a host request permission, once, for a bounded, explicitly
+enumerated set of BIP32 derivation paths (a "scope"). After a single
+on-device confirmation, individual ``xpub <path>`` requests that fall
+inside the approved scope are answered without asking again, while
+anything outside the scope keeps requiring the normal per-request
+confirmation. See docs/communication.md for the full protocol writeup.
+
+Grammar
+-------
+::
+
+    scope     := entry (";" entry)*
+    entry     := "m" ("/" component)*
+    component := index | range
+    index     := digits ["h" | "H" | "'"]
+    range     := "{" digits "-" digits "}" ["h" | "H" | "'"]
+
+At most one ``range`` component is allowed per entry. Both digits in a
+range are inclusive bounds on the (non-hardened) child index; a
+trailing hardening marker, if present, applies to the whole range.
+There is no wildcard, no open range and no recursive matching - every
+scope denotes a finite, precomputable set of paths.
+
+All limits below are enforced *before* any expansion or allocation
+proportional to their value, so a hostile scope can't force a large
+allocation or a slow/huge confirmation screen.
+"""
+
+from embit import bip32
+
+MAX_SCOPE_LEN = 1024  # raw "begin <scope>" argument, bytes
+MAX_ENTRIES = 16  # scope entries per authorization
+MAX_PATH_DEPTH = 8  # bip32 components per entry
+MAX_RANGE_WIDTH = 200  # (hi - lo + 1) for a single range component
+MAX_TOTAL_XPUBS = 200  # sum of counts across all entries - the request budget
+
+HARDENED = bip32.HARDENED_INDEX
+
+# purposes with a well-known coin-type slot at m/purpose'/coin_type'/...
+STANDARD_PURPOSES = (44, 48, 49, 84, 86, 87)
+
+
+class ScopeError(Exception):
+    """Malformed, oversized, ambiguous or network-mismatched scope request."""
+
+
+class ScopeEntry:
+    """One normalized scope entry: an exact path, or a path with exactly
+    one bounded range component. Also tracks, per possible value, whether
+    it has already been silently exported once (Model A budget: every
+    unique authorized path may be exported silently at most once)."""
+
+    __slots__ = ("components", "range_index", "count", "consumed")
+
+    def __init__(self, components, range_index, count):
+        self.components = components  # tuple of: int, or ("range", lo, hi)
+        self.range_index = range_index
+        self.count = count
+        self.consumed = bytearray((count + 7) // 8)
+
+    def format(self):
+        """Canonical display string, rendered from the parsed/normalized
+        representation - never from the original request text - so what
+        is shown on screen is always exactly what gets enforced."""
+        parts = []
+        for comp in self.components:
+            if isinstance(comp, tuple):
+                _, lo, hi = comp
+                hardened = lo >= HARDENED
+                lo_raw = lo - HARDENED if hardened else lo
+                hi_raw = hi - HARDENED if hardened else hi
+                parts.append("{%d-%d}%s" % (lo_raw, hi_raw, "h" if hardened else ""))
+            else:
+                hardened = comp >= HARDENED
+                raw = comp - HARDENED if hardened else comp
+                parts.append("%d%s" % (raw, "h" if hardened else ""))
+        return "m/" + "/".join(parts)
+
+    def match(self, components):
+        """Returns the consumption-bitset index if the normalized bip32
+        path `components` falls inside this entry, else None. Matching is
+        purely on parsed integer components, never on raw text."""
+        if len(components) != len(self.components):
+            return None
+        for i, comp in enumerate(self.components):
+            v = components[i]
+            if isinstance(comp, tuple):
+                _, lo, hi = comp
+                if v < lo or v > hi:
+                    return None
+            elif comp != v:
+                return None
+        if self.range_index is None:
+            return 0
+        _, lo, _ = self.components[self.range_index]
+        return components[self.range_index] - lo
+
+    def is_consumed(self, idx):
+        return (self.consumed[idx // 8] >> (idx % 8)) & 1 == 1
+
+    def consume(self, idx):
+        self.consumed[idx // 8] |= 1 << (idx % 8)
+
+
+def _parse_uint(s):
+    if not s or len(s) > 10 or not s.isdigit():
+        raise ScopeError("Invalid number: %r" % s)
+    return int(s)
+
+
+def _parse_component(text):
+    if not text:
+        raise ScopeError("Empty path component")
+    if text[0] == "{":
+        hardened = text[-1] in ("h", "H", "'")
+        body = text[:-1] if hardened else text
+        if body[:1] != "{" or body[-1:] != "}":
+            raise ScopeError("Malformed range component: %r" % text)
+        bounds = body[1:-1].split("-")
+        if len(bounds) != 2:
+            raise ScopeError("Malformed range component: %r" % text)
+        lo_raw = _parse_uint(bounds[0])
+        hi_raw = _parse_uint(bounds[1])
+        if lo_raw > hi_raw:
+            raise ScopeError("Invalid range (start > end): %r" % text)
+        if hi_raw >= HARDENED:
+            raise ScopeError("Range value out of bounds: %r" % text)
+        if hi_raw - lo_raw + 1 > MAX_RANGE_WIDTH:
+            raise ScopeError("Range too wide (max %d): %r" % (MAX_RANGE_WIDTH, text))
+        offset = HARDENED if hardened else 0
+        return ("range", lo_raw + offset, hi_raw + offset)
+    hardened = text[-1] in ("h", "H", "'")
+    raw_text = text[:-1] if hardened else text
+    val = _parse_uint(raw_text)
+    if val >= HARDENED:
+        raise ScopeError("Path value out of bounds: %r" % text)
+    return val + (HARDENED if hardened else 0)
+
+
+def _parse_entry(text):
+    text = text.strip()
+    if not text.startswith("m"):
+        raise ScopeError("Scope entry must start with 'm': %r" % text)
+    rest = text[1:]
+    if rest.startswith("/"):
+        rest = rest[1:]
+    elif rest != "":
+        raise ScopeError("Malformed scope entry: %r" % text)
+    rest = rest.rstrip("/")
+    if not rest:
+        raise ScopeError("Scope entry has no derivation components: %r" % text)
+    parts = rest.split("/")
+    if len(parts) > MAX_PATH_DEPTH:
+        raise ScopeError("Path too deep (max %d): %r" % (MAX_PATH_DEPTH, text))
+    components = []
+    range_index = None
+    for i, part in enumerate(parts):
+        comp = _parse_component(part)
+        if isinstance(comp, tuple):
+            if range_index is not None:
+                raise ScopeError("Only one range allowed per scope entry: %r" % text)
+            range_index = i
+        components.append(comp)
+    if range_index is None:
+        count = 1
+    else:
+        _, lo, hi = components[range_index]
+        lo_raw = lo - HARDENED if lo >= HARDENED else lo
+        hi_raw = hi - HARDENED if hi >= HARDENED else hi
+        count = hi_raw - lo_raw + 1
+    return ScopeEntry(tuple(components), range_index, count)
+
+
+def _overlaps(a, b):
+    """Two entries overlap iff their (per-component independent) value
+    sets intersect at every component - since each entry varies at most
+    one component, that per-component check is exact, not approximate."""
+    if len(a.components) != len(b.components):
+        return False
+    for ca, cb in zip(a.components, b.components):
+        lo_a, hi_a = (ca[1], ca[2]) if isinstance(ca, tuple) else (ca, ca)
+        lo_b, hi_b = (cb[1], cb[2]) if isinstance(cb, tuple) else (cb, cb)
+        if hi_a < lo_b or hi_b < lo_a:
+            return False
+    return True
+
+
+def _validate_standard_coin_type(entry, network_name, expected_coin_type):
+    """For recognizable standard purposes (44'/48'/49'/84'/86'/87'), the
+    coin-type component must be a fixed value matching the currently
+    active Specter network. Non-standard/custom paths are left alone -
+    they carry no implied network semantics to enforce."""
+    comps = entry.components
+    if len(comps) < 2:
+        return
+    purpose = comps[0]
+    if isinstance(purpose, tuple) or purpose < HARDENED:
+        return
+    if purpose - HARDENED not in STANDARD_PURPOSES:
+        return
+    coin = comps[1]
+    expected = expected_coin_type + HARDENED
+    if isinstance(coin, tuple) or coin != expected:
+        raise ScopeError(
+            "Scope entry does not match the active network (%s): %s"
+            % (network_name, entry.format())
+        )
+
+
+def parse_scope(scope_str, network_name, expected_coin_type):
+    """
+    Parses, validates, normalizes and network-checks `scope_str`.
+    Returns (entries, total_count). Raises ScopeError on any problem;
+    never returns a partially valid scope.
+    """
+    if len(scope_str) > MAX_SCOPE_LEN:
+        raise ScopeError("Scope request too large")
+    raw_entries = [e.strip() for e in scope_str.split(";")]
+    raw_entries = [e for e in raw_entries if e]
+    if not raw_entries:
+        raise ScopeError("Empty scope")
+    if len(raw_entries) > MAX_ENTRIES:
+        raise ScopeError("Too many scope entries (max %d)" % MAX_ENTRIES)
+
+    entries = []
+    total = 0
+    for raw in raw_entries:
+        entry = _parse_entry(raw)
+        total += entry.count
+        if total > MAX_TOTAL_XPUBS:
+            raise ScopeError("Scope too large (max %d keys)" % MAX_TOTAL_XPUBS)
+        entries.append(entry)
+
+    for i in range(len(entries)):
+        for j in range(i + 1, len(entries)):
+            if _overlaps(entries[i], entries[j]):
+                raise ScopeError(
+                    "Overlapping or duplicate scope entries are not allowed"
+                )
+
+    for entry in entries:
+        _validate_standard_coin_type(entry, network_name, expected_coin_type)
+
+    return entries, total
+
+
+class Authorization:
+    """A confirmed, volatile, network-bound scope permission.
+    Exists only in RAM; never persisted to flash/SD/settings."""
+
+    __slots__ = ("entries", "network", "remaining")
+
+    def __init__(self, entries, network):
+        self.entries = entries
+        self.network = network
+        self.remaining = sum(e.count for e in entries)
+
+    def try_consume(self, network, components):
+        """If `components` (a parsed bip32 path) is silently authorized
+        right now, marks it consumed and returns True. Never widens or
+        modifies the scope itself - only tracks per-path consumption."""
+        if network != self.network:
+            return False
+        for entry in self.entries:
+            idx = entry.match(components)
+            if idx is None:
+                continue
+            if entry.is_consumed(idx):
+                return False
+            entry.consume(idx)
+            self.remaining -= 1
+            return True
+        return False

--- a/src/apps/xpubs/scope.py
+++ b/src/apps/xpubs/scope.py
@@ -220,6 +220,32 @@ def standard_path_coin_type_mismatch(path, expected_coin_type):
     return path[1] != (expected_coin_type + HARDENED)
 
 
+# Short, screen-friendly hint naming the network(s) a given BIP44 coin
+# type belongs to, so a rejected request can tell the user which network
+# to switch the device to. Coin type 1' is deliberately shared by several
+# test networks, so it can only ever name the candidates.
+_COIN_TYPE_NETWORK_HINTS = {
+    0: "Mainnet",
+    1: "Testnet, Signet or Regtest",
+    1776: "Liquid",
+}
+
+
+def network_hint_for_path(path):
+    """
+    A short human string naming the network(s) `path` (already-parsed) is
+    for, by its BIP44 coin type - e.g. "Mainnet", "Liquid", or
+    "Testnet, Signet or Regtest". Returns None when there's no useful hint
+    (path too short, non-hardened or unrecognized coin type).
+    """
+    if len(path) < 2:
+        return None
+    coin = path[1]
+    if coin < HARDENED:
+        return None
+    return _COIN_TYPE_NETWORK_HINTS.get(coin - HARDENED)
+
+
 def _validate_standard_coin_type(entry, network_name, expected_coin_type):
     """For recognizable standard purposes (44'/48'/49'/84'/86'/87'), the
     coin-type component must be a fixed value matching the currently

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -328,22 +328,26 @@ class XpubApp(BaseApp):
             if xpubauth_scope.standard_path_coin_type_mismatch(
                 path, NETWORKS[self.network]["bip32"]
             ):
+                device_net = self.network
                 hint = xpubauth_scope.network_hint_for_path(path)
                 switch_to = hint if hint else "the matching network"
-                await show_screen(
-                    Alert(
+                open_settings = await show_screen(
+                    Prompt(
                         "Host tried to get access\nto the following key",
                         "Derivation:\n%s\n\n"
                         "This device is currently on %s.\n"
                         "This key cannot be shared from here.\n\n"
                         "To share it, switch the device to\n%s first." % (
-                            derivation, NETWORKS[self.network]["name"], switch_to,
+                            derivation, NETWORKS[device_net]["name"], switch_to,
                         ),
-                        button_text="OK",
+                        confirm_text="Network settings",
+                        cancel_text="OK",
                     )
                 )
+                if open_settings:
+                    await self.communicate(BytesIO(b"select_network"), app="")
                 raise AppError(
-                    "network mismatch: device is on %s" % self.network
+                    "network mismatch: device is on %s" % device_net
                 )
             fingerprint = hexlify(self.keystore.fingerprint).decode()
             confirm = await show_screen(

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -328,15 +328,16 @@ class XpubApp(BaseApp):
             if xpubauth_scope.standard_path_coin_type_mismatch(
                 path, NETWORKS[self.network]["bip32"]
             ):
+                hint = xpubauth_scope.network_hint_for_path(path)
+                switch_to = hint if hint else "the matching network"
                 await show_screen(
                     Alert(
                         "Host tried to get access\nto the following key",
                         "Derivation:\n%s\n\n"
                         "This device is currently on %s.\n"
                         "This key cannot be shared from here.\n\n"
-                        "To share it, switch the device to the "
-                        "matching network first." % (
-                            derivation, NETWORKS[self.network]["name"],
+                        "To share it, switch the device to\n%s first." % (
+                            derivation, NETWORKS[self.network]["name"], switch_to,
                         ),
                         button_text="OK",
                     )

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -316,6 +316,34 @@ class XpubApp(BaseApp):
                 if self._authorization.remaining <= 0:
                     self._authorization = None
                 return BytesIO(xpub_str.encode()), {}
+            # A standard-purpose path (44'/48'/49'/84'/86'/87') whose coin
+            # type doesn't match the network currently active on this
+            # device can never be legitimately shared from here - the same
+            # rule an xpubauth scope is held to (see scope.py), now also
+            # enforced for individual, non-scoped requests. Tell the local
+            # user exactly what was asked for and why it's refused, and
+            # send the host a machine-parseable reason (which network this
+            # device is actually on) instead of silently deriving a key
+            # for a network it isn't set to.
+            if xpubauth_scope.standard_path_coin_type_mismatch(
+                path, NETWORKS[self.network]["bip32"]
+            ):
+                await show_screen(
+                    Alert(
+                        "Host tried to get access\nto the following key",
+                        "Derivation:\n%s\n\n"
+                        "This device is currently on %s.\n"
+                        "This key cannot be shared from here.\n\n"
+                        "To share it, switch the device to the "
+                        "matching network first." % (
+                            derivation, NETWORKS[self.network]["name"],
+                        ),
+                        button_text="OK",
+                    )
+                )
+                raise AppError(
+                    "network mismatch: device is on %s" % self.network
+                )
             fingerprint = hexlify(self.keystore.fingerprint).decode()
             confirm = await show_screen(
                 Prompt(

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -1,4 +1,4 @@
-from app import BaseApp, AppError, NetworkSwitchRequested
+from app import BaseApp, AppError
 from gui.screens import Menu, DerivationScreen, NumericScreen, Alert, InputScreen, Prompt
 from .screens import XPubScreen
 from . import scope as xpubauth_scope
@@ -331,8 +331,21 @@ class XpubApp(BaseApp):
                 device_net = self.network
                 hint = xpubauth_scope.network_hint_for_path(path)
                 switch_to = hint if hint else "the matching network"
-                open_settings = await show_screen(
-                    Prompt(
+                # UX note: from a pure usability standpoint this screen
+                # would ideally carry a second "Network settings" button
+                # that takes the user straight to the network picker, so
+                # they don't have to hunt for it in the menu after being
+                # told to switch. It's deliberately left out for now:
+                # host commands run in their own asyncio task, separate
+                # from the main() menu loop, and this firmware has no
+                # primitive for one to drive the other's navigation. The
+                # only way to show the picker from here is to stack it as
+                # a popup over whatever menu happens to be active, which
+                # works but is a fair bit of plumbing for one button.
+                # Worth revisiting if/when cross-task navigation exists -
+                # the UX win is real.
+                await show_screen(
+                    Alert(
                         "Host tried to get access\nto the following key",
                         "Derivation:\n%s\n\n"
                         "This device is currently on %s.\n"
@@ -340,14 +353,10 @@ class XpubApp(BaseApp):
                         "To share it, switch the device to\n%s first." % (
                             derivation, NETWORKS[device_net]["name"], switch_to,
                         ),
-                        confirm_text="Network settings",
-                        cancel_text="OK",
+                        button_text="OK",
                     )
                 )
-                host_message = "network mismatch: device is on %s" % device_net
-                if open_settings:
-                    raise NetworkSwitchRequested(host_message)
-                raise AppError(host_message)
+                raise AppError("network mismatch: device is on %s" % device_net)
             fingerprint = hexlify(self.keystore.fingerprint).decode()
             confirm = await show_screen(
                 Prompt(

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -1,6 +1,7 @@
 from app import BaseApp, AppError
 from gui.screens import Menu, DerivationScreen, NumericScreen, Alert, InputScreen, Prompt
 from .screens import XPubScreen
+from . import scope as xpubauth_scope
 import json
 from binascii import hexlify
 from embit.liquid.networks import NETWORKS
@@ -21,12 +22,23 @@ class XpubApp(BaseApp):
     export_generic_json = "json"
     export_specter_diy = "specter-diy"
     button = "Master public keys"
-    prefixes = [b"fingerprint", b"xpub"]
+    prefixes = [b"fingerprint", b"xpub", b"xpubauth"]
     name = "xpub"
 
     def __init__(self, path):
         self.account = 0
-        pass
+        # volatile scoped multi-xpub authorization (RAM only, never
+        # persisted); see scope.py for the grammar and matching rules
+        self._authorization = None
+
+    def init(self, keystore, network, show_loader, communicate):
+        super().init(keystore, network, show_loader, communicate)
+        # a new key or network invalidates any prior authorization -
+        # it belongs to a specific keystore on a specific network
+        self._authorization = None
+
+    def on_lock(self):
+        self._authorization = None
 
     async def menu(self, show_screen, show_all=False):
         net = NETWORKS[self.network]
@@ -260,6 +272,8 @@ class XpubApp(BaseApp):
         # reads prefix from the stream (until first space)
         prefix = self.get_prefix(stream)
         # get device fingerprint, data is ignored
+        # non-interactive: used for device discovery/identification by
+        # companion software, must not require on-device confirmation
         if prefix == b"fingerprint":
             return BytesIO(hexlify(self.keystore.fingerprint)), {}
         # get xpub,
@@ -271,11 +285,81 @@ class XpubApp(BaseApp):
                 path = bip32.parse_path(path.decode())
             except:
                 raise AppError('Invalid path: "%s"' % path.decode())
-            # get xpub
-            xpub = self.keystore.get_xpub(bip32.path_to_str(path))
+            # normalize to the canonical string representation
+            derivation = bip32.path_to_str(path)
+            # derive the xpub so we can show the user exactly what would be shared
+            xpub = self.keystore.get_xpub(derivation)
+            xpub_str = xpub.to_base58(NETWORKS[self.network]["xpub"])
+            # a previously approved scope covers this exact normalized
+            # path and hasn't already been used - no extra prompt needed
+            if self._authorization is not None and self._authorization.try_consume(
+                self.network, path
+            ):
+                if self._authorization.remaining <= 0:
+                    self._authorization = None
+                return BytesIO(xpub_str.encode()), {}
+            fingerprint = hexlify(self.keystore.fingerprint).decode()
+            confirm = await show_screen(
+                Prompt(
+                    "Share Xpub?",
+                    "A connected host wants the\nextended public key for:\n\n%s\n\n%s" % (
+                        derivation, xpub_str,
+                    ),
+                    note="Device fingerprint %s" % fingerprint,
+                )
+            )
+            if not confirm:
+                return False
             # send back as base58
-            return BytesIO(xpub.to_base58(NETWORKS[self.network]["xpub"]).encode()), {}
+            return BytesIO(xpub_str.encode()), {}
+        # xpubauth begin <scope> / xpubauth end -
+        # one confirmation for a bounded, explicit set of paths, see scope.py
+        elif prefix == b"xpubauth":
+            data = stream.read().strip().decode()
+            if data == "end":
+                self._authorization = None
+                return True
+            if data == "begin" or data.startswith("begin "):
+                scope_str = data[len("begin"):].strip()
+                return await self.xpubauth_begin(scope_str, show_screen)
+            raise AppError("Unknown xpubauth subcommand")
         raise AppError("Unknown command")
+
+    async def xpubauth_begin(self, scope_str, show_screen):
+        try:
+            entries, total = xpubauth_scope.parse_scope(
+                scope_str, self.network, NETWORKS[self.network]["bip32"]
+            )
+        except xpubauth_scope.ScopeError as e:
+            raise AppError(str(e))
+        net_name = NETWORKS[self.network]["name"]
+        allowed = "\n".join(entry.format() for entry in entries)
+        fingerprint = hexlify(self.keystore.fingerprint).decode()
+        message = (
+            "Connected software requests temporary\n"
+            "access to multiple public account keys.\n\n"
+            "Network: %s\n\n"
+            "Allowed:\n%s\n\n"
+            "Up to %d extended public keys.\n\n"
+            "Private keys are not shared." % (net_name, allowed, total)
+        )
+        confirm = await show_screen(
+            Prompt(
+                "Share multiple XPUBs?",
+                message,
+                confirm_text="Allow",
+                cancel_text="Cancel",
+                note="Device fingerprint %s" % fingerprint,
+            )
+        )
+        if not confirm:
+            # fail closed: nothing is approved, any prior authorization
+            # (if this was a replacement request) is left untouched
+            return False
+        # commit only now that the user has approved this exact scope -
+        # this also replaces (never merges with) any prior authorization
+        self._authorization = xpubauth_scope.Authorization(entries, self.network)
+        return True
 
     async def show_xpub(self, derivation, show_screen):
         self.show_loader(title="Deriving the key...")

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -346,11 +346,11 @@ class XpubApp(BaseApp):
                 # the UX win is real.
                 await show_screen(
                     Alert(
-                        "Host tried to get access\nto the following key",
+                        "Host tried to get access\nto the following Xpub",
                         "Derivation:\n%s\n\n"
                         "This device is currently on %s.\n"
-                        "This key cannot be shared from here.\n\n"
-                        "To share it, switch the device to\n%s first." % (
+                        "This Xpub cannot be shared from here.\n\n"
+                        "To share it, switch the device\nto %s in the settings first." % (
                             derivation, NETWORKS[device_net]["name"], switch_to,
                         ),
                         button_text="OK",

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -290,13 +290,19 @@ class XpubApp(BaseApp):
             raw = stream.read(MAX_XPUB_PATH_LEN + 1)
             if len(raw) > MAX_XPUB_PATH_LEN:
                 raise AppError("Path request too large")
-            path = raw
+            path_str = None
             try:
-                path = raw.strip()
+                path_str = raw.strip().decode()
                 # convert to list of indexes
-                path = bip32.parse_path(path.decode())
-            except:
-                raise AppError('Invalid path: "%s"' % path.decode())
+                path = bip32.parse_path(path_str)
+            except (ValueError, IndexError):
+                # narrow, not bare: decode() raises UnicodeError (a
+                # ValueError subclass) on non-UTF-8 input, and
+                # bip32.parse_path raises ValueError / IndexError on a
+                # malformed or empty path component. Anything else is a
+                # real bug and should propagate, not be masked as
+                # "Invalid path".
+                raise AppError('Invalid path: "%s"' % (path_str or raw))
             # normalize to the canonical string representation
             derivation = bip32.path_to_str(path)
             # derive the xpub so we can show the user exactly what would be shared

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -11,6 +11,11 @@ from io import BytesIO
 import platform
 from collections import OrderedDict
 
+# A single derivation-path request ("xpub <path>") is tiny. Cap the host
+# input well above any realistic path but far below anything that could
+# exhaust RAM on the STM32F469, and enforce it before .decode()/parsing.
+MAX_XPUB_PATH_LEN = 1024
+
 class XpubApp(BaseApp):
     """
     WalletManager class manages your wallets.
@@ -279,8 +284,15 @@ class XpubApp(BaseApp):
         # get xpub,
         # data: derivation path in human-readable form like m/44h/1h/0
         elif prefix == b"xpub":
+            # bound the host input before decoding - a derivation path is
+            # tiny, anything larger is malformed or a memory-exhaustion
+            # attempt and must be rejected before it becomes a str
+            raw = stream.read(MAX_XPUB_PATH_LEN + 1)
+            if len(raw) > MAX_XPUB_PATH_LEN:
+                raise AppError("Path request too large")
+            path = raw
             try:
-                path = stream.read().strip()
+                path = raw.strip()
                 # convert to list of indexes
                 path = bip32.parse_path(path.decode())
             except:
@@ -315,7 +327,13 @@ class XpubApp(BaseApp):
         # xpubauth begin <scope> / xpubauth end -
         # one confirmation for a bounded, explicit set of paths, see scope.py
         elif prefix == b"xpubauth":
-            data = stream.read().strip().decode()
+            # bound the request as it is read, before .decode()/parsing,
+            # so a hostile host cannot force a huge string allocation
+            # ahead of the MAX_SCOPE_LEN check inside parse_scope
+            raw = stream.read(xpubauth_scope.MAX_SCOPE_COMMAND_LEN + 1)
+            if len(raw) > xpubauth_scope.MAX_SCOPE_COMMAND_LEN:
+                raise AppError("xpubauth request too large")
+            data = raw.strip().decode()
             if data == "end":
                 self._authorization = None
                 return True
@@ -326,6 +344,13 @@ class XpubApp(BaseApp):
         raise AppError("Unknown command")
 
     async def xpubauth_begin(self, scope_str, show_screen):
+        # Fail closed: a fresh "begin" revokes any prior authorization
+        # up front, before the new scope is even parsed or displayed.
+        # Whatever happens next - parse error, cancel, or a successful
+        # confirm - the old scope is already gone, so a user who cancels
+        # a suspicious new request is never silently left with a stale
+        # (possibly broader) permission still active.
+        self._authorization = None
         try:
             entries, total = xpubauth_scope.parse_scope(
                 scope_str, self.network, NETWORKS[self.network]["bip32"]
@@ -353,11 +378,12 @@ class XpubApp(BaseApp):
             )
         )
         if not confirm:
-            # fail closed: nothing is approved, any prior authorization
-            # (if this was a replacement request) is left untouched
+            # any prior authorization was already dropped at the top of
+            # this method; nothing new is approved, so the device is now
+            # left with no authorization at all
             return False
-        # commit only now that the user has approved this exact scope -
-        # this also replaces (never merges with) any prior authorization
+        # commit the freshly approved scope (any prior authorization was
+        # already cleared above - begin never merges or falls back)
         self._authorization = xpubauth_scope.Authorization(entries, self.network)
         return True
 

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -1,4 +1,4 @@
-from app import BaseApp, AppError
+from app import BaseApp, AppError, NetworkSwitchRequested
 from gui.screens import Menu, DerivationScreen, NumericScreen, Alert, InputScreen, Prompt
 from .screens import XPubScreen
 from . import scope as xpubauth_scope
@@ -344,11 +344,10 @@ class XpubApp(BaseApp):
                         cancel_text="OK",
                     )
                 )
+                host_message = "network mismatch: device is on %s" % device_net
                 if open_settings:
-                    await self.communicate(BytesIO(b"select_network"), app="")
-                raise AppError(
-                    "network mismatch: device is on %s" % device_net
-                )
+                    raise NetworkSwitchRequested(host_message)
+                raise AppError(host_message)
             fingerprint = hexlify(self.keystore.fingerprint).decode()
             confirm = await show_screen(
                 Prompt(

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -303,19 +303,21 @@ class XpubApp(BaseApp):
                 # real bug and should propagate, not be masked as
                 # "Invalid path".
                 raise AppError('Invalid path: "%s"' % (path_str or raw))
+            # a real derivation path is a handful of levels deep; anything
+            # past the limit the scoped parser already enforces
+            # (scope.MAX_PATH_DEPTH) is malformed or a derivation-DoS
+            # attempt - reject it before doing any BIP32 work
+            if len(path) > xpubauth_scope.MAX_PATH_DEPTH:
+                raise AppError(
+                    "Path too deep (max %d)" % xpubauth_scope.MAX_PATH_DEPTH
+                )
             # normalize to the canonical string representation
             derivation = bip32.path_to_str(path)
-            # derive the xpub so we can show the user exactly what would be shared
-            xpub = self.keystore.get_xpub(derivation)
-            xpub_str = xpub.to_base58(NETWORKS[self.network]["xpub"])
-            # a previously approved scope covers this exact normalized
-            # path and hasn't already been used - no extra prompt needed
-            if self._authorization is not None and self._authorization.try_consume(
-                self.network, path
-            ):
-                if self._authorization.remaining <= 0:
-                    self._authorization = None
-                return BytesIO(xpub_str.encode()), {}
+            # Validate the request fully - network, then authorization -
+            # *before* deriving anything. The xpub is never leaked on a
+            # mismatch, but there's no reason to spend the derivation on a
+            # request that's going to be refused either way.
+            #
             # A standard-purpose path (44'/48'/49'/84'/86'/87') whose coin
             # type doesn't match the network currently active on this
             # device can never be legitimately shared from here - the same
@@ -357,6 +359,20 @@ class XpubApp(BaseApp):
                     )
                 )
                 raise AppError("network mismatch: device is on %s" % device_net)
+            # a previously approved scope covers this exact normalized
+            # path and hasn't already been used - no extra prompt needed
+            authorized = self._authorization is not None and (
+                self._authorization.try_consume(self.network, path)
+            )
+            # derive the xpub - to hand straight back for an authorized
+            # path, or to show the user exactly what would be shared
+            xpub_str = self.keystore.get_xpub(derivation).to_base58(
+                NETWORKS[self.network]["xpub"]
+            )
+            if authorized:
+                if self._authorization.remaining <= 0:
+                    self._authorization = None
+                return BytesIO(xpub_str.encode()), {}
             fingerprint = hexlify(self.keystore.fingerprint).decode()
             confirm = await show_screen(
                 Prompt(

--- a/src/gui/screens/prompt.py
+++ b/src/gui/screens/prompt.py
@@ -9,14 +9,18 @@ class Prompt(Screen):
                  confirm_text="Confirm", cancel_text="Cancel", note=None, warning=None):
         super().__init__()
         self.title = add_label(title, scr=self, style="title")
+        anchor = self.title
+        page_offset = 0
         if note is not None:
             self.note = add_label(note, scr=self, style="hint")
             self.note.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 5)
-            obj = self.note
+            # leave a blank line between the note and the message below it
+            anchor = self.note
+            page_offset = 20
         self.page = lv.page(self)
         self.page.set_size(480, 600)
         self.message = add_label(message, scr=self.page)
-        self.page.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 0)
+        self.page.align(anchor, lv.ALIGN.OUT_BOTTOM_MID, 0, page_offset)
         # Initialize an empty icon label. It will display nothing until a symbol is set.
         self.icon = lv.label(self)
         self.icon.set_text("")

--- a/src/specter.py
+++ b/src/specter.py
@@ -18,7 +18,7 @@ from platform import (
     get_flash_write_protection_status,
 )
 from hosts import Host, HostError
-from app import BaseApp
+from app import BaseApp, NetworkSwitchRequested
 from embit import bip39
 from embit.liquid.networks import NETWORKS
 from gui.screens.settings import HostSettings
@@ -237,11 +237,6 @@ class Specter:
                     return self.set_mnemonic(mnemonic)
                 else:
                     return True
-            if data == b"select_network":
-                # let an app (e.g. the xpub network-mismatch screen) send
-                # the user straight to the network picker
-                await self.select_network()
-                return True
             raise SpecterError("Invalid command '%s'" % data)
         return await self.process_host_request(stream, popup=False, appname=app, show_fn=show_fn)
 
@@ -721,6 +716,12 @@ class Specter:
             stream.seek(0)
             app = matching_apps[0]
             res = await app.process_host_command(stream, show_fn)
+        except NetworkSwitchRequested as e:
+            # the app refused the request and the user chose to fix the
+            # network: open the picker, then still report the failure
+            self.gui.hide_loader()
+            await self.select_network()
+            raise HostError(e.host_message)
         except Exception as e:
             if isinstance(e, BaseError):
                 # error that has a meaningfull message, will be sent to the host

--- a/src/specter.py
+++ b/src/specter.py
@@ -630,6 +630,9 @@ class Specter:
         # lock the keystore
         if hasattr(self.keystore, "lock"):
             self.keystore.lock()
+        # let apps discard volatile security-sensitive state
+        for app in self.apps:
+            app.on_lock()
         # disable hosts
         for host in self.hosts:
             await host.disable()

--- a/src/specter.py
+++ b/src/specter.py
@@ -23,6 +23,7 @@ from embit import bip39
 from embit.liquid.networks import NETWORKS
 from gui.screens.settings import HostSettings
 from gui.screens.mnemonic import MnemonicPrompt
+from gui.screens import Menu
 
 # small helper functions
 from helpers import gen_mnemonic, fix_mnemonic
@@ -435,7 +436,7 @@ class Specter:
             raise SpecterError("Not implemented")
         return self.settingsmenu
 
-    async def select_network(self):
+    async def select_network(self, show_fn=None):
         buttons = [
             (None, "Production"),
             ("main", "Bitcoin Mainnet"),
@@ -447,8 +448,16 @@ class Specter:
             ("liquidtestnet", "Liquid Testnet"),
             ("elementsregtest", "Liquid Regtest"),
         ]
-        # wait for menu selection
-        menuitem = await self.gui.menu(buttons, last=(255, None))
+        # wait for menu selection. When called from inside a host-command
+        # handler (show_fn given) the picker has to go over the current
+        # screen as a popup - loading it as a full screen would delete the
+        # menu the main loop is still waiting on and wedge navigation.
+        if show_fn is not None:
+            menuitem = await show_fn(
+                Menu(buttons, title="Switch network", last=(255, None))
+            )
+        else:
+            menuitem = await self.gui.menu(buttons, last=(255, None))
         if menuitem != 255:
             self.set_network(menuitem)
 
@@ -720,7 +729,7 @@ class Specter:
             # the app refused the request and the user chose to fix the
             # network: open the picker, then still report the failure
             self.gui.hide_loader()
-            await self.select_network()
+            await self.select_network(show_fn=show_fn)
             raise HostError(e.host_message)
         except Exception as e:
             if isinstance(e, BaseError):

--- a/src/specter.py
+++ b/src/specter.py
@@ -237,6 +237,11 @@ class Specter:
                     return self.set_mnemonic(mnemonic)
                 else:
                     return True
+            if data == b"select_network":
+                # let an app (e.g. the xpub network-mismatch screen) send
+                # the user straight to the network picker
+                await self.select_network()
+                return True
             raise SpecterError("Invalid command '%s'" % data)
         return await self.process_host_request(stream, popup=False, appname=app, show_fn=show_fn)
 

--- a/src/specter.py
+++ b/src/specter.py
@@ -18,12 +18,11 @@ from platform import (
     get_flash_write_protection_status,
 )
 from hosts import Host, HostError
-from app import BaseApp, NetworkSwitchRequested
+from app import BaseApp
 from embit import bip39
 from embit.liquid.networks import NETWORKS
 from gui.screens.settings import HostSettings
 from gui.screens.mnemonic import MnemonicPrompt
-from gui.screens import Menu
 
 # small helper functions
 from helpers import gen_mnemonic, fix_mnemonic
@@ -436,7 +435,7 @@ class Specter:
             raise SpecterError("Not implemented")
         return self.settingsmenu
 
-    async def select_network(self, show_fn=None):
+    async def select_network(self):
         buttons = [
             (None, "Production"),
             ("main", "Bitcoin Mainnet"),
@@ -448,16 +447,8 @@ class Specter:
             ("liquidtestnet", "Liquid Testnet"),
             ("elementsregtest", "Liquid Regtest"),
         ]
-        # wait for menu selection. When called from inside a host-command
-        # handler (show_fn given) the picker has to go over the current
-        # screen as a popup - loading it as a full screen would delete the
-        # menu the main loop is still waiting on and wedge navigation.
-        if show_fn is not None:
-            menuitem = await show_fn(
-                Menu(buttons, title="Switch network", last=(255, None))
-            )
-        else:
-            menuitem = await self.gui.menu(buttons, last=(255, None))
+        # wait for menu selection
+        menuitem = await self.gui.menu(buttons, last=(255, None))
         if menuitem != 255:
             self.set_network(menuitem)
 
@@ -725,12 +716,6 @@ class Specter:
             stream.seek(0)
             app = matching_apps[0]
             res = await app.process_host_command(stream, show_fn)
-        except NetworkSwitchRequested as e:
-            # the app refused the request and the user chose to fix the
-            # network: open the picker, then still report the failure
-            self.gui.hide_loader()
-            await self.select_network(show_fn=show_fn)
-            raise HostError(e.host_message)
         except Exception as e:
             if isinstance(e, BaseError):
                 # error that has a meaningfull message, will be sent to the host

--- a/test/integration/tests/test_basic.py
+++ b/test/integration/tests/test_basic.py
@@ -20,10 +20,17 @@ class BasicTest(TestCase):
         self.assertEqual(res, b"error: User cancelled")
 
     def test_get_xpub(self):
+        # fingerprint is non-interactive (device discovery/identification)
         res = sim.query(b"fingerprint")
         self.assertEqual(res, b"73c5da0a")
-        res = sim.query(b"xpub m/44h/1h/0h")
+        # xpub requests must be confirmed on the device
+        res = sim.query(b"xpub m/44h/1h/0h", [True])
         self.assertEqual(res, b"tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba")
+
+    def test_get_xpub_rejected(self):
+        # rejecting the on-device confirmation must not leak the xpub
+        res = sim.query(b"xpub m/44h/1h/0h", [False])
+        self.assertEqual(res, b"error: User cancelled")
 
     def test_add_wallet(self):
         # and(pk(A),after(100)) -> and_v(v:pk(A),after(100))

--- a/test/integration/tests/test_xpubauth.py
+++ b/test/integration/tests/test_xpubauth.py
@@ -1,0 +1,91 @@
+from unittest import TestCase
+from util.controller import sim
+
+
+class XpubAuthIntegrationTest(TestCase):
+    def test_begin_end_and_in_scope_requests(self):
+        # one confirmation for the scope...
+        res = sim.query(b"xpubauth begin m/84h/1h/{0-2}h", [True])
+        self.assertEqual(res, b"success")
+
+        # ...then in-scope requests need no further confirmation at all.
+        # sim.query() is called here with no "commands" to send to the
+        # GUI socket - if the device were to show a prompt, nothing
+        # would confirm it and the USB read below would time out empty,
+        # so a real tpub coming back proves no prompt was shown.
+        res = sim.query(b"xpub m/84h/1h/0h")
+        self.assertTrue(res.startswith(b"tpub"), res)
+        res = sim.query(b"xpub m/84h/1h/2h")
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+        # a path outside the approved scope still requires confirmation
+        res = sim.query(b"xpub m/84h/1h/9h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+        # explicit end
+        res = sim.query(b"xpubauth end")
+        self.assertEqual(res, b"success")
+
+        # the same in-scope path now requires confirmation again -
+        # without it, the request would time out instead of succeeding
+        res = sim.query(b"xpub m/84h/1h/0h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+    def test_exact_four_paths(self):
+        scope = b"m/84h/1h/0h;m/86h/1h/0h;m/48h/1h/0h/2h;m/48h/1h/1h/2h"
+        res = sim.query(b"xpubauth begin " + scope, [True])
+        self.assertEqual(res, b"success")
+
+        for path in [b"m/84h/1h/0h", b"m/86h/1h/0h", b"m/48h/1h/0h/2h", b"m/48h/1h/1h/2h"]:
+            res = sim.query(b"xpub " + path)
+            self.assertTrue(res.startswith(b"tpub"), res)
+
+        # a fifth, unrelated path is not covered and needs confirmation
+        res = sim.query(b"xpub m/49h/1h/0h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+        sim.query(b"xpubauth end")
+
+    def test_repeated_request_for_consumed_path_reprompts(self):
+        res = sim.query(b"xpubauth begin m/84h/1h/0h", [True])
+        self.assertEqual(res, b"success")
+
+        # first silent use consumes the single-path authorization
+        res = sim.query(b"xpub m/84h/1h/0h")
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+        # authorization is fully consumed and self-clears - a repeat
+        # request needs confirmation again
+        res = sim.query(b"xpub m/84h/1h/0h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+    def test_cancelled_begin_grants_nothing(self):
+        res = sim.query(b"xpubauth begin m/84h/1h/{0-2}h", [False])
+        self.assertEqual(res, b"error: User cancelled")
+
+        # nothing was authorized - a matching path still prompts
+        res = sim.query(b"xpub m/84h/1h/0h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)
+
+    def test_invalid_scope_is_rejected_without_prompting(self):
+        res = sim.query(b"xpubauth begin m/84h/0h/*")
+        self.assertTrue(res.startswith(b"error:"), res)
+
+    def test_bip138_like_discovery_flow(self):
+        scope = b";".join([
+            b"m/44h/1h/{0-9}h", b"m/49h/1h/{0-9}h", b"m/84h/1h/{0-9}h",
+            b"m/86h/1h/{0-9}h", b"m/87h/1h/{0-9}h",
+            b"m/48h/1h/{0-9}h/1h", b"m/48h/1h/{0-9}h/2h",
+        ])
+        res = sim.query(b"xpubauth begin " + scope, [True])
+        self.assertEqual(res, b"success")
+
+        # sequential lookups, no further prompts, stopping early
+        for path in [b"m/84h/1h/0h", b"m/84h/1h/1h", b"m/49h/1h/0h"]:
+            res = sim.query(b"xpub " + path)
+            self.assertTrue(res.startswith(b"tpub"), res)
+
+        sim.query(b"xpubauth end")
+
+        res = sim.query(b"xpub m/84h/1h/2h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)

--- a/test/integration/tests/test_xpubauth.py
+++ b/test/integration/tests/test_xpubauth.py
@@ -71,6 +71,20 @@ class XpubAuthIntegrationTest(TestCase):
         res = sim.query(b"xpubauth begin m/84h/0h/*")
         self.assertTrue(res.startswith(b"error:"), res)
 
+    def test_cancelled_replacement_begin_revokes_prior_authorization(self):
+        # an authorization is active...
+        res = sim.query(b"xpubauth begin m/84h/1h/{0-2}h", [True])
+        self.assertEqual(res, b"success")
+
+        # ...a new begin arrives and the user cancels it
+        res = sim.query(b"xpubauth begin m/86h/1h/{0-2}h", [False])
+        self.assertEqual(res, b"error: User cancelled")
+
+        # fail closed: the prior authorization is gone too, so a
+        # formerly in-scope path now requires normal confirmation again
+        res = sim.query(b"xpub m/84h/1h/0h", [True])
+        self.assertTrue(res.startswith(b"tpub"), res)
+
     def test_bip138_like_discovery_flow(self):
         scope = b";".join([
             b"m/44h/1h/{0-9}h", b"m/49h/1h/{0-9}h", b"m/84h/1h/{0-9}h",

--- a/test/native_support.py
+++ b/test/native_support.py
@@ -105,7 +105,10 @@ def setup_native_stubs():
         "DevSettings",
     ]:
         if not hasattr(screens, _name):
-            setattr(screens, _name, type(_name, (), {}))
+            def _stub_init(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+            setattr(screens, _name, type(_name, (), {"__init__": _stub_init}))
 
     _ensure_submodule("gui.screens", "mnemonic", {
         "ExportMnemonicScreen": type("ExportMnemonicScreen", (), {}),
@@ -123,6 +126,8 @@ def setup_native_stubs():
     common = _ensure_module("gui.common")
     if not hasattr(common, "HOR_RES"):
         common.HOR_RES = 480
+    if not hasattr(common, "PADDING"):
+        common.PADDING = 20
     if not hasattr(common, "styles"):
         common.styles = types.SimpleNamespace()
     for _name in [

--- a/test/tests/util.py
+++ b/test/tests/util.py
@@ -1,6 +1,7 @@
 from keystore.ram import RAMKeyStore
 from app import BaseApp
 from apps.wallets import App as WalletsApp
+from apps.xpubs import App as XpubsApp
 import platform
 
 TEST_DIR = "testdir"
@@ -48,3 +49,10 @@ def get_wallets_app(keystore, network):
     wapp = WalletsApp(TEST_DIR+"/wallets")
     wapp.init(keystore, network, show_loader, communicate)
     return wapp
+
+def get_xpubs_app(keystore, network):
+    platform.maybe_mkdir(TEST_DIR)
+    platform.maybe_mkdir(TEST_DIR+"/xpubs")
+    xapp = XpubsApp(TEST_DIR+"/xpubs")
+    xapp.init(keystore, network, show_loader, communicate)
+    return xapp

--- a/test/tests_native/__init__.py
+++ b/test/tests_native/__init__.py
@@ -1,1 +1,4 @@
 from .test_wallet_manager_parsing import *
+from .test_xpubs_host_command import *
+from .test_xpub_scope import *
+from .test_xpubauth_host_command import *

--- a/test/tests_native/test_xpub_scope.py
+++ b/test/tests_native/test_xpub_scope.py
@@ -1,0 +1,286 @@
+import sys
+
+if sys.implementation.name != 'micropython':
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+from unittest import TestCase
+from embit import bip32
+
+from apps.xpubs import scope as xpubauth_scope
+
+
+MAIN = ("main", 0)
+TEST = ("test", 1)
+
+
+class ScopeParsingTest(TestCase):
+    def test_single_exact_path(self):
+        entries, total = xpubauth_scope.parse_scope("m/84h/0h/0h", *MAIN)
+        self.assertEqual(total, 1)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].format(), "m/84h/0h/0h")
+
+    def test_four_exact_paths(self):
+        entries, total = xpubauth_scope.parse_scope(
+            "m/84h/0h/0h;m/86h/0h/0h;m/48h/0h/0h/2h;m/48h/0h/1h/2h", *MAIN
+        )
+        self.assertEqual(total, 4)
+        self.assertEqual(len(entries), 4)
+
+    def test_bounded_range_count(self):
+        entries, total = xpubauth_scope.parse_scope("m/84h/0h/{0-9}h", *MAIN)
+        self.assertEqual(total, 10)
+
+    def test_multiple_ranges_count(self):
+        entries, total = xpubauth_scope.parse_scope(
+            "m/84h/0h/{0-9}h;m/86h/0h/{0-2}h;m/48h/0h/{0-4}h/2h", *MAIN
+        )
+        self.assertEqual(total, 10 + 3 + 5)
+
+    def test_bip138_like_scope_count(self):
+        # roughly the BIP-0138 common discovery space for one network
+        scope = ";".join([
+            "m/44h/0h/{0-9}h",
+            "m/49h/0h/{0-9}h",
+            "m/84h/0h/{0-9}h",
+            "m/86h/0h/{0-9}h",
+            "m/87h/0h/{0-9}h",
+            "m/48h/0h/{0-9}h/1h",
+            "m/48h/0h/{0-9}h/2h",
+        ])
+        entries, total = xpubauth_scope.parse_scope(scope, *MAIN)
+        self.assertEqual(total, 70)
+        self.assertLessEqual(total, xpubauth_scope.MAX_TOTAL_XPUBS)
+
+    def test_hardened_notation_is_equivalent(self):
+        a, _ = xpubauth_scope.parse_scope("m/84h/0h/{0-9}h", *MAIN)
+        b, _ = xpubauth_scope.parse_scope("m/84'/0'/{0-9}'", *MAIN)
+        self.assertEqual(a[0].components, b[0].components)
+        self.assertEqual(a[0].format(), b[0].format())
+
+    def test_zero_width_range_is_valid(self):
+        entries, total = xpubauth_scope.parse_scope("m/84h/0h/{0-0}h", *MAIN)
+        self.assertEqual(total, 1)
+
+    def test_reversed_range_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{9-0}h", *MAIN)
+
+    def test_negative_range_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{-1-5}h", *MAIN)
+
+    def test_value_at_hardened_boundary_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/2147483648", *MAIN)
+
+    def test_huge_decimal_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/123456789012h", *MAIN)
+
+    def test_range_too_wide_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{0-500}h", *MAIN)
+
+    def test_huge_range_is_rejected_before_expansion(self):
+        # the canonical "don't even try to expand this" example
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{0-2147483647}h", *MAIN)
+
+    def test_malformed_braces_are_rejected(self):
+        for bad in ["m/84h/0h/{0-9", "m/84h/0h/0-9}h", "m/84h/0h/{0-9]h"]:
+            with self.assertRaises(xpubauth_scope.ScopeError):
+                xpubauth_scope.parse_scope(bad, *MAIN)
+
+    def test_missing_boundary_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{-9}h", *MAIN)
+
+    def test_extra_boundary_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{0-5-9}h", *MAIN)
+
+    def test_unexpected_characters_are_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{0-9x}h", *MAIN)
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/5x", *MAIN)
+
+    def test_too_many_path_components_is_rejected(self):
+        deep = "m/" + "/".join(["0h"] * (xpubauth_scope.MAX_PATH_DEPTH + 1))
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope(deep, *MAIN)
+
+    def test_too_many_scope_entries_is_rejected(self):
+        entries = ";".join(
+            "m/84h/0h/%dh" % i for i in range(xpubauth_scope.MAX_ENTRIES + 1)
+        )
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope(entries, *MAIN)
+
+    def test_total_expansion_over_budget_is_rejected(self):
+        scope = ";".join([
+            "m/84h/0h/{0-99}h",
+            "m/86h/0h/{0-99}h",
+            "m/49h/0h/{0-99}h",
+        ])
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope(scope, *MAIN)
+
+    def test_wildcards_are_not_a_grammar_construct(self):
+        for bad in ["*", "m/*", "m/84h/0h/*"]:
+            with self.assertRaises(xpubauth_scope.ScopeError):
+                xpubauth_scope.parse_scope(bad, *MAIN)
+
+    def test_multiple_ranges_in_one_entry_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/{0-1}h/{0-9}h", *MAIN)
+
+    def test_empty_scope_is_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("", *MAIN)
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("   ;  ", *MAIN)
+
+    def test_oversized_scope_string_is_rejected(self):
+        huge = "m/84h/0h/0h;" * (xpubauth_scope.MAX_SCOPE_LEN // 10)
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope(huge, *MAIN)
+
+
+class ScopeOverlapTest(TestCase):
+    def test_duplicate_exact_paths_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/5h;m/84h/0h/5h", *MAIN)
+
+    def test_exact_path_inside_range_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/{0-9}h;m/84h/0h/5h", *MAIN)
+
+    def test_overlapping_ranges_rejected(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope(
+                "m/84h/0h/{0-9}h;m/84h/0h/{5-15}h", *MAIN
+            )
+
+    def test_non_overlapping_ranges_allowed(self):
+        entries, total = xpubauth_scope.parse_scope(
+            "m/84h/0h/{0-9}h;m/84h/0h/{10-15}h", *MAIN
+        )
+        self.assertEqual(total, 16)
+
+    def test_different_depth_entries_never_overlap(self):
+        entries, total = xpubauth_scope.parse_scope(
+            "m/84h/0h/0h;m/84h/0h/0h/1h", *MAIN
+        )
+        self.assertEqual(total, 2)
+
+
+class ScopeNetworkValidationTest(TestCase):
+    def test_mainnet_standard_path_accepted(self):
+        xpubauth_scope.parse_scope("m/84h/0h/{0-9}h", *MAIN)
+
+    def test_testnet_style_path_rejected_on_mainnet(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/1h/0h", *MAIN)
+
+    def test_mainnet_style_path_rejected_on_testnet(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope("m/84h/0h/0h", *TEST)
+
+    def test_testnet_style_path_accepted_on_testnet(self):
+        xpubauth_scope.parse_scope("m/84h/1h/{0-9}h", *TEST)
+
+    def test_mixed_network_scope_rejected_as_whole(self):
+        with self.assertRaises(xpubauth_scope.ScopeError):
+            xpubauth_scope.parse_scope(
+                "m/84h/0h/{0-9}h;m/84h/1h/{0-9}h", *MAIN
+            )
+
+    def test_non_standard_purpose_has_no_coin_policy(self):
+        # an unusual/custom path is not a recognized BIP44-style form,
+        # so no coin-type policy is enforced on it either way
+        xpubauth_scope.parse_scope("m/123456h/0h/0h", *MAIN)
+        xpubauth_scope.parse_scope("m/123456h/1h/0h", *MAIN)
+
+    def test_non_hardened_purpose_has_no_coin_policy(self):
+        xpubauth_scope.parse_scope("m/84/1h/0h", *MAIN)
+
+
+class ScopeMatchingTest(TestCase):
+    def _entry(self, scope_str, network=MAIN):
+        entries, _ = xpubauth_scope.parse_scope(scope_str, *network)
+        return entries[0]
+
+    def test_match_boundaries_of_a_range(self):
+        entry = self._entry("m/84h/0h/{0-9}h")
+        for value in (0, 5, 9):
+            path = bip32.parse_path("m/84h/0h/%dh" % value)
+            self.assertIsNotNone(entry.match(path))
+        for value in (10,):
+            path = bip32.parse_path("m/84h/0h/%dh" % value)
+            self.assertIsNone(entry.match(path))
+
+    def test_match_uses_normalized_hardened_notation(self):
+        entry = self._entry("m/84h/0h/{0-9}h")
+        path = bip32.parse_path("m/84'/0'/3'")
+        self.assertIsNotNone(entry.match(path))
+
+    def test_out_of_scope_paths_do_not_match(self):
+        entry = self._entry("m/84h/0h/{0-9}h")
+        for bad in ["m/84h/0h/10h", "m/84h/1h/0h", "m/85h/0h/0h", "m", "m/0h"]:
+            try:
+                path = bip32.parse_path(bad)
+            except Exception:
+                continue
+            self.assertIsNone(entry.match(path))
+
+    def test_prefix_is_not_authorized(self):
+        entry = self._entry("m/84h/0h/1h")
+        path = bip32.parse_path("m/84h/0h/1h/999h")
+        self.assertIsNone(entry.match(path))
+
+
+class AuthorizationBudgetTest(TestCase):
+    def test_consumable_permission_is_single_use(self):
+        entries, _ = xpubauth_scope.parse_scope("m/84h/0h/0h", *MAIN)
+        auth = xpubauth_scope.Authorization(entries, "main")
+        path = bip32.parse_path("m/84h/0h/0h")
+        self.assertTrue(auth.try_consume("main", path))
+        self.assertFalse(auth.try_consume("main", path))
+
+    def test_each_value_in_range_consumable_once(self):
+        entries, _ = xpubauth_scope.parse_scope("m/84h/0h/{0-2}h", *MAIN)
+        auth = xpubauth_scope.Authorization(entries, "main")
+        for value in (0, 1, 2):
+            path = bip32.parse_path("m/84h/0h/%dh" % value)
+            self.assertTrue(auth.try_consume("main", path))
+        for value in (0, 1, 2):
+            path = bip32.parse_path("m/84h/0h/%dh" % value)
+            self.assertFalse(auth.try_consume("main", path))
+
+    def test_remaining_reaches_zero_after_full_consumption(self):
+        entries, total = xpubauth_scope.parse_scope("m/84h/0h/{0-2}h", *MAIN)
+        auth = xpubauth_scope.Authorization(entries, "main")
+        self.assertEqual(auth.remaining, total)
+        for value in (0, 1, 2):
+            auth.try_consume("main", bip32.parse_path("m/84h/0h/%dh" % value))
+        self.assertEqual(auth.remaining, 0)
+
+    def test_network_mismatch_never_consumes(self):
+        entries, _ = xpubauth_scope.parse_scope("m/84h/0h/0h", *MAIN)
+        auth = xpubauth_scope.Authorization(entries, "main")
+        path = bip32.parse_path("m/84h/0h/0h")
+        self.assertFalse(auth.try_consume("test", path))
+        self.assertEqual(auth.remaining, 1)
+        # still consumable on the correct network afterwards
+        self.assertTrue(auth.try_consume("main", path))
+
+    def test_unrelated_path_never_consumes(self):
+        entries, _ = xpubauth_scope.parse_scope("m/84h/0h/{0-9}h", *MAIN)
+        auth = xpubauth_scope.Authorization(entries, "main")
+        path = bip32.parse_path("m/85h/0h/0h")
+        self.assertFalse(auth.try_consume("main", path))
+        self.assertEqual(auth.remaining, 10)

--- a/test/tests_native/test_xpub_scope.py
+++ b/test/tests_native/test_xpub_scope.py
@@ -209,6 +209,54 @@ class ScopeNetworkValidationTest(TestCase):
         xpubauth_scope.parse_scope("m/84/1h/0h", *MAIN)
 
 
+class StandardPathCoinTypeMismatchTest(TestCase):
+    """standard_path_coin_type_mismatch() applies the same rule
+    _validate_standard_coin_type() applies to an xpubauth scope entry, but
+    to a single already-parsed path - used to guard plain, non-scoped
+    `xpub <path>` requests."""
+
+    def test_matching_mainnet_path_is_not_a_mismatch(self):
+        path = bip32.parse_path("m/84h/0h/0h")
+        self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 0))
+
+    def test_testnet_style_path_mismatches_on_mainnet(self):
+        path = bip32.parse_path("m/84h/1h/0h")
+        self.assertTrue(xpubauth_scope.standard_path_coin_type_mismatch(path, 0))
+
+    def test_mainnet_style_path_mismatches_on_testnet(self):
+        path = bip32.parse_path("m/84h/0h/0h")
+        self.assertTrue(xpubauth_scope.standard_path_coin_type_mismatch(path, 1))
+
+    def test_matching_testnet_path_is_not_a_mismatch(self):
+        path = bip32.parse_path("m/84h/1h/0h")
+        self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 1))
+
+    def test_every_standard_purpose_is_covered(self):
+        for purpose in xpubauth_scope.STANDARD_PURPOSES:
+            path = bip32.parse_path("m/%dh/1h/0h" % purpose)
+            self.assertTrue(
+                xpubauth_scope.standard_path_coin_type_mismatch(path, 0),
+                "purpose %dh not enforced" % purpose,
+            )
+
+    def test_non_standard_purpose_is_never_a_mismatch(self):
+        path = bip32.parse_path("m/123456h/1h/0h")
+        self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 0))
+
+    def test_non_hardened_purpose_is_never_a_mismatch(self):
+        path = bip32.parse_path("m/84/1h/0h")
+        self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 0))
+
+    def test_path_shorter_than_two_components_is_never_a_mismatch(self):
+        path = bip32.parse_path("m/84h")
+        self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 0))
+
+    def test_liquid_coin_type_is_covered(self):
+        path = bip32.parse_path("m/84h/1776h/0h")
+        self.assertTrue(xpubauth_scope.standard_path_coin_type_mismatch(path, 0))
+        self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 1776))
+
+
 class ScopeMatchingTest(TestCase):
     def _entry(self, scope_str, network=MAIN):
         entries, _ = xpubauth_scope.parse_scope(scope_str, *network)

--- a/test/tests_native/test_xpub_scope.py
+++ b/test/tests_native/test_xpub_scope.py
@@ -257,6 +257,39 @@ class StandardPathCoinTypeMismatchTest(TestCase):
         self.assertFalse(xpubauth_scope.standard_path_coin_type_mismatch(path, 1776))
 
 
+class NetworkHintForPathTest(TestCase):
+    def test_mainnet_coin_type_names_mainnet(self):
+        self.assertEqual(
+            xpubauth_scope.network_hint_for_path(bip32.parse_path("m/84h/0h/0h")),
+            "Mainnet",
+        )
+
+    def test_liquid_coin_type_names_liquid(self):
+        self.assertEqual(
+            xpubauth_scope.network_hint_for_path(bip32.parse_path("m/84h/1776h/0h")),
+            "Liquid",
+        )
+
+    def test_testnet_coin_type_names_the_candidates(self):
+        hint = xpubauth_scope.network_hint_for_path(bip32.parse_path("m/84h/1h/0h"))
+        self.assertIn("Testnet", hint)
+        self.assertIn("Signet", hint)
+        self.assertIn("Regtest", hint)
+
+    def test_unknown_coin_type_has_no_hint(self):
+        self.assertIsNone(
+            xpubauth_scope.network_hint_for_path(bip32.parse_path("m/84h/999h/0h"))
+        )
+
+    def test_short_or_soft_path_has_no_hint(self):
+        self.assertIsNone(
+            xpubauth_scope.network_hint_for_path(bip32.parse_path("m/84h"))
+        )
+        self.assertIsNone(
+            xpubauth_scope.network_hint_for_path(bip32.parse_path("m/84h/1/0h"))
+        )
+
+
 class ScopeMatchingTest(TestCase):
     def _entry(self, scope_str, network=MAIN):
         entries, _ = xpubauth_scope.parse_scope(scope_str, *network)

--- a/test/tests_native/test_xpubauth_host_command.py
+++ b/test/tests_native/test_xpubauth_host_command.py
@@ -197,13 +197,14 @@ class XpubAuthHostCommandTest(TestCase):
         # a testnet-style path is out of the (mainnet) authorized scope,
         # but it's also a network mismatch on this "main" device - that
         # takes precedence over the usual "just ask" fallback: refused
-        # outright, never shown as a normal Confirm/Cancel prompt
+        # with the dedicated screen, not the normal "Share Xpub?" prompt
         self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
-        show_screen, seen = self._show_screen(True)
+        show_screen, seen = self._show_screen(False)  # tap "OK"
         with self.assertRaises(Exception):
             self._xpub("m/84h/1h/0h", show_screen)
         self.assertEqual(len(seen), 1)
-        self.assertNotIsInstance(seen[0], Prompt)
+        title = seen[0].args[0] if seen[0].args else seen[0].kwargs.get("title", "")
+        self.assertIn("Host tried to get access", title)
 
     def test_prefix_child_is_not_silently_authorized(self):
         self._begin("m/84h/0h/1h", self._show_screen(True)[0])

--- a/test/tests_native/test_xpubauth_host_command.py
+++ b/test/tests_native/test_xpubauth_host_command.py
@@ -1,0 +1,383 @@
+import sys
+
+if sys.implementation.name != 'micropython':
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+from unittest import TestCase
+from io import BytesIO
+from binascii import hexlify
+import gc
+
+from tests.util import get_keystore, get_xpubs_app, clear_testdir
+from embit import bip32
+from embit.liquid.networks import NETWORKS
+from gui.screens import Prompt
+
+
+class XpubAuthHostCommandTest(TestCase):
+    def setUp(self):
+        clear_testdir()
+        self.keystore = get_keystore()
+        self.app = get_xpubs_app(self.keystore, "main")
+
+    def tearDown(self):
+        clear_testdir()
+        gc.collect()
+
+    # ---- test harness helpers (mirrors test_xpubs_host_command.py) ----
+
+    def _show_screen(self, *responses):
+        """Returns (show_screen, seen) where show_screen replies with
+        `responses` in order (repeating the last one if exhausted)."""
+        seen = []
+        responses = list(responses)
+
+        async def show_screen(scr):
+            seen.append(scr)
+            if len(responses) > 1:
+                return responses.pop(0)
+            return responses[0]
+
+        return show_screen, seen
+
+    def _run(self, coro):
+        try:
+            coro.send(None)
+        except StopIteration as e:
+            return e.value
+        raise AssertionError("coroutine did not complete in one step")
+
+    def _xpub(self, path, show_screen):
+        stream = BytesIO(b"xpub " + path.encode())
+        return self._run(self.app.process_host_command(stream, show_screen))
+
+    def _begin(self, scope, show_screen):
+        stream = BytesIO(b"xpubauth begin " + scope.encode())
+        return self._run(self.app.process_host_command(stream, show_screen))
+
+    def _end(self, show_screen):
+        stream = BytesIO(b"xpubauth end")
+        return self._run(self.app.process_host_command(stream, show_screen))
+
+    def _expected_xpub(self, path, network="main"):
+        return self.keystore.get_xpub(path).to_base58(NETWORKS[network]["xpub"])
+
+    # ---- begin: happy paths ----
+
+    def test_begin_exact_single_path(self):
+        show_screen, seen = self._show_screen(True)
+        res = self._begin("m/84h/0h/0h", show_screen)
+        self.assertTrue(res)
+        self.assertEqual(len(seen), 1)
+        self.assertIsInstance(seen[0], Prompt)
+
+    def test_begin_shows_network_paths_and_count(self):
+        show_screen, seen = self._show_screen(True)
+        self._begin("m/84h/0h/{0-9}h", show_screen)
+        shown = seen[0]
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        self.assertIn(NETWORKS["main"]["name"], message)
+        self.assertIn("m/84h/0h/{0-9}h", message)
+        self.assertIn("10", message)
+
+    def test_begin_exactly_one_confirmation_for_bip138_scope(self):
+        scope = ";".join([
+            "m/44h/0h/{0-9}h", "m/49h/0h/{0-9}h", "m/84h/0h/{0-9}h",
+            "m/86h/0h/{0-9}h", "m/87h/0h/{0-9}h",
+            "m/48h/0h/{0-9}h/1h", "m/48h/0h/{0-9}h/2h",
+        ])
+        show_screen, seen = self._show_screen(True)
+        res = self._begin(scope, show_screen)
+        self.assertTrue(res)
+        self.assertEqual(len(seen), 1)
+
+    def test_begin_cancel_leaves_no_authorization(self):
+        show_screen, seen = self._show_screen(False)
+        res = self._begin("m/84h/0h/{0-9}h", show_screen)
+        self.assertFalse(res)
+        self.assertIsNone(self.app._authorization)
+
+    def test_begin_invalid_scope_leaves_no_authorization(self):
+        show_screen, seen = self._show_screen(True)
+        with self.assertRaises(Exception):
+            self._begin("garbage", show_screen)
+        self.assertEqual(seen, [])
+        self.assertIsNone(self.app._authorization)
+
+    def test_begin_locked_device_rejected(self):
+        from unittest.mock import patch, PropertyMock
+        show_screen, seen = self._show_screen(True)
+        with patch.object(
+            type(self.keystore), "is_locked", new_callable=PropertyMock, return_value=True
+        ):
+            with self.assertRaises(Exception):
+                self._begin("m/84h/0h/0h", show_screen)
+        self.assertEqual(seen, [])
+
+    # ---- in-scope requests bypass confirmation ----
+
+    def test_in_scope_first_boundary_no_prompt(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        res = self._xpub("m/84h/0h/0h", show_screen)
+        stream, meta = res
+        self.assertEqual(stream.read().decode(), self._expected_xpub("m/84h/0h/0h"))
+        self.assertEqual(seen, [])
+
+    def test_in_scope_middle_no_prompt(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        res = self._xpub("m/84h/0h/5h", show_screen)
+        stream, meta = res
+        self.assertEqual(stream.read().decode(), self._expected_xpub("m/84h/0h/5h"))
+        self.assertEqual(seen, [])
+
+    def test_in_scope_last_boundary_no_prompt(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        res = self._xpub("m/84h/0h/9h", show_screen)
+        stream, meta = res
+        self.assertEqual(stream.read().decode(), self._expected_xpub("m/84h/0h/9h"))
+        self.assertEqual(seen, [])
+
+    def test_in_scope_matches_hardened_prime_notation(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        res = self._xpub("m/84'/0'/3'", show_screen)
+        stream, meta = res
+        self.assertEqual(stream.read().decode(), self._expected_xpub("m/84h/0h/3h"))
+        self.assertEqual(seen, [])
+
+    def test_exact_four_paths_all_retrievable_without_prompt(self):
+        paths = ["m/84h/0h/0h", "m/86h/0h/0h", "m/48h/0h/0h/2h", "m/48h/0h/1h/2h"]
+        self._begin(";".join(paths), self._show_screen(True)[0])
+        for path in paths:
+            show_screen, seen = self._show_screen(True)
+            res = self._xpub(path, show_screen)
+            stream, meta = res
+            self.assertEqual(stream.read().decode(), self._expected_xpub(path))
+            self.assertEqual(seen, [])
+
+    def test_fifth_unrelated_path_still_prompts(self):
+        paths = ["m/84h/0h/0h", "m/86h/0h/0h", "m/48h/0h/0h/2h", "m/48h/0h/1h/2h"]
+        self._begin(";".join(paths), self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/49h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+        self.assertIsInstance(seen[0], Prompt)
+
+    # ---- out-of-scope requests fall back to normal confirmation ----
+
+    def test_out_of_range_index_prompts_normally(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/10h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_out_of_scope_does_not_widen_authorization(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        # approve an unrelated path individually
+        self._xpub("m/85h/0h/0h", self._show_screen(True)[0])
+        # it must not have joined the scope - still prompts every time
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/85h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_different_account_out_of_scope_prompts(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        for bad in ["m/84h/1h/0h", "m/85h/0h/0h", "m", "m/0h"]:
+            show_screen, seen = self._show_screen(True)
+            self._xpub(bad, show_screen)
+            self.assertEqual(len(seen), 1, "expected a prompt for %r" % bad)
+
+    def test_prefix_child_is_not_silently_authorized(self):
+        self._begin("m/84h/0h/1h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/1h/999h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    # ---- budget: consumable, single-use permissions ----
+
+    def test_repeated_request_for_consumed_path_reprompts(self):
+        self._begin("m/84h/0h/0h", self._show_screen(True)[0])
+        show_screen1, seen1 = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen1)
+        self.assertEqual(seen1, [])
+        # second request for the same, already-consumed path
+        show_screen2, seen2 = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen2)
+        self.assertEqual(len(seen2), 1)
+
+    def test_authorization_ends_after_full_consumption(self):
+        self._begin("m/84h/0h/{0-1}h", self._show_screen(True)[0])
+        self._xpub("m/84h/0h/0h", self._show_screen(True)[0])
+        self.assertIsNotNone(self.app._authorization)
+        self._xpub("m/84h/0h/1h", self._show_screen(True)[0])
+        self.assertIsNone(self.app._authorization)
+
+    # ---- explicit end ----
+
+    def test_end_clears_authorization(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        self.assertTrue(self._end(self._show_screen(True)[0]))
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_end_without_active_authorization_is_a_noop_success(self):
+        self.assertTrue(self._end(self._show_screen(True)[0]))
+
+    # ---- a second begin replaces, never merges ----
+
+    def test_second_begin_replaces_after_fresh_confirmation(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        self._begin("m/86h/0h/{0-9}h", self._show_screen(True)[0])
+        # old scope no longer authorized
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+        # new scope is
+        show_screen2, seen2 = self._show_screen(True)
+        self._xpub("m/86h/0h/0h", show_screen2)
+        self.assertEqual(seen2, [])
+
+    def test_cancelled_second_begin_keeps_first_authorization(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        res = self._begin("m/86h/0h/{0-9}h", self._show_screen(False)[0])
+        self.assertFalse(res)
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(seen, [])
+
+    # ---- invalidation ----
+
+    def test_lock_clears_authorization(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        self.app.on_lock()
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_network_switch_clears_authorization(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        self.app.init(self.keystore, "test", self.app.show_loader, self.app.communicate)
+        self.app.init(self.keystore, "main", self.app.show_loader, self.app.communicate)
+        # back on the original network, but the authorization is gone -
+        # the very same path that used to be in-scope must re-prompt
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_network_switch_invalidates_even_when_authorization_object_survives(self):
+        # defense in depth: directly exercise the network check inside
+        # try_consume, independent of the init()-triggered reset above
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        auth = self.app._authorization
+        self.assertIsNotNone(auth)
+        auth.network = "test"  # simulate a stale authorization surviving
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_reinit_same_network_clears_authorization(self):
+        # covers seed reload / passphrase change / storage switch, which
+        # all funnel through init()
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        self.app.init(self.keystore, "main", self.app.show_loader, self.app.communicate)
+        show_screen, seen = self._show_screen(True)
+        self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    # ---- cancellation never leaks xpubs ----
+
+    def test_out_of_scope_cancel_leaks_nothing(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(False)
+        res = self._xpub("m/84h/0h/50h", show_screen)
+        self.assertFalse(res)
+
+    # ---- fingerprint is unaffected by any of this ----
+
+    def test_fingerprint_stays_non_interactive_with_active_authorization(self):
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"fingerprint")
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        result_stream, meta = res
+        self.assertEqual(result_stream.read().decode(), hexlify(self.keystore.fingerprint).decode())
+        self.assertEqual(seen, [])
+
+
+class Bip138LikeIntegrationTest(TestCase):
+    """End-to-end walk-through of the motivating BIP-0138 use case:
+    one authorization confirmation, many silent per-path lookups,
+    an early stop, then an explicit end."""
+
+    def setUp(self):
+        clear_testdir()
+        self.keystore = get_keystore()
+        self.app = get_xpubs_app(self.keystore, "main")
+
+    def tearDown(self):
+        clear_testdir()
+        gc.collect()
+
+    def _show_screen(self, response):
+        seen = []
+
+        async def show_screen(scr):
+            seen.append(scr)
+            return response
+
+        return show_screen, seen
+
+    def _run(self, coro):
+        try:
+            coro.send(None)
+        except StopIteration as e:
+            return e.value
+        raise AssertionError("coroutine did not complete in one step")
+
+    def test_full_bip138_like_flow(self):
+        # 1: fingerprint without UI
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"fingerprint")
+        self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])
+
+        # 2-5: one authorization confirmation for the discovery scope
+        scope = ";".join([
+            "m/44h/0h/{0-9}h", "m/49h/0h/{0-9}h", "m/84h/0h/{0-9}h",
+            "m/86h/0h/{0-9}h", "m/87h/0h/{0-9}h",
+            "m/48h/0h/{0-9}h/1h", "m/48h/0h/{0-9}h/2h",
+        ])
+        begin_show, begin_seen = self._show_screen(True)
+        stream = BytesIO(b"xpubauth begin " + scope.encode())
+        self.assertTrue(self._run(self.app.process_host_command(stream, begin_show)))
+        self.assertEqual(len(begin_seen), 1)
+
+        # 6-8: sequential per-path lookups with no further prompts
+        for path in ["m/84h/0h/0h", "m/84h/0h/1h", "m/49h/0h/0h"]:
+            show_screen, seen = self._show_screen(True)
+            stream = BytesIO(b"xpub " + path.encode())
+            res = self._run(self.app.process_host_command(stream, show_screen))
+            result_stream, meta = res
+            expected = self.keystore.get_xpub(path).to_base58(NETWORKS["main"]["xpub"])
+            self.assertEqual(result_stream.read().decode(), expected)
+            self.assertEqual(seen, [])
+
+        # 9: recovery "succeeds" and stops early - the remaining ~67
+        # authorized paths are simply never requested
+
+        # 10: host ends the authorization explicitly
+        end_show, _ = self._show_screen(True)
+        stream = BytesIO(b"xpubauth end")
+        self.assertTrue(self._run(self.app.process_host_command(stream, end_show)))
+
+        # 11: a formerly in-scope path requires normal confirmation again
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/2h")
+        self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(len(seen), 1)

--- a/test/tests_native/test_xpubauth_host_command.py
+++ b/test/tests_native/test_xpubauth_host_command.py
@@ -282,6 +282,15 @@ class XpubAuthHostCommandTest(TestCase):
             self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(seen, [])
 
+    def test_malformed_xpub_path_raises_apperror_not_bare_exception(self):
+        from app import AppError
+        show_screen, seen = self._show_screen(True)
+        for bad in (b"m/84h/zz", b"m/84h//0h", b"\xff\xfe not utf-8"):
+            stream = BytesIO(b"xpub " + bad)
+            with self.assertRaises(AppError):
+                self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])
+
     # ---- invalidation ----
 
     def test_lock_clears_authorization(self):

--- a/test/tests_native/test_xpubauth_host_command.py
+++ b/test/tests_native/test_xpubauth_host_command.py
@@ -188,10 +188,22 @@ class XpubAuthHostCommandTest(TestCase):
 
     def test_different_account_out_of_scope_prompts(self):
         self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
-        for bad in ["m/84h/1h/0h", "m/85h/0h/0h", "m", "m/0h"]:
+        for bad in ["m/85h/0h/0h", "m", "m/0h"]:
             show_screen, seen = self._show_screen(True)
             self._xpub(bad, show_screen)
             self.assertEqual(len(seen), 1, "expected a prompt for %r" % bad)
+
+    def test_out_of_scope_wrong_network_path_is_refused_not_prompted(self):
+        # a testnet-style path is out of the (mainnet) authorized scope,
+        # but it's also a network mismatch on this "main" device - that
+        # takes precedence over the usual "just ask" fallback: refused
+        # outright, never shown as a normal Confirm/Cancel prompt
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        show_screen, seen = self._show_screen(True)
+        with self.assertRaises(Exception):
+            self._xpub("m/84h/1h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+        self.assertNotIsInstance(seen[0], Prompt)
 
     def test_prefix_child_is_not_silently_authorized(self):
         self._begin("m/84h/0h/1h", self._show_screen(True)[0])

--- a/test/tests_native/test_xpubauth_host_command.py
+++ b/test/tests_native/test_xpubauth_host_command.py
@@ -11,6 +11,7 @@ from binascii import hexlify
 import gc
 
 from tests.util import get_keystore, get_xpubs_app, clear_testdir
+from apps.xpubs.xpubs import MAX_XPUB_PATH_LEN
 from embit import bip32
 from embit.liquid.networks import NETWORKS
 from gui.screens import Prompt
@@ -243,12 +244,42 @@ class XpubAuthHostCommandTest(TestCase):
         self._xpub("m/86h/0h/0h", show_screen2)
         self.assertEqual(seen2, [])
 
-    def test_cancelled_second_begin_keeps_first_authorization(self):
+    def test_cancelled_second_begin_revokes_first_authorization(self):
+        # fail closed: a new begin drops the old authorization up front,
+        # so cancelling the new request leaves NO authorization active
         self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
         res = self._begin("m/86h/0h/{0-9}h", self._show_screen(False)[0])
         self.assertFalse(res)
+        self.assertIsNone(self.app._authorization)
         show_screen, seen = self._show_screen(True)
         self._xpub("m/84h/0h/0h", show_screen)
+        self.assertEqual(len(seen), 1)
+
+    def test_invalid_second_begin_revokes_first_authorization(self):
+        # a malformed replacement scope also leaves no authorization
+        self._begin("m/84h/0h/{0-9}h", self._show_screen(True)[0])
+        with self.assertRaises(Exception):
+            self._begin("garbage", self._show_screen(True)[0])
+        self.assertIsNone(self.app._authorization)
+
+    # ---- host input is bounded before it is decoded/parsed ----
+
+    def test_oversized_xpubauth_request_rejected_before_parsing(self):
+        from apps.xpubs import scope as scope_mod
+        # a valid-looking prefix followed by megabytes of padding
+        huge = "begin m/84h/0h/0h" + ("A" * (scope_mod.MAX_SCOPE_COMMAND_LEN + 4096))
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpubauth " + huge.encode())
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])
+        self.assertIsNone(self.app._authorization)
+
+    def test_oversized_xpub_path_rejected_before_parsing(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/" + b"1" * (MAX_XPUB_PATH_LEN + 4096))
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(seen, [])
 
     # ---- invalidation ----

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -153,6 +153,7 @@ class XpubsHostCommandTest(TestCase):
             self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(len(seen), 1)
         self.assertTrue(self._is_mismatch_screen(seen[0]))
+        self.assertNotIsInstance(seen[0], Prompt)
 
     def test_xpub_wrong_network_error_names_the_active_network(self):
         show_screen, seen = self._show_screen(False)
@@ -184,32 +185,26 @@ class XpubsHostCommandTest(TestCase):
         message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
         self.assertIn("Mainnet", message)
 
-    def test_xpub_wrong_network_offers_a_network_settings_button(self):
+    def test_xpub_wrong_network_screen_is_a_plain_dismiss_no_action_button(self):
+        # the screen only informs and dismisses - it deliberately does not
+        # offer a jump-to-network-settings action (see the UX note in
+        # xpubs.py); a single button, and no confirm/cancel pair
         show_screen, seen = self._show_screen(False)
         stream = BytesIO(b"xpub m/84h/0h/0h")
         with self.assertRaises(Exception):
             self._run(self.app.process_host_command(stream, show_screen))
-        self.assertEqual(seen[0].kwargs.get("confirm_text"), "Network settings")
+        self.assertIsNone(seen[0].kwargs.get("confirm_text"))
+        self.assertIsNone(seen[0].kwargs.get("cancel_text"))
 
-    def test_xpub_wrong_network_button_signals_a_network_switch(self):
-        # tapping "Network settings" raises NetworkSwitchRequested so
-        # Specter can open the picker; the host still gets the failure
-        from app import NetworkSwitchRequested
-
-        show_screen, seen = self._show_screen(True)  # tap "Network settings"
-        stream = BytesIO(b"xpub m/84h/0h/0h")
-        with self.assertRaises(NetworkSwitchRequested) as ctx:
-            self._run(self.app.process_host_command(stream, show_screen))
-        self.assertIn("network mismatch", ctx.exception.host_message)
-
-    def test_xpub_wrong_network_ok_button_does_not_signal_a_switch(self):
-        from app import NetworkSwitchRequested
-
-        show_screen, seen = self._show_screen(False)  # tap "OK"
-        stream = BytesIO(b"xpub m/84h/0h/0h")
-        with self.assertRaises(Exception) as ctx:
-            self._run(self.app.process_host_command(stream, show_screen))
-        self.assertNotIsInstance(ctx.exception, NetworkSwitchRequested)
+    def test_xpub_wrong_network_still_refuses_whatever_the_user_taps(self):
+        # the informational screen has one button; tapping it (whatever
+        # value it returns) must still surface the machine-parseable error
+        for response in (True, False):
+            show_screen, seen = self._show_screen(response)
+            stream = BytesIO(b"xpub m/84h/0h/0h")
+            with self.assertRaises(Exception) as ctx:
+                self._run(self.app.process_host_command(stream, show_screen))
+            self.assertIn("network mismatch: device is on test", str(ctx.exception))
 
     def test_xpub_wrong_network_never_reaches_derivation_confirm(self):
         # dismissing with "OK" must not fall through to the normal prompt

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -168,6 +168,17 @@ class XpubsHostCommandTest(TestCase):
         self.assertIn("m/48h/0h/7h/2h", message)
         self.assertIn(NETWORKS["test"]["name"], message)
 
+    def test_xpub_wrong_network_alert_names_the_target_network(self):
+        # app is on "test"; a mainnet-coin-type request should be told to
+        # switch to Mainnet, by name
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        shown = seen[0]
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        self.assertIn("Mainnet", message)
+
     def test_xpub_wrong_network_never_reaches_derivation_confirm(self):
         # a Cancel/Confirm answer of True must not matter - the request is
         # refused before the normal Prompt is even shown

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -191,19 +191,25 @@ class XpubsHostCommandTest(TestCase):
             self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(seen[0].kwargs.get("confirm_text"), "Network settings")
 
-    def test_xpub_wrong_network_button_opens_the_network_picker(self):
-        sent = []
+    def test_xpub_wrong_network_button_signals_a_network_switch(self):
+        # tapping "Network settings" raises NetworkSwitchRequested so
+        # Specter can open the picker; the host still gets the failure
+        from app import NetworkSwitchRequested
 
-        async def rec_communicate(stream, app=None, **kw):
-            sent.append((stream.read(), app))
-            return None
-
-        self.app.communicate = rec_communicate
         show_screen, seen = self._show_screen(True)  # tap "Network settings"
         stream = BytesIO(b"xpub m/84h/0h/0h")
-        with self.assertRaises(Exception):
+        with self.assertRaises(NetworkSwitchRequested) as ctx:
             self._run(self.app.process_host_command(stream, show_screen))
-        self.assertEqual(sent, [(b"select_network", "")])
+        self.assertIn("network mismatch", ctx.exception.host_message)
+
+    def test_xpub_wrong_network_ok_button_does_not_signal_a_switch(self):
+        from app import NetworkSwitchRequested
+
+        show_screen, seen = self._show_screen(False)  # tap "OK"
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with self.assertRaises(Exception) as ctx:
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertNotIsInstance(ctx.exception, NetworkSwitchRequested)
 
     def test_xpub_wrong_network_never_reaches_derivation_confirm(self):
         # dismissing with "OK" must not fall through to the normal prompt

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -65,11 +65,11 @@ class XpubsHostCommandTest(TestCase):
 
     def test_xpub_approved_matches_direct_derivation(self):
         show_screen, seen = self._show_screen(True)
-        stream = BytesIO(b"xpub m/84h/0h/0h")
+        stream = BytesIO(b"xpub m/84h/1h/0h")
         res = self._run(self.app.process_host_command(stream, show_screen))
         self.assertIsNotNone(res)
         result_stream, meta = res
-        expected = self.keystore.get_xpub("m/84h/0h/0h").to_base58(
+        expected = self.keystore.get_xpub("m/84h/1h/0h").to_base58(
             NETWORKS["test"]["xpub"]
         )
         self.assertEqual(result_stream.read().decode(), expected)
@@ -78,35 +78,35 @@ class XpubsHostCommandTest(TestCase):
 
     def test_xpub_rejected_returns_no_xpub(self):
         show_screen, seen = self._show_screen(False)
-        stream = BytesIO(b"xpub m/84h/0h/0h")
+        stream = BytesIO(b"xpub m/84h/1h/0h")
         res = self._run(self.app.process_host_command(stream, show_screen))
         self.assertFalse(res)
         self.assertEqual(len(seen), 1)
 
     def test_confirmation_shows_requested_path_first_case(self):
         show_screen, seen = self._show_screen(False)
-        stream = BytesIO(b"xpub m/84h/0h/0h")
+        stream = BytesIO(b"xpub m/84h/1h/0h")
         self._run(self.app.process_host_command(stream, show_screen))
         shown = seen[0]
         message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
-        self.assertIn("m/84h/0h/0h", message)
+        self.assertIn("m/84h/1h/0h", message)
 
     def test_confirmation_shows_requested_path_second_case(self):
         show_screen, seen = self._show_screen(False)
-        stream = BytesIO(b"xpub m/48h/0h/7h/2h")
+        stream = BytesIO(b"xpub m/48h/1h/7h/2h")
         self._run(self.app.process_host_command(stream, show_screen))
         shown = seen[0]
         message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
-        self.assertIn("m/48h/0h/7h/2h", message)
-        self.assertNotIn("m/84h/0h/0h", message)
+        self.assertIn("m/48h/1h/7h/2h", message)
+        self.assertNotIn("m/84h/1h/0h", message)
 
     def test_confirmation_shows_actual_xpub_value(self):
         show_screen, seen = self._show_screen(False)
-        stream = BytesIO(b"xpub m/84h/0h/0h")
+        stream = BytesIO(b"xpub m/84h/1h/0h")
         self._run(self.app.process_host_command(stream, show_screen))
         shown = seen[0]
         message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
-        expected = self.keystore.get_xpub("m/84h/0h/0h").to_base58(
+        expected = self.keystore.get_xpub("m/84h/1h/0h").to_base58(
             NETWORKS["test"]["xpub"]
         )
         self.assertIn(expected, message)

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -176,7 +176,7 @@ class XpubsHostCommandTest(TestCase):
 
     def test_xpub_wrong_network_screen_names_the_target_network(self):
         # app is on "test"; a mainnet-coin-type request should be told to
-        # switch to Mainnet, by name
+        # switch to Mainnet, by name, and pointed at the settings
         show_screen, seen = self._show_screen(False)
         stream = BytesIO(b"xpub m/84h/0h/0h")
         with self.assertRaises(Exception):
@@ -184,6 +184,18 @@ class XpubsHostCommandTest(TestCase):
         shown = seen[0]
         message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
         self.assertIn("Mainnet", message)
+        self.assertIn("in the settings", message)
+
+    def test_xpub_wrong_network_screen_talks_about_an_xpub_not_a_key(self):
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        shown = seen[0]
+        title = shown.args[0] if shown.args else shown.kwargs.get("title", "")
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        self.assertIn("Xpub", title)
+        self.assertIn("Xpub", message)
 
     def test_xpub_wrong_network_screen_is_a_plain_dismiss_no_action_button(self):
         # the screen only informs and dismisses - it deliberately does not

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -14,7 +14,7 @@ import gc
 from tests.util import get_keystore, get_xpubs_app, clear_testdir
 from embit import bip32
 from embit.liquid.networks import NETWORKS
-from gui.screens import Prompt
+from gui.screens import Alert, Prompt
 
 
 class XpubsHostCommandTest(TestCase):
@@ -136,3 +136,64 @@ class XpubsHostCommandTest(TestCase):
         with self.assertRaises(Exception):
             self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(seen, [])
+
+    # self.app is on "test" (coin type 1'): a standard-purpose path with
+    # mainnet's coin type (0') must be refused outright - never shown as
+    # a normal "Share Xpub?" Confirm/Cancel prompt - and the host must get
+    # a machine-parseable reason back, not a silently-derived key.
+    def test_xpub_wrong_network_shows_alert_not_prompt(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(len(seen), 1)
+        self.assertIsInstance(seen[0], Alert)
+
+    def test_xpub_wrong_network_error_names_the_active_network(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        try:
+            self._run(self.app.process_host_command(stream, show_screen))
+            self.fail("expected an exception")
+        except Exception as e:
+            self.assertIn("test", str(e))
+
+    def test_xpub_wrong_network_alert_shows_path_and_active_network(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/48h/0h/7h/2h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        shown = seen[0]
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        self.assertIn("m/48h/0h/7h/2h", message)
+        self.assertIn(NETWORKS["test"]["name"], message)
+
+    def test_xpub_wrong_network_never_reaches_derivation_confirm(self):
+        # a Cancel/Confirm answer of True must not matter - the request is
+        # refused before the normal Prompt is even shown
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/49h/0h/0h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(len(seen), 1)
+
+    def test_xpub_matching_network_still_uses_normal_prompt(self):
+        # same standard purpose, but the coin type matches the app's
+        # active "test" network - normal Confirm/Cancel flow, unaffected
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/1h/0h")
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        self.assertIsNotNone(res)
+        self.assertEqual(len(seen), 1)
+        self.assertIsInstance(seen[0], Prompt)
+
+    def test_xpub_non_standard_purpose_is_never_network_checked(self):
+        # a non-standard/custom purpose carries no implied network
+        # semantics and must go through the normal prompt regardless of
+        # its second component
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/1234h/0h/0h")
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        self.assertIsNotNone(res)
+        self.assertEqual(len(seen), 1)
+        self.assertIsInstance(seen[0], Prompt)

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -137,6 +137,34 @@ class XpubsHostCommandTest(TestCase):
             self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(seen, [])
 
+    def test_excessively_deep_path_is_rejected_before_any_bip32_work(self):
+        # same depth cap the scoped parser enforces - a path past it is
+        # malformed / a derivation-DoS attempt and must fail before the
+        # xpub is derived or any screen is shown
+        from apps.xpubs import scope as xpubauth_scope
+
+        deep = "m/" + "/".join(["1h"] * (xpubauth_scope.MAX_PATH_DEPTH + 1))
+        show_screen, seen = self._show_screen(True)
+        with patch.object(
+            type(self.keystore), "get_xpub", side_effect=AssertionError("derived!")
+        ):
+            with self.assertRaises(Exception) as ctx:
+                self._run(
+                    self.app.process_host_command(
+                        BytesIO(("xpub " + deep).encode()), show_screen
+                    )
+                )
+        self.assertNotIsInstance(ctx.exception, AssertionError)
+        self.assertEqual(seen, [])
+
+    def test_path_at_the_depth_limit_is_still_accepted(self):
+        depth = 4  # m/48h/1h/0h/2h - a real multisig path, well within
+        stream = BytesIO(b"xpub m/48h/1h/0h/2h")
+        show_screen, seen = self._show_screen(True)
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        self.assertIsNotNone(res)
+        self.assertEqual(len(seen), 1)
+
     # self.app is on "test" (coin type 1'): a standard-purpose path with
     # mainnet's coin type (0') must be refused outright - never answered
     # with the normal "Share Xpub?" Confirm/Cancel - and the host must get
@@ -163,6 +191,19 @@ class XpubsHostCommandTest(TestCase):
             self.fail("expected an exception")
         except Exception as e:
             self.assertIn("test", str(e))
+
+    def test_xpub_wrong_network_is_caught_before_the_xpub_is_derived(self):
+        # the network check must gate the derivation, not the other way
+        # round - if get_xpub() were reached it would blow up here
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with patch.object(
+            type(self.keystore), "get_xpub", side_effect=AssertionError("derived!")
+        ):
+            with self.assertRaises(Exception) as ctx:
+                self._run(self.app.process_host_command(stream, show_screen))
+        self.assertNotIsInstance(ctx.exception, AssertionError)
+        self.assertIn("network mismatch", str(ctx.exception))
 
     def test_xpub_wrong_network_screen_shows_path_and_active_network(self):
         show_screen, seen = self._show_screen(False)

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -14,7 +14,7 @@ import gc
 from tests.util import get_keystore, get_xpubs_app, clear_testdir
 from embit import bip32
 from embit.liquid.networks import NETWORKS
-from gui.screens import Alert, Prompt
+from gui.screens import Prompt
 
 
 class XpubsHostCommandTest(TestCase):
@@ -138,19 +138,24 @@ class XpubsHostCommandTest(TestCase):
         self.assertEqual(seen, [])
 
     # self.app is on "test" (coin type 1'): a standard-purpose path with
-    # mainnet's coin type (0') must be refused outright - never shown as
-    # a normal "Share Xpub?" Confirm/Cancel prompt - and the host must get
+    # mainnet's coin type (0') must be refused outright - never answered
+    # with the normal "Share Xpub?" Confirm/Cancel - and the host must get
     # a machine-parseable reason back, not a silently-derived key.
-    def test_xpub_wrong_network_shows_alert_not_prompt(self):
-        show_screen, seen = self._show_screen(True)
+    @staticmethod
+    def _is_mismatch_screen(scr):
+        title = scr.args[0] if scr.args else scr.kwargs.get("title", "")
+        return "Host tried to get access" in title
+
+    def test_xpub_wrong_network_shows_the_refusal_screen_not_the_share_prompt(self):
+        show_screen, seen = self._show_screen(False)  # tap "OK"
         stream = BytesIO(b"xpub m/84h/0h/0h")
         with self.assertRaises(Exception):
             self._run(self.app.process_host_command(stream, show_screen))
         self.assertEqual(len(seen), 1)
-        self.assertIsInstance(seen[0], Alert)
+        self.assertTrue(self._is_mismatch_screen(seen[0]))
 
     def test_xpub_wrong_network_error_names_the_active_network(self):
-        show_screen, seen = self._show_screen(True)
+        show_screen, seen = self._show_screen(False)
         stream = BytesIO(b"xpub m/84h/0h/0h")
         try:
             self._run(self.app.process_host_command(stream, show_screen))
@@ -158,8 +163,8 @@ class XpubsHostCommandTest(TestCase):
         except Exception as e:
             self.assertIn("test", str(e))
 
-    def test_xpub_wrong_network_alert_shows_path_and_active_network(self):
-        show_screen, seen = self._show_screen(True)
+    def test_xpub_wrong_network_screen_shows_path_and_active_network(self):
+        show_screen, seen = self._show_screen(False)
         stream = BytesIO(b"xpub m/48h/0h/7h/2h")
         with self.assertRaises(Exception):
             self._run(self.app.process_host_command(stream, show_screen))
@@ -168,10 +173,10 @@ class XpubsHostCommandTest(TestCase):
         self.assertIn("m/48h/0h/7h/2h", message)
         self.assertIn(NETWORKS["test"]["name"], message)
 
-    def test_xpub_wrong_network_alert_names_the_target_network(self):
+    def test_xpub_wrong_network_screen_names_the_target_network(self):
         # app is on "test"; a mainnet-coin-type request should be told to
         # switch to Mainnet, by name
-        show_screen, seen = self._show_screen(True)
+        show_screen, seen = self._show_screen(False)
         stream = BytesIO(b"xpub m/84h/0h/0h")
         with self.assertRaises(Exception):
             self._run(self.app.process_host_command(stream, show_screen))
@@ -179,10 +184,30 @@ class XpubsHostCommandTest(TestCase):
         message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
         self.assertIn("Mainnet", message)
 
+    def test_xpub_wrong_network_offers_a_network_settings_button(self):
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen[0].kwargs.get("confirm_text"), "Network settings")
+
+    def test_xpub_wrong_network_button_opens_the_network_picker(self):
+        sent = []
+
+        async def rec_communicate(stream, app=None, **kw):
+            sent.append((stream.read(), app))
+            return None
+
+        self.app.communicate = rec_communicate
+        show_screen, seen = self._show_screen(True)  # tap "Network settings"
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(sent, [(b"select_network", "")])
+
     def test_xpub_wrong_network_never_reaches_derivation_confirm(self):
-        # a Cancel/Confirm answer of True must not matter - the request is
-        # refused before the normal Prompt is even shown
-        show_screen, seen = self._show_screen(True)
+        # dismissing with "OK" must not fall through to the normal prompt
+        show_screen, seen = self._show_screen(False)
         stream = BytesIO(b"xpub m/49h/0h/0h")
         with self.assertRaises(Exception):
             self._run(self.app.process_host_command(stream, show_screen))

--- a/test/tests_native/test_xpubs_host_command.py
+++ b/test/tests_native/test_xpubs_host_command.py
@@ -1,0 +1,138 @@
+import sys
+
+if sys.implementation.name != 'micropython':
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+from unittest import TestCase
+from unittest.mock import patch, PropertyMock
+from io import BytesIO
+from binascii import hexlify
+import gc
+
+from tests.util import get_keystore, get_xpubs_app, clear_testdir
+from embit import bip32
+from embit.liquid.networks import NETWORKS
+from gui.screens import Prompt
+
+
+class XpubsHostCommandTest(TestCase):
+    def setUp(self):
+        clear_testdir()
+        self.keystore = get_keystore()
+        self.app = get_xpubs_app(self.keystore, "test")
+
+    def tearDown(self):
+        clear_testdir()
+        gc.collect()
+
+    def _show_screen(self, response):
+        seen = []
+
+        async def show_screen(scr):
+            seen.append(scr)
+            return response
+
+        return show_screen, seen
+
+    def _run(self, coro):
+        try:
+            coro.send(None)
+        except StopIteration as e:
+            return e.value
+        raise AssertionError("coroutine did not complete in one step")
+
+    def test_locked_device_rejects_xpub_request(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        with patch.object(
+            type(self.keystore), "is_locked", new_callable=PropertyMock, return_value=True
+        ):
+            with self.assertRaises(Exception):
+                self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])
+
+    def test_locked_device_rejects_fingerprint_request(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"fingerprint")
+        with patch.object(
+            type(self.keystore), "is_locked", new_callable=PropertyMock, return_value=True
+        ):
+            with self.assertRaises(Exception):
+                self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])
+
+    def test_xpub_approved_matches_direct_derivation(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        self.assertIsNotNone(res)
+        result_stream, meta = res
+        expected = self.keystore.get_xpub("m/84h/0h/0h").to_base58(
+            NETWORKS["test"]["xpub"]
+        )
+        self.assertEqual(result_stream.read().decode(), expected)
+        self.assertEqual(len(seen), 1)
+        self.assertIsInstance(seen[0], Prompt)
+
+    def test_xpub_rejected_returns_no_xpub(self):
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        self.assertFalse(res)
+        self.assertEqual(len(seen), 1)
+
+    def test_confirmation_shows_requested_path_first_case(self):
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        self._run(self.app.process_host_command(stream, show_screen))
+        shown = seen[0]
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        self.assertIn("m/84h/0h/0h", message)
+
+    def test_confirmation_shows_requested_path_second_case(self):
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/48h/0h/7h/2h")
+        self._run(self.app.process_host_command(stream, show_screen))
+        shown = seen[0]
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        self.assertIn("m/48h/0h/7h/2h", message)
+        self.assertNotIn("m/84h/0h/0h", message)
+
+    def test_confirmation_shows_actual_xpub_value(self):
+        show_screen, seen = self._show_screen(False)
+        stream = BytesIO(b"xpub m/84h/0h/0h")
+        self._run(self.app.process_host_command(stream, show_screen))
+        shown = seen[0]
+        message = shown.args[1] if len(shown.args) > 1 else shown.kwargs.get("message")
+        expected = self.keystore.get_xpub("m/84h/0h/0h").to_base58(
+            NETWORKS["test"]["xpub"]
+        )
+        self.assertIn(expected, message)
+
+    def test_fingerprint_returns_immediately_without_confirmation(self):
+        # fingerprint is used for non-interactive device discovery/
+        # identification by companion software and must never prompt
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"fingerprint")
+        res = self._run(self.app.process_host_command(stream, show_screen))
+        self.assertIsNotNone(res)
+        result_stream, meta = res
+        expected = hexlify(self.keystore.fingerprint).decode()
+        self.assertEqual(result_stream.read().decode(), expected)
+        self.assertEqual(seen, [])
+
+    def test_invalid_derivation_fails_before_confirmation(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub garbage")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])
+
+    def test_empty_path_fails_before_confirmation(self):
+        show_screen, seen = self._show_screen(True)
+        stream = BytesIO(b"xpub ")
+        with self.assertRaises(Exception):
+            self._run(self.app.process_host_command(stream, show_screen))
+        self.assertEqual(seen, [])


### PR DESCRIPTION
## Summary

`XpubApp.process_host_command()` returned the master fingerprint or an
XPUB at any host-selected derivation path immediately once the device was
unlocked, with no trusted-screen confirmation. Any process on the
connected computer that can reach the serial port could silently
enumerate the wallet fingerprint and every XPUB, and from those the
wallet's addresses and balance.

- **`fingerprint` stays non-interactive** — companion software (Specter
  Desktop, Liana) uses it for passive device discovery/identification.
  Still gated by the unchanged locked-device check.
- **`xpub <path>` now requires an on-device Confirm/Cancel**, showing the
  normalized derivation path and the exact XPUB that would be returned.
  Reject returns no key material (`error: User cancelled`).
- **`xpubauth begin <scope>` / `xpubauth end`** — one on-device
  confirmation authorizes a **bounded, explicitly enumerated** set of
  derivation paths (e.g. the four standard account keys, or a
  BIP-138-style discovery scope). Afterwards `xpub <path>` requests that
  fall inside the approved scope are answered without a further prompt,
  **each authorized path exactly once**; anything outside keeps prompting
  individually. The authorization is RAM-only, network-bound, and cleared
  on `xpubauth end` / lock / re-init / network change / self-exhaustion /
  a new `begin`. See `docs/communication.md` for the full grammar and
  lifecycle. This keeps the confirm-by-default privacy property while
  making multi-key import practical (N prompts → 1).
- **Wrong-network requests are refused.** A standard-purpose path
  (44'/48'/49'/84'/86'/87') whose coin type doesn't match the network the
  device is on can never be legitimately shared from there — the same
  rule an `xpubauth` scope is held to, also enforced for individual
  requests. The device shows a screen naming the requested derivation,
  the active network, and by name the network to switch to (`0'` →
  Mainnet, `1776'` → Liquid, `1'` → "Testnet, Signet or Regtest"). The
  host gets `error: network mismatch: device is on <network>`.
- **Input is bounded.** The `xpub` / `xpubauth` payloads are capped
  (`MAX_XPUB_PATH_LEN` / `MAX_SCOPE_COMMAND_LEN`) as they're read, before
  `.decode()`, and the parsed path depth is capped (`MAX_PATH_DEPTH`)
  before any BIP32 derivation. Path parsing catches only
  `(ValueError, IndexError)` instead of a bare `except`.
- `hwidevice.py` (this repo's bundled reference HWI client) drops the 3s
  timeout on `get_pubkey_at_path()` (a human confirms now) and gains
  `authorize_xpubs()` / `end_xpub_authorization()`. `get_master_fingerprint`
  keeps its short timeout. Signing is untouched.

## Companion-repo compatibility

- **Specter Desktop:** cryptoadvance/specter-desktop#2702 — matching
  timeout removal, wires up `xpubauth begin/end` for a single
  confirmation across the standard key set, and turns the `network
  mismatch` error into a "switch the device to X" message.
- **async-hwi:** wizardsardine/async-hwi#139 — maps a cancelled `xpub`
  request to `UserCancelled`/`UserRefused`.
- Older companion software is unaffected — it keeps sending individual
  `xpub <path>` requests, each confirmed on its own.

## Test plan

- [x] `test/run_native_tests.py` — 121/121, incl.
  `test_xpubs_host_command.py`, `test_xpub_scope.py`,
  `test_xpubauth_host_command.py` (scope grammar, range/overlap
  rejection, network binding, single-use consumption, self-exhaustion,
  fail-closed on replacement `begin`, cancel leaves no authorization,
  wrong-network refusal).
- [x] `make disco` builds clean (CI "Build Firmware").
- [x] Real STM32F469 Discovery hardware, over USB-serial and end-to-end
  through Specter Desktop's "Get via USB": one `xpubauth begin`
  confirmation, then the standard keys returned without further prompts;
  device on Mainnet / Regtest / Liquid — matching-coin-type request
  returns the key, wrong-network request shows the refusal screen and
  returns `error: network mismatch: device is on <net>`.
