### PR TITLE
Fix incomplete secure wipe of QSPI flash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,21 @@ on:
 
 jobs:
   build:
-    name: Build Firmware
+    name: Build Firmware (USE_DBOOT=${{ matrix.use_dboot }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # USE_DBOOT=0 is the Makefile default; USE_DBOOT=1 is what
+        # build_firmware.sh actually ships to real devices (`make disco
+        # USE_DBOOT=1`) and leaves less flash for FLASH_TEXT (1664 KiB vs
+        # 1920 KiB), so both are built here rather than only the default.
+        use_dboot: [0, 1]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
 
@@ -29,15 +37,16 @@ jobs:
             nix-${{ runner.os }}-
 
       - name: Build Unix simulator
+        if: matrix.use_dboot == 0
         run: nix develop -c make unix
 
       - name: Build STM32F469 Discovery firmware
-        run: nix develop -c make disco
+        run: nix develop -c make disco USE_DBOOT=${{ matrix.use_dboot }}
 
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-binaries
+          name: firmware-binaries-dboot${{ matrix.use_dboot }}
           path: |
             bin/specter-diy.bin
             bin/specter-diy.hex

--- a/docs/flash-block-map.md
+++ b/docs/flash-block-map.md
@@ -4,8 +4,11 @@ Verified block map of `pyb.Flash()` on the STM32F469 Discovery board, as built b
 Specter's firmware (`make disco USE_DBOOT=1`). `pyb.Flash()` (no args) exposes the
 whole board's storage as one block device addressed with these **absolute** block
 numbers. This is the ground truth behind the `*_BLOCK` constants in `src/platform.py`
-(`INTERNAL_FLASH_START_BLOCK`, `INTERNAL_FLASH_END_BLOCK`, `QSPI_START_BLOCK`,
-`QSPI_END_BLOCK`) and behind what `platform.wipe()` overwrites.
+(`INTERNAL_FLASH_START_BLOCK`, `INTERNAL_FLASH_END_BLOCK`, `QSPI_START_BLOCK`) and
+behind what `platform.wipe()` overwrites. Note that the block size and the end of the
+QSPI region are deliberately **not** constants: `wipe()` reads both back from the block
+device with `ioctl()`, so only the split point between the two filesystems is stated in
+the code.
 
 | Blocks        | Region                                   | Notes |
 |---------------|-------------------------------------------|-------|
@@ -38,10 +41,11 @@ driver.
 ## Keeping this current
 
 These submodule pins can move independently of this file. If `f469-disco` or the
-MicroPython fork is updated, re-check the sources above before trusting this table -
-`platform.wipe()` also runs a runtime geometry check (`f.ioctl()` block size/count
-against `FLASH_BLOCK_SIZE`/`QSPI_END_BLOCK`) and refuses to wipe on a mismatch, but
-that check can't catch every possible drift (e.g. a shifted split point that still
-adds up to the same total block count). See also the tracking issue to expose the
-partition boundary as a proper runtime API instead of a hard-coded constant:
-[diybitcoinhardware/f469-disco - Expose flash partition boundary via a queryable API](https://github.com/diybitcoinhardware/f469-disco/issues).
+MicroPython fork is updated, re-check the sources above before trusting this table.
+Block size and total block count drift is handled automatically, because `wipe()` takes
+both from the device. The split point is the part that cannot be read back: `wipe()`
+only sanity-checks that the device extends past it and refuses to touch anything if it
+does not, which will not catch a shifted split point that still leaves the total block
+count plausible. See the tracking issue to expose the partition boundary as a proper
+runtime API instead of a hard-coded constant:
+[diybitcoinhardware/f469-disco#44](https://github.com/diybitcoinhardware/f469-disco/issues/44).

--- a/docs/flash-block-map.md
+++ b/docs/flash-block-map.md
@@ -1,0 +1,47 @@
+# Flash Block Map (STM32F469 Discovery)
+
+Verified block map of `pyb.Flash()` on the STM32F469 Discovery board, as built by
+Specter's firmware (`make disco USE_DBOOT=1`). `pyb.Flash()` (no args) exposes the
+whole board's storage as one block device addressed with these **absolute** block
+numbers. This is the ground truth behind the `*_BLOCK` constants in `src/platform.py`
+(`INTERNAL_FLASH_START_BLOCK`, `INTERNAL_FLASH_END_BLOCK`, `QSPI_START_BLOCK`,
+`QSPI_END_BLOCK`) and behind what `platform.wipe()` overwrites.
+
+| Blocks        | Region                                   | Notes |
+|---------------|-------------------------------------------|-------|
+| 0             | software-emulated MBR (`storage.c:storage_read/write_block`) | not backed by real flash - writes to it are silently discarded by the block device |
+| 1 – 255       | unmapped                                   | not part of any partition; `writeblocks()` on these fails (`storage_write_block()` returns false -> `-EIO`). Physically these blocks fall in the bootloader/ISR sector (`0x08000000`, 16K) and the reserved sector (`FLASH_RSV`, `0x08004000`, 16K) of `ports/stm32/boards/stm32f469xi_dboot.ld` - never reachable through this API regardless |
+| 256 – 447     | internal flash, the `/flash` filesystem    | `FLASH_PART1_START_BLOCK = 0x100` (`storage.h`); 192 blocks = 96 KiB, matching `FLASH_MEM_SEG1` (`flashbdev.c`, STM32F469xx: sectors 2-4, `0x08008000`), which is exactly the `FLASH_FS` region of `stm32f469xi_dboot.ld` - disjoint from `FLASH_TEXT` (the application firmware, sectors 5-21 starting at `0x08020000`) and from `FLASH_BOOT1`/`FLASH_BOOT2` (the bootloader slots, sectors 22-23) |
+| 448 – 33215   | external QSPI flash, the `/qspi` filesystem | `FLASH_PART2_START_BLOCK = FLASH_PART1_START_BLOCK + 192` (`storage.h`); 32768 blocks = 16 MiB, the full size of the on-board QSPI NOR flash chip (`MICROPY_HW_SPIFLASH_SIZE_BITS = 128 Mbit`, `boards/STM32F469DISC/mpconfigboard.h`) |
+
+## Why a raw overwrite actually destroys the data
+
+The QSPI chip is addressed as plain NOR flash - no wear-leveling, remapping or
+translation layer sits between the block numbers above and the physical sectors
+(see `spi_bdev_writeblocks()` / `mp_spiflash_cached_write()` in
+`ports/stm32/spibdev.c` and `drivers/memory/spiflash.c`), so overwriting every
+block in a range overwrites all addressable QSPI sectors, which prevents recovery
+through normal digital reads of the flash contents. (This says nothing about
+charge-remanence / decapping-level analog recovery, which is out of scope for this
+threat model.) Required sector-erase-before-write is handled transparently by that
+driver.
+
+## Sources checked
+
+- `diybitcoinhardware/f469-disco` (submodule pin `db3ce3e`)
+- `diybitcoinhardware/micropython` (submodule pin `6bdf1b6`)
+- `ports/stm32/{storage.h,storage.c,flashbdev.c,spibdev.c}`
+- `ports/stm32/boards/STM32F469DISC/{mpconfigboard.h,mpconfigboard.mk}`
+- `ports/stm32/boards/stm32f469xi_dboot.ld`
+- `drivers/memory/spiflash.c`
+
+## Keeping this current
+
+These submodule pins can move independently of this file. If `f469-disco` or the
+MicroPython fork is updated, re-check the sources above before trusting this table -
+`platform.wipe()` also runs a runtime geometry check (`f.ioctl()` block size/count
+against `FLASH_BLOCK_SIZE`/`QSPI_END_BLOCK`) and refuses to wipe on a mismatch, but
+that check can't catch every possible drift (e.g. a shifted split point that still
+adds up to the same total block count). See also the tracking issue to expose the
+partition boundary as a proper runtime API instead of a hard-coded constant:
+[diybitcoinhardware/f469-disco - Expose flash partition boundary via a queryable API](https://github.com/diybitcoinhardware/f469-disco/issues).

--- a/src/platform.py
+++ b/src/platform.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import pyb
-import gc
 
 simulator = (sys.platform in ["linux", "darwin"])
 
@@ -392,10 +391,13 @@ def reboot():
 # remapping or translation layer sits between the block numbers above and
 # the physical sectors (see spi_bdev_writeblocks()/mp_spiflash_cached_write()
 # in ports/stm32/spibdev.c and drivers/memory/spiflash.c), so overwriting
-# every block in a range does physically destroy the data that was there.
-# Required sector-erase-before-write is handled transparently by that
-# driver. Sources checked: diybitcoinhardware/f469-disco (submodule pin
-# db3ce3e), diybitcoinhardware/micropython (submodule pin 6bdf1b6),
+# every block in a range overwrites all addressable QSPI sectors, which
+# prevents recovery through normal digital reads of the flash contents
+# (this says nothing about charge-remanence/decapping-level analog
+# recovery, which is out of scope for this threat model). Required
+# sector-erase-before-write is handled transparently by that driver.
+# Sources checked: diybitcoinhardware/f469-disco (submodule pin db3ce3e),
+# diybitcoinhardware/micropython (submodule pin 6bdf1b6),
 # ports/stm32/{storage.h,storage.c,flashbdev.c,spibdev.c},
 # ports/stm32/boards/STM32F469DISC/{mpconfigboard.h,mpconfigboard.mk},
 # ports/stm32/boards/stm32f469xi_dboot.ld, drivers/memory/spiflash.c.
@@ -407,51 +409,75 @@ INTERNAL_FLASH_END_BLOCK = INTERNAL_FLASH_START_BLOCK + 192     # + FLASH_MEM_SE
 QSPI_START_BLOCK = INTERNAL_FLASH_END_BLOCK                     # FLASH_PART2_START_BLOCK
 QSPI_END_BLOCK = QSPI_START_BLOCK + 32768                       # + QSPI flash block count
 
-# How many blocks get freshly randomized data per writeblocks() call.
-# Kept small, and a multiple of the QSPI erase-sector size (8 blocks ==
-# 4096 bytes), so the wipe never needs a whole region's worth of RAM (up
-# to 16MiB for QSPI) at once.
+# How many blocks get overwritten per writeblocks() call. Kept small, and
+# a multiple of the QSPI erase-sector size (8 blocks == 4096 bytes), so
+# the wipe never needs a whole region's worth of RAM (up to 16MiB for
+# QSPI) at once.
 WIPE_CHUNK_BLOCKS = 16
 
-# extmod/vfs.h: MP_BLOCKDEV_IOCTL_SYNC. Both the internal-flash driver
-# (flashbdev.c) and the QSPI driver (drivers/memory/spiflash.c, built with
-# USE_WR_DELAY) keep a *write-behind* RAM cache: writeblocks() only
-# guarantees the data reaches that RAM cache, not the physical chip. The
-# cache is flushed to physical storage on a sector-boundary crossing, on
-# this ioctl, or - eventually - by a periodic background IRQ. Nothing
-# forces the very last sector each overwrite loop below touches to be
-# flushed before reboot() other than calling this ioctl explicitly, so
-# wipe() must do that itself: a hard reset with a still-dirty cache would
-# lose our random overwrite of that sector from RAM and leave the
-# original, pre-wipe bytes physically in place on the chip.
+# extmod/vfs.h: MP_BLOCKDEV_IOCTL_BLOCK_COUNT / MP_BLOCKDEV_IOCTL_SYNC.
+MP_BLOCKDEV_IOCTL_BLOCK_COUNT = 4
 MP_BLOCKDEV_IOCTL_SYNC = 3
+# Both the internal-flash driver (flashbdev.c) and the QSPI driver
+# (drivers/memory/spiflash.c, built with USE_WR_DELAY) keep a
+# *write-behind* RAM cache: writeblocks() only guarantees the data
+# reaches that RAM cache, not the physical chip. The cache is flushed to
+# physical storage on a sector-boundary crossing, on this ioctl, or -
+# eventually - by a periodic background IRQ. Nothing forces the very
+# last sector each overwrite loop below touches to be flushed before
+# reboot() other than calling this ioctl explicitly, so wipe() must do
+# that itself: a hard reset with a still-dirty cache would lose our
+# overwrite of that sector from RAM and leave the original, pre-wipe
+# bytes physically in place on the chip.
+#
+# Known limitation: on the QSPI path, a genuine erase/program failure
+# during that flush (in mp_spiflash_cache_flush_internal(), spiflash.c)
+# is not propagated up through mp_spiflash_cache_flush() -> the SYNC
+# ioctl -> here - the C driver clears its dirty flag and returns before
+# checking the erase/write result. The same applies to a sector-boundary
+# flush triggered mid-loop by a writeblocks() call. So a hardware write
+# failure at that level can go undetected by wipe() even though the
+# higher-level checks below (writeblocks()'s own return code, and the
+# geometry check below) still catch what they can. Fixing that requires
+# propagating real error codes through the pinned MicroPython fork's
+# QSPI driver - out of scope here.
 
 
 def _secure_overwrite_blocks(f, start_block, end_block, block_size,
                               chunk_blocks=WIPE_CHUNK_BLOCKS):
     """
     Overwrites blocks [start_block, end_block) of the raw flash block
-    device `f` with fresh random data, `chunk_blocks` blocks at a time,
-    so the whole region never needs to fit in RAM at once.
+    device `f` with a fixed zero pattern, `chunk_blocks` blocks at a
+    time, so the whole region never needs to fit in RAM at once.
+
+    Uses zeros rather than os.urandom(): the QSPI/internal-flash drivers
+    already erase (and thus fully overwrite) every sector they touch, so
+    randomness buys nothing against this threat model (a chip pulled off
+    the board and read directly) beyond what any fixed pattern gives -
+    while os.urandom() on this port draws one hardware RNG sample per
+    *byte* (ports/stm32/rng.c: ~10us each, 10ms timeout), which would
+    cost minutes just generating bytes for the 16 MiB QSPI region alone,
+    on top of the actual erase/program time. A single pre-built buffer is
+    reused (sliced for the final, possibly shorter chunk) instead of
+    allocating fresh memory every iteration.
 
     A failed chunk does not stop the wipe: we keep going so as much of
     the remaining sensitive data as possible still gets destroyed. But
     the return value reflects whether *every* chunk succeeded - callers
     must not treat a False result as if the region were fully wiped.
     """
+    zeros = bytes(chunk_blocks * block_size)
     ok = True
     block = start_block
     while block < end_block:
         n = min(chunk_blocks, end_block - block)
+        buf = zeros if n == chunk_blocks else zeros[:n * block_size]
         try:
-            buf = os.urandom(n * block_size)
             ret = f.writeblocks(block, buf)
-            del buf
             if ret:
                 ok = False
         except Exception:
             ok = False
-        gc.collect()
         block += n
     return ok
 
@@ -462,13 +488,34 @@ def wipe():
 
     Deletes the "/flash" and "/qspi" filesystems, and on real hardware
     also physically overwrites the underlying internal-flash and QSPI
-    block ranges (see the verified block map above) with fresh random
-    data. Logical file deletion alone is not enough: an attacker with
+    block ranges (see the verified block map above) with a fixed
+    pattern. Logical file deletion alone is not enough: an attacker with
     physical access to the external QSPI flash chip could still recover
     "deleted" files straight from it, since deleting a file only drops
     its filesystem entry - the QSPI chip itself is unaffected. Firmware,
     bootloader and reserved blocks are never touched.
     """
+    f = None
+    block_size = None
+    if not simulator:
+        # Check the actual flash geometry against what the block map
+        # above assumes, before deleting anything. The constants are
+        # correct for the hardware this was verified against, but if a
+        # future board revision, MicroPython fork update, or QSPI chip
+        # change ever shifted them, that mismatch could otherwise go
+        # unnoticed - the tests only check the code against itself, not
+        # against real hardware. Fail closed instead of guessing: refuse
+        # to touch either filesystem rather than wipe based on assumed
+        # boundaries that may no longer hold.
+        f = pyb.Flash()
+        block_size = f.ioctl(5, None)
+        block_count = f.ioctl(MP_BLOCKDEV_IOCTL_BLOCK_COUNT, None)
+        if block_size != FLASH_BLOCK_SIZE or block_count != QSPI_END_BLOCK:
+            raise RuntimeError(
+                "Unexpected flash geometry (block_size=%r, block_count=%r); "
+                "refusing to wipe" % (block_size, block_count)
+            )
+
     # delete files normally in simulator (best-effort on hardware too,
     # though the block overwrite below is what actually destroys data there)
     try:
@@ -476,7 +523,7 @@ def wipe():
         delete_recursively(fpath("/qspi"))
     except:
         pass
-    # on real hardware overwrite flash with random data
+    # on real hardware overwrite flash with a fixed pattern
     if not simulator:
         # /flash and /qspi are unmounted independently, and a failure on
         # either is tracked rather than swallowed: a clean unmount is what
@@ -497,9 +544,6 @@ def wipe():
         except Exception:
             qspi_unmount_ok = False
 
-        f = pyb.Flash()
-        block_size = f.ioctl(5, None)
-
         internal_ok = _secure_overwrite_blocks(
             f, INTERNAL_FLASH_START_BLOCK, INTERNAL_FLASH_END_BLOCK, block_size
         )
@@ -519,10 +563,9 @@ def wipe():
             # Whatever could be destroyed already has been (see
             # _secure_overwrite_blocks), but a partial wipe must never be
             # allowed to look like a successful one. Raise instead of
-            # rebooting so the caller's existing critical-error handling
-            # (CriticalErrorWipeImmediately / handle_exception in
-            # specter.py) surfaces the failure instead of silently
-            # trusting the device is clean.
+            # rebooting so the caller (specter.py's Specter.wipe_or_halt())
+            # surfaces the failure instead of silently trusting the device
+            # is clean.
             raise RuntimeError(
                 "Secure wipe failed to overwrite all flash blocks; "
                 "device may still contain recoverable data"

--- a/src/platform.py
+++ b/src/platform.py
@@ -413,6 +413,19 @@ QSPI_END_BLOCK = QSPI_START_BLOCK + 32768                       # + QSPI flash b
 # to 16MiB for QSPI) at once.
 WIPE_CHUNK_BLOCKS = 16
 
+# extmod/vfs.h: MP_BLOCKDEV_IOCTL_SYNC. Both the internal-flash driver
+# (flashbdev.c) and the QSPI driver (drivers/memory/spiflash.c, built with
+# USE_WR_DELAY) keep a *write-behind* RAM cache: writeblocks() only
+# guarantees the data reaches that RAM cache, not the physical chip. The
+# cache is flushed to physical storage on a sector-boundary crossing, on
+# this ioctl, or - eventually - by a periodic background IRQ. Nothing
+# forces the very last sector each overwrite loop below touches to be
+# flushed before reboot() other than calling this ioctl explicitly, so
+# wipe() must do that itself: a hard reset with a still-dirty cache would
+# lose our random overwrite of that sector from RAM and leave the
+# original, pre-wipe bytes physically in place on the chip.
+MP_BLOCKDEV_IOCTL_SYNC = 3
+
 
 def _secure_overwrite_blocks(f, start_block, end_block, block_size,
                               chunk_blocks=WIPE_CHUNK_BLOCKS):
@@ -465,14 +478,25 @@ def wipe():
         pass
     # on real hardware overwrite flash with random data
     if not simulator:
+        # /flash and /qspi are unmounted independently, and a failure on
+        # either is tracked rather than swallowed: a clean unmount is what
+        # flushes any write-behind cache left over from delete_recursively()
+        # above (see flashbdev.c/spiflash.c), and losing that guarantee is
+        # itself a reason not to trust the wipe. It does not, however, stop
+        # us from attempting the raw overwrite below - that's still the
+        # best available defense even if the unmount failed.
+        flash_unmount_ok = True
         try:
             os.umount("/flash")
-        except:
-            pass
+        except Exception:
+            flash_unmount_ok = False
+
+        qspi_unmount_ok = True
         try:
             os.umount("/qspi")
-        except:
-            pass
+        except Exception:
+            qspi_unmount_ok = False
+
         f = pyb.Flash()
         block_size = f.ioctl(5, None)
 
@@ -483,7 +507,15 @@ def wipe():
             f, QSPI_START_BLOCK, QSPI_END_BLOCK, block_size
         )
 
-        if not (internal_ok and qspi_ok):
+        # Force the write-behind cache out to physical flash now - see
+        # MP_BLOCKDEV_IOCTL_SYNC above for why this can't be skipped.
+        sync_ok = True
+        try:
+            f.ioctl(MP_BLOCKDEV_IOCTL_SYNC, None)
+        except Exception:
+            sync_ok = False
+
+        if not (flash_unmount_ok and qspi_unmount_ok and internal_ok and qspi_ok and sync_ok):
             # Whatever could be destroyed already has been (see
             # _secure_overwrite_blocks), but a partial wipe must never be
             # allowed to look like a successful one. Raise instead of

--- a/src/platform.py
+++ b/src/platform.py
@@ -356,51 +356,15 @@ def reboot():
         pyb.hard_reset()
 
 
-# Verified block map of pyb.Flash() on the STM32F469 Discovery board, as
-# built by Specter's firmware (make disco USE_DBOOT=1). pyb.Flash() (no
-# args) exposes the whole board's storage as one block device addressed
-# with these ABSOLUTE block numbers:
-#
-#   block 0            software-emulated MBR (storage.c:storage_read/
-#                       write_block); not backed by real flash - writes
-#                       to it are silently discarded by the block device
-#   blocks 1   - 255    unmapped: not part of any partition, writeblocks()
-#                       on these fails (storage_write_block() returns
-#                       false -> -EIO). Physically these blocks fall in
-#                       the bootloader/ISR sector (0x08000000, 16K) and
-#                       the reserved sector (FLASH_RSV, 0x08004000, 16K)
-#                       of ports/stm32/boards/stm32f469xi_dboot.ld - never
-#                       reachable through this API regardless
-#   blocks 256 - 447    internal flash, the "/flash" filesystem
-#                       (FLASH_PART1_START_BLOCK = 0x100, storage.h);
-#                       192 blocks = 96 KiB, matching FLASH_MEM_SEG1
-#                       (flashbdev.c, STM32F469xx: sectors 2-4, 0x08008000)
-#                       which is exactly the FLASH_FS region of
-#                       stm32f469xi_dboot.ld - disjoint from FLASH_TEXT
-#                       (the application firmware, sectors 5-21 starting
-#                       at 0x08020000) and from FLASH_BOOT1/FLASH_BOOT2
-#                       (the bootloader slots, sectors 22-23)
-#   blocks 448 - 33215  external QSPI flash, the "/qspi" filesystem
-#                       (FLASH_PART2_START_BLOCK = FLASH_PART1_START_BLOCK
-#                       + 192, storage.h); 32768 blocks = 16 MiB, the full
-#                       size of the on-board QSPI NOR flash chip
-#                       (MICROPY_HW_SPIFLASH_SIZE_BITS = 128 Mbit,
-#                       boards/STM32F469DISC/mpconfigboard.h)
-#
-# The QSPI chip is addressed as plain NOR flash - no wear-leveling,
-# remapping or translation layer sits between the block numbers above and
-# the physical sectors (see spi_bdev_writeblocks()/mp_spiflash_cached_write()
-# in ports/stm32/spibdev.c and drivers/memory/spiflash.c), so overwriting
-# every block in a range overwrites all addressable QSPI sectors, which
-# prevents recovery through normal digital reads of the flash contents
-# (this says nothing about charge-remanence/decapping-level analog
-# recovery, which is out of scope for this threat model). Required
-# sector-erase-before-write is handled transparently by that driver.
-# Sources checked: diybitcoinhardware/f469-disco (submodule pin db3ce3e),
-# diybitcoinhardware/micropython (submodule pin 6bdf1b6),
-# ports/stm32/{storage.h,storage.c,flashbdev.c,spibdev.c},
-# ports/stm32/boards/STM32F469DISC/{mpconfigboard.h,mpconfigboard.mk},
-# ports/stm32/boards/stm32f469xi_dboot.ld, drivers/memory/spiflash.c.
+# Verified block map of pyb.Flash() on the STM32F469 Discovery board
+# (make disco USE_DBOOT=1). Absolute block numbers:
+#   block 0            emulated MBR, not backed by real flash
+#   blocks 1   - 255    unmapped (bootloader/reserved sectors), never
+#                       reachable through this API
+#   blocks 256 - 447    internal flash, the "/flash" filesystem (96 KiB)
+#   blocks 448 - 33215  external QSPI flash, the "/qspi" filesystem (16 MiB)
+# Full derivation, source files checked and submodule pins:
+# see docs/flash-block-map.md
 FLASH_BLOCK_SIZE = 512
 
 INTERNAL_FLASH_START_BLOCK = 0x100                             # FLASH_PART1_START_BLOCK

--- a/src/platform.py
+++ b/src/platform.py
@@ -365,13 +365,16 @@ def reboot():
 #   blocks 448 - 33215  external QSPI flash, the "/qspi" filesystem (16 MiB)
 # Full derivation, source files checked and submodule pins:
 # see docs/flash-block-map.md
-FLASH_BLOCK_SIZE = 512
-
+# The boundary between the two filesystems is the only part of the map
+# below that no ioctl() exposes: it comes from the linker script and
+# storage.h inside the pinned submodule, so it has to be stated here.
+# Block size and the end of the QSPI region are *not* restated - wipe()
+# reads both from the block device at run time (see
+# diybitcoinhardware/f469-disco#44 for making the boundary queryable too).
 INTERNAL_FLASH_START_BLOCK = 0x100                             # FLASH_PART1_START_BLOCK
 INTERNAL_FLASH_END_BLOCK = INTERNAL_FLASH_START_BLOCK + 192     # + FLASH_MEM_SEG1_NUM_BLOCKS
 
 QSPI_START_BLOCK = INTERNAL_FLASH_END_BLOCK                     # FLASH_PART2_START_BLOCK
-QSPI_END_BLOCK = QSPI_START_BLOCK + 32768                       # + QSPI flash block count
 
 # How many blocks get overwritten per writeblocks() call. Kept small, and
 # a multiple of the QSPI erase-sector size (8 blocks == 4096 bytes), so
@@ -379,9 +382,10 @@ QSPI_END_BLOCK = QSPI_START_BLOCK + 32768                       # + QSPI flash b
 # QSPI) at once.
 WIPE_CHUNK_BLOCKS = 16
 
-# extmod/vfs.h: MP_BLOCKDEV_IOCTL_BLOCK_COUNT / MP_BLOCKDEV_IOCTL_SYNC.
-MP_BLOCKDEV_IOCTL_BLOCK_COUNT = 4
+# extmod/vfs.h: MP_BLOCKDEV_IOCTL_SYNC / _BLOCK_COUNT / _BLOCK_SIZE.
 MP_BLOCKDEV_IOCTL_SYNC = 3
+MP_BLOCKDEV_IOCTL_BLOCK_COUNT = 4
+MP_BLOCKDEV_IOCTL_BLOCK_SIZE = 5
 # Both the internal-flash driver (flashbdev.c) and the QSPI driver
 # (drivers/memory/spiflash.c, built with USE_WR_DELAY) keep a
 # *write-behind* RAM cache: writeblocks() only guarantees the data
@@ -488,20 +492,27 @@ def wipe():
     """
     f = None
     block_size = None
+    qspi_end_block = None
     if not simulator:
-        # Check the actual flash geometry against what the block map
-        # above assumes, before deleting anything. The constants are
-        # correct for the hardware this was verified against, but if a
-        # future board revision, MicroPython fork update, or QSPI chip
-        # change ever shifted them, that mismatch could otherwise go
-        # unnoticed - the tests only check the code against itself, not
-        # against real hardware. Fail closed instead of guessing: refuse
-        # to touch either filesystem rather than wipe based on assumed
-        # boundaries that may no longer hold.
+        # Read the actual flash geometry, before deleting anything.
+        # Block size and the end of the QSPI region are taken from the
+        # device rather than assumed, so a larger or differently sized
+        # chip gets wiped in full instead of only up to a hardcoded
+        # bound. QSPI runs to the last block of the device: the two
+        # filesystems together cover everything above the split point.
         f = pyb.Flash()
-        block_size = f.ioctl(5, None)
+        block_size = f.ioctl(MP_BLOCKDEV_IOCTL_BLOCK_SIZE, None)
         block_count = f.ioctl(MP_BLOCKDEV_IOCTL_BLOCK_COUNT, None)
-        if block_size != FLASH_BLOCK_SIZE or block_count != QSPI_END_BLOCK:
+        qspi_end_block = block_count
+
+        # What cannot be read back is the internal/QSPI split point, so
+        # that assumption still has to be sanity-checked: if the device
+        # does not even extend past it, the layout this code was
+        # verified against no longer holds and the block numbers below
+        # are meaningless. Fail closed rather than overwrite a range
+        # picked by guesswork - a wipe that silently hits the wrong
+        # blocks would report success while leaving the seed in place.
+        if not block_size or not block_count or block_count <= QSPI_START_BLOCK:
             raise RuntimeError(
                 "Unexpected flash geometry (block_size=%r, block_count=%r); "
                 "refusing to wipe" % (block_size, block_count)
@@ -545,7 +556,7 @@ def wipe():
         internal_sync_ok = _sync_flash(f)
 
         qspi_ok = _secure_overwrite_blocks(
-            f, QSPI_START_BLOCK, QSPI_END_BLOCK, block_size
+            f, QSPI_START_BLOCK, qspi_end_block, block_size
         )
         # Final flush - see MP_BLOCKDEV_IOCTL_SYNC above for why this
         # can't be skipped.

--- a/src/platform.py
+++ b/src/platform.py
@@ -430,17 +430,44 @@ MP_BLOCKDEV_IOCTL_SYNC = 3
 # overwrite of that sector from RAM and leave the original, pre-wipe
 # bytes physically in place on the chip.
 #
-# Known limitation: on the QSPI path, a genuine erase/program failure
-# during that flush (in mp_spiflash_cache_flush_internal(), spiflash.c)
-# is not propagated up through mp_spiflash_cache_flush() -> the SYNC
-# ioctl -> here - the C driver clears its dirty flag and returns before
-# checking the erase/write result. The same applies to a sector-boundary
-# flush triggered mid-loop by a writeblocks() call. So a hardware write
-# failure at that level can go undetected by wipe() even though the
-# higher-level checks below (writeblocks()'s own return code, and the
-# geometry check below) still catch what they can. Fixing that requires
-# propagating real error codes through the pinned MicroPython fork's
-# QSPI driver - out of scope here.
+# Known limitation: the pinned MicroPython storage drivers do not
+# reliably propagate every underlying physical erase/program failure up
+# to this Python-level API - and this affects both flash regions, not
+# just QSPI:
+#   - QSPI (drivers/memory/spiflash.c): a genuine erase/program failure
+#     during a cache flush (mp_spiflash_cache_flush_internal()) is not
+#     propagated through mp_spiflash_cache_flush() -> the SYNC ioctl, nor
+#     through a sector-boundary flush triggered mid-loop by a
+#     writeblocks() call - the C driver clears its dirty flag and
+#     returns before checking the erase/write result.
+#   - Internal flash (ports/stm32/flash.c): flash_erase() and
+#     flash_write() are themselves declared void - a HAL_FLASHEx_Erase()
+#     or HAL_FLASH_Program() failure inside them is checked but has
+#     nowhere to go, and flash_bdev's cache (flashbdev.c) is marked clean
+#     again regardless.
+# So a hardware write failure at that level can go undetected here, even
+# though every check wipe() below actually has access to (writeblocks()'s
+# own return code, the SYNC ioctl's return code, and the geometry check
+# below) is applied. This means "not (internal_ok and qspi_ok and ...)"
+# below is not a complete guarantee that every possible physical write
+# failure was caught - only that every failure the pinned MicroPython
+# fork's block-device API actually surfaces was caught. Fixing the gap
+# itself requires propagating real error codes through both of those
+# drivers - out of scope here.
+
+
+def _sync_flash(f):
+    """
+    Forces the write-behind cache (see MP_BLOCKDEV_IOCTL_SYNC above) out
+    to physical flash, checking both an exception and a nonzero/failure
+    return code - not just whether the call raised. See the "Known
+    limitation" note above for what this can and can't actually catch.
+    """
+    try:
+        ret = f.ioctl(MP_BLOCKDEV_IOCTL_SYNC, None)
+    except Exception:
+        return False
+    return ret in (0, None)
 
 
 def _secure_overwrite_blocks(f, start_block, end_block, block_size,
@@ -547,19 +574,21 @@ def wipe():
         internal_ok = _secure_overwrite_blocks(
             f, INTERNAL_FLASH_START_BLOCK, INTERNAL_FLASH_END_BLOCK, block_size
         )
+        # Flush now, before starting the much longer QSPI loop: if power
+        # is lost partway through overwriting 16 MiB of QSPI, the internal
+        # flash's last touched sector should already be durably written
+        # rather than still waiting in the write-behind cache.
+        internal_sync_ok = _sync_flash(f)
+
         qspi_ok = _secure_overwrite_blocks(
             f, QSPI_START_BLOCK, QSPI_END_BLOCK, block_size
         )
+        # Final flush - see MP_BLOCKDEV_IOCTL_SYNC above for why this
+        # can't be skipped.
+        qspi_sync_ok = _sync_flash(f)
 
-        # Force the write-behind cache out to physical flash now - see
-        # MP_BLOCKDEV_IOCTL_SYNC above for why this can't be skipped.
-        sync_ok = True
-        try:
-            f.ioctl(MP_BLOCKDEV_IOCTL_SYNC, None)
-        except Exception:
-            sync_ok = False
-
-        if not (flash_unmount_ok and qspi_unmount_ok and internal_ok and qspi_ok and sync_ok):
+        if not (flash_unmount_ok and qspi_unmount_ok and internal_ok and qspi_ok
+                and internal_sync_ok and qspi_sync_ok):
             # Whatever could be destroyed already has been (see
             # _secure_overwrite_blocks), but a partial wipe must never be
             # allowed to look like a successful one. Raise instead of

--- a/src/platform.py
+++ b/src/platform.py
@@ -357,15 +357,107 @@ def reboot():
         pyb.hard_reset()
 
 
+# Verified block map of pyb.Flash() on the STM32F469 Discovery board, as
+# built by Specter's firmware (make disco USE_DBOOT=1). pyb.Flash() (no
+# args) exposes the whole board's storage as one block device addressed
+# with these ABSOLUTE block numbers:
+#
+#   block 0            software-emulated MBR (storage.c:storage_read/
+#                       write_block); not backed by real flash - writes
+#                       to it are silently discarded by the block device
+#   blocks 1   - 255    unmapped: not part of any partition, writeblocks()
+#                       on these fails (storage_write_block() returns
+#                       false -> -EIO). Physically these blocks fall in
+#                       the bootloader/ISR sector (0x08000000, 16K) and
+#                       the reserved sector (FLASH_RSV, 0x08004000, 16K)
+#                       of ports/stm32/boards/stm32f469xi_dboot.ld - never
+#                       reachable through this API regardless
+#   blocks 256 - 447    internal flash, the "/flash" filesystem
+#                       (FLASH_PART1_START_BLOCK = 0x100, storage.h);
+#                       192 blocks = 96 KiB, matching FLASH_MEM_SEG1
+#                       (flashbdev.c, STM32F469xx: sectors 2-4, 0x08008000)
+#                       which is exactly the FLASH_FS region of
+#                       stm32f469xi_dboot.ld - disjoint from FLASH_TEXT
+#                       (the application firmware, sectors 5-21 starting
+#                       at 0x08020000) and from FLASH_BOOT1/FLASH_BOOT2
+#                       (the bootloader slots, sectors 22-23)
+#   blocks 448 - 33215  external QSPI flash, the "/qspi" filesystem
+#                       (FLASH_PART2_START_BLOCK = FLASH_PART1_START_BLOCK
+#                       + 192, storage.h); 32768 blocks = 16 MiB, the full
+#                       size of the on-board QSPI NOR flash chip
+#                       (MICROPY_HW_SPIFLASH_SIZE_BITS = 128 Mbit,
+#                       boards/STM32F469DISC/mpconfigboard.h)
+#
+# The QSPI chip is addressed as plain NOR flash - no wear-leveling,
+# remapping or translation layer sits between the block numbers above and
+# the physical sectors (see spi_bdev_writeblocks()/mp_spiflash_cached_write()
+# in ports/stm32/spibdev.c and drivers/memory/spiflash.c), so overwriting
+# every block in a range does physically destroy the data that was there.
+# Required sector-erase-before-write is handled transparently by that
+# driver. Sources checked: diybitcoinhardware/f469-disco (submodule pin
+# db3ce3e), diybitcoinhardware/micropython (submodule pin 6bdf1b6),
+# ports/stm32/{storage.h,storage.c,flashbdev.c,spibdev.c},
+# ports/stm32/boards/STM32F469DISC/{mpconfigboard.h,mpconfigboard.mk},
+# ports/stm32/boards/stm32f469xi_dboot.ld, drivers/memory/spiflash.c.
+FLASH_BLOCK_SIZE = 512
+
+INTERNAL_FLASH_START_BLOCK = 0x100                             # FLASH_PART1_START_BLOCK
+INTERNAL_FLASH_END_BLOCK = INTERNAL_FLASH_START_BLOCK + 192     # + FLASH_MEM_SEG1_NUM_BLOCKS
+
+QSPI_START_BLOCK = INTERNAL_FLASH_END_BLOCK                     # FLASH_PART2_START_BLOCK
+QSPI_END_BLOCK = QSPI_START_BLOCK + 32768                       # + QSPI flash block count
+
+# How many blocks get freshly randomized data per writeblocks() call.
+# Kept small, and a multiple of the QSPI erase-sector size (8 blocks ==
+# 4096 bytes), so the wipe never needs a whole region's worth of RAM (up
+# to 16MiB for QSPI) at once.
+WIPE_CHUNK_BLOCKS = 16
+
+
+def _secure_overwrite_blocks(f, start_block, end_block, block_size,
+                              chunk_blocks=WIPE_CHUNK_BLOCKS):
+    """
+    Overwrites blocks [start_block, end_block) of the raw flash block
+    device `f` with fresh random data, `chunk_blocks` blocks at a time,
+    so the whole region never needs to fit in RAM at once.
+
+    A failed chunk does not stop the wipe: we keep going so as much of
+    the remaining sensitive data as possible still gets destroyed. But
+    the return value reflects whether *every* chunk succeeded - callers
+    must not treat a False result as if the region were fully wiped.
+    """
+    ok = True
+    block = start_block
+    while block < end_block:
+        n = min(chunk_blocks, end_block - block)
+        try:
+            buf = os.urandom(n * block_size)
+            ret = f.writeblocks(block, buf)
+            del buf
+            if ret:
+                ok = False
+        except Exception:
+            ok = False
+        gc.collect()
+        block += n
+    return ok
+
+
 def wipe():
     """
-    Blocks map in disco board
-    0: MBR
-    1   - 255:   reserved
-    256 - 447:   internal flash
-    448 - 33215: QSPI
+    Securely wipes user data.
+
+    Deletes the "/flash" and "/qspi" filesystems, and on real hardware
+    also physically overwrites the underlying internal-flash and QSPI
+    block ranges (see the verified block map above) with fresh random
+    data. Logical file deletion alone is not enough: an attacker with
+    physical access to the external QSPI flash chip could still recover
+    "deleted" files straight from it, since deleting a file only drops
+    its filesystem entry - the QSPI chip itself is unaffected. Firmware,
+    bootloader and reserved blocks are never touched.
     """
-    # delete files normally in simulator
+    # delete files normally in simulator (best-effort on hardware too,
+    # though the block overwrite below is what actually destroys data there)
     try:
         delete_recursively(fpath("/flash"))
         delete_recursively(fpath("/qspi"))
@@ -373,16 +465,36 @@ def wipe():
         pass
     # on real hardware overwrite flash with random data
     if not simulator:
-        os.umount("/flash")
-        os.umount("/qspi")
+        try:
+            os.umount("/flash")
+        except:
+            pass
+        try:
+            os.umount("/qspi")
+        except:
+            pass
         f = pyb.Flash()
         block_size = f.ioctl(5, None)
-        # wipe internal flash with random bytes
-        for i in range(256, 450):
-            b = os.urandom(block_size)
-            f.writeblocks(i, b)
-            del b
-            gc.collect()
+
+        internal_ok = _secure_overwrite_blocks(
+            f, INTERNAL_FLASH_START_BLOCK, INTERNAL_FLASH_END_BLOCK, block_size
+        )
+        qspi_ok = _secure_overwrite_blocks(
+            f, QSPI_START_BLOCK, QSPI_END_BLOCK, block_size
+        )
+
+        if not (internal_ok and qspi_ok):
+            # Whatever could be destroyed already has been (see
+            # _secure_overwrite_blocks), but a partial wipe must never be
+            # allowed to look like a successful one. Raise instead of
+            # rebooting so the caller's existing critical-error handling
+            # (CriticalErrorWipeImmediately / handle_exception in
+            # specter.py) surfaces the failure instead of silently
+            # trusting the device is clean.
+            raise RuntimeError(
+                "Secure wipe failed to overwrite all flash blocks; "
+                "device may still contain recoverable data"
+            )
     # mpy will reformat fs on reboot
     reboot()
 

--- a/src/specter.py
+++ b/src/specter.py
@@ -635,17 +635,22 @@ class Specter:
         warning so the user knows not to trust the device, then forces
         the same reboot so the device does not keep running in an
         undefined state (some blocks overwritten, filesystems possibly
-        gone, but still executing).
+        gone, but still executing). The reboot is in a `finally` so it
+        still happens even if showing that warning itself raises -
+        recovering from a partial hardware wipe must not depend on the
+        GUI working.
         """
         try:
             self.wipe()
         except Exception as wipe_exc:
-            await self.gui.error(
-                "Wipe failed to complete!\n\n%s\n\n"
-                "Do not consider this device safe. The device will now restart."
-                % wipe_exc
-            )
-            reboot()
+            try:
+                await self.gui.error(
+                    "Wipe failed to complete!\n\n%s\n\n"
+                    "Do not consider this device safe. The device will now restart."
+                    % wipe_exc
+                )
+            finally:
+                reboot()
 
     async def lock(self):
         # lock the keystore

--- a/src/specter.py
+++ b/src/specter.py
@@ -135,18 +135,7 @@ class Specter:
             await self.gui.error("Critical error, the device will be wiped.\n\n%s" % e)
             self.gui.show_loader(title="Wiping the device...")
             # wipe everything and reboot
-            try:
-                self.wipe()
-            except Exception as wipe_exc:
-                # wipe() failed to fully destroy the sensitive data it was
-                # meant to. Never let that look like a successful wipe -
-                # tell the user loudly and stop here instead of proceeding
-                # as if the device were safe.
-                await self.gui.error(
-                    "Wipe failed to complete!\n\n%s\n\n"
-                    "Do not consider this device safe." % wipe_exc
-                )
-                raise
+            await self.wipe_or_halt()
         # catch an expected error
         except BaseError as e:
             # show error
@@ -614,7 +603,7 @@ class Specter:
                     "But it doesn't include files stored on SD card or smartcard.\n\n"
                     "Are you sure?",
                 ):
-                    self.wipe()
+                    await self.wipe_or_halt()
                 return
             elif menuitem == 777:
                 await self.keystore.change_pin()
@@ -636,6 +625,27 @@ class Specter:
         # TODO: wipe the smartcard as well?
         # platform.wipe
         wipe()
+
+    async def wipe_or_halt(self):
+        """
+        Runs the wipe and always ends in one deterministic outcome: a
+        clean wipe reboots as normal (platform.wipe() does that itself
+        and never returns). A failed wipe never falls back to running on
+        top of a partially destroyed filesystem - it shows an explicit
+        warning so the user knows not to trust the device, then forces
+        the same reboot so the device does not keep running in an
+        undefined state (some blocks overwritten, filesystems possibly
+        gone, but still executing).
+        """
+        try:
+            self.wipe()
+        except Exception as wipe_exc:
+            await self.gui.error(
+                "Wipe failed to complete!\n\n%s\n\n"
+                "Do not consider this device safe. The device will now restart."
+                % wipe_exc
+            )
+            reboot()
 
     async def lock(self):
         # lock the keystore

--- a/src/specter.py
+++ b/src/specter.py
@@ -135,7 +135,18 @@ class Specter:
             await self.gui.error("Critical error, the device will be wiped.\n\n%s" % e)
             self.gui.show_loader(title="Wiping the device...")
             # wipe everything and reboot
-            self.wipe()
+            try:
+                self.wipe()
+            except Exception as wipe_exc:
+                # wipe() failed to fully destroy the sensitive data it was
+                # meant to. Never let that look like a successful wipe -
+                # tell the user loudly and stop here instead of proceeding
+                # as if the device were safe.
+                await self.gui.error(
+                    "Wipe failed to complete!\n\n%s\n\n"
+                    "Do not consider this device safe." % wipe_exc
+                )
+                raise
         # catch an expected error
         except BaseError as e:
             # show error

--- a/test/tests_native/__init__.py
+++ b/test/tests_native/__init__.py
@@ -1,1 +1,2 @@
 from .test_wallet_manager_parsing import *
+from .test_platform_wipe import *

--- a/test/tests_native/test_platform_wipe.py
+++ b/test/tests_native/test_platform_wipe.py
@@ -1,0 +1,246 @@
+import sys
+
+if sys.implementation.name != 'micropython':
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+from unittest import TestCase
+
+import pyb
+import platform
+from tests.util import clear_testdir
+
+
+class FakeFlash:
+    """
+    Records every writeblocks() call so tests can check exactly which
+    blocks were (or were not) overwritten, without touching real hardware.
+    """
+
+    def __init__(self, block_size=512, fail_at_blocks=None, raise_at_blocks=None):
+        self.block_size = block_size
+        self.calls = []  # list of (block_num, num_blocks)
+        self.fail_at_blocks = set(fail_at_blocks or [])
+        self.raise_at_blocks = set(raise_at_blocks or [])
+
+    def ioctl(self, cmd, arg):
+        if cmd == 5:  # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
+            return self.block_size
+        return None
+
+    def writeblocks(self, block_num, buf):
+        assert len(buf) % self.block_size == 0
+        n = len(buf) // self.block_size
+        self.calls.append((block_num, n))
+        if block_num in self.raise_at_blocks:
+            raise OSError("simulated flash failure")
+        if block_num in self.fail_at_blocks:
+            return -5  # negative errno == failure, per block protocol
+        return 0
+
+    def written_blocks(self):
+        """Returns the set of individual block numbers passed a buffer."""
+        blocks = set()
+        for start, n in self.calls:
+            blocks.update(range(start, start + n))
+        return blocks
+
+
+class BlockMapConstantsTest(TestCase):
+    """
+    Pins down the verified hardware block map (see platform.py) so a
+    future edit can't silently reintroduce an off-by-one or shrink the
+    wiped range.
+    """
+
+    def test_internal_flash_range(self):
+        self.assertEqual(platform.INTERNAL_FLASH_START_BLOCK, 256)
+        self.assertEqual(platform.INTERNAL_FLASH_END_BLOCK, 448)
+        # 192 blocks * 512 bytes == 96 KiB == FLASH_MEM_SEG1 on STM32F469xx
+        self.assertEqual(
+            platform.INTERNAL_FLASH_END_BLOCK - platform.INTERNAL_FLASH_START_BLOCK,
+            192,
+        )
+
+    def test_qspi_range(self):
+        self.assertEqual(platform.QSPI_START_BLOCK, 448)
+        self.assertEqual(platform.QSPI_END_BLOCK, 33216)
+        # 32768 blocks * 512 bytes == 16 MiB == the on-board QSPI chip
+        self.assertEqual(
+            platform.QSPI_END_BLOCK - platform.QSPI_START_BLOCK,
+            32768,
+        )
+
+    def test_qspi_starts_immediately_after_internal_flash(self):
+        self.assertEqual(platform.QSPI_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK)
+
+    def test_reserved_region_is_excluded(self):
+        # blocks 0-255 (fake MBR + reserved/bootloader sectors) must never
+        # be part of either wiped range
+        self.assertGreaterEqual(platform.INTERNAL_FLASH_START_BLOCK, 256)
+
+
+class SecureOverwriteBlocksTest(TestCase):
+    def test_wipes_full_range_with_no_gaps_or_overrun(self):
+        f = FakeFlash()
+        ok = platform._secure_overwrite_blocks(
+            f, platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK, 512
+        )
+        self.assertTrue(ok)
+        self.assertEqual(
+            f.written_blocks(),
+            set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK)),
+        )
+        # first and last block of the range must be included (off-by-one guard)
+        self.assertIn(platform.INTERNAL_FLASH_START_BLOCK, f.written_blocks())
+        self.assertIn(platform.INTERNAL_FLASH_END_BLOCK - 1, f.written_blocks())
+        # the end block itself (exclusive bound) must never be written
+        self.assertNotIn(platform.INTERNAL_FLASH_END_BLOCK, f.written_blocks())
+
+    def test_wipes_full_qspi_range(self):
+        f = FakeFlash()
+        ok = platform._secure_overwrite_blocks(
+            f, platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK, 512
+        )
+        self.assertTrue(ok)
+        self.assertEqual(
+            f.written_blocks(),
+            set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK)),
+        )
+        self.assertIn(platform.QSPI_START_BLOCK, f.written_blocks())
+        self.assertIn(platform.QSPI_END_BLOCK - 1, f.written_blocks())
+        self.assertNotIn(platform.QSPI_END_BLOCK, f.written_blocks())
+
+    def test_never_touches_blocks_outside_requested_range(self):
+        f = FakeFlash()
+        platform._secure_overwrite_blocks(f, 300, 320, 512)
+        for start, n in f.calls:
+            self.assertGreaterEqual(start, 300)
+            self.assertLessEqual(start + n, 320)
+
+    def test_uses_given_block_size_for_buffers(self):
+        f = FakeFlash(block_size=4096)
+        platform._secure_overwrite_blocks(f, 0, 32, 4096, chunk_blocks=8)
+        for start, n in f.calls:
+            self.assertLessEqual(n * 4096, 8 * 4096)
+
+    def test_chunking_never_loads_whole_region_at_once(self):
+        f = FakeFlash()
+        platform._secure_overwrite_blocks(f, 0, 1000, 512, chunk_blocks=16)
+        for _, n in f.calls:
+            self.assertLessEqual(n, 16)
+        self.assertGreater(len(f.calls), 1)
+
+    def test_write_failure_does_not_stop_the_wipe(self):
+        f = FakeFlash(fail_at_blocks={16})
+        ok = platform._secure_overwrite_blocks(f, 0, 64, 512, chunk_blocks=16)
+        self.assertFalse(ok)
+        # every chunk should still have been attempted despite the failure
+        self.assertEqual(f.written_blocks(), set(range(0, 64)))
+
+    def test_write_exception_does_not_stop_the_wipe(self):
+        f = FakeFlash(raise_at_blocks={32})
+        ok = platform._secure_overwrite_blocks(f, 0, 64, 512, chunk_blocks=16)
+        self.assertFalse(ok)
+        self.assertEqual(f.written_blocks(), set(range(0, 64)))
+
+
+class WipeSimulatorTest(TestCase):
+    def setUp(self):
+        clear_testdir()
+        self.rebooted = False
+
+        def fake_reboot():
+            self.rebooted = True
+
+        self._orig_reboot = platform.reboot
+        platform.reboot = fake_reboot
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("hardware block device must not be touched in simulator mode")
+
+        self._orig_flash = getattr(pyb, "Flash", None)
+        pyb.Flash = fail_if_called
+
+    def tearDown(self):
+        platform.reboot = self._orig_reboot
+        if self._orig_flash is None:
+            del pyb.Flash
+        else:
+            pyb.Flash = self._orig_flash
+        clear_testdir()
+
+    def test_wipe_deletes_files_and_never_touches_hardware(self):
+        platform.maybe_mkdir(platform.fpath("/flash"))
+        platform.maybe_mkdir(platform.fpath("/qspi"))
+        with open(platform.fpath("/flash/secret.txt"), "w") as f:
+            f.write("do not recover me")
+        with open(platform.fpath("/qspi/wallet.json"), "w") as f:
+            f.write("{}")
+
+        platform.wipe()
+
+        self.assertTrue(self.rebooted)
+        self.assertFalse(platform.file_exists(platform.fpath("/flash/secret.txt")))
+        self.assertFalse(platform.file_exists(platform.fpath("/qspi/wallet.json")))
+
+
+class WipeHardwareTest(TestCase):
+    """
+    Exercises the `if not simulator:` branch of wipe() by flipping the
+    module-level `simulator` flag, without requiring real STM32 hardware.
+    """
+
+    def setUp(self):
+        clear_testdir()
+        self._orig_simulator = platform.simulator
+        platform.simulator = False
+
+        self.rebooted = False
+
+        def fake_reboot():
+            self.rebooted = True
+
+        self._orig_reboot = platform.reboot
+        platform.reboot = fake_reboot
+
+        self._orig_umount = platform.os.umount if hasattr(platform.os, "umount") else None
+        self.umounted = []
+        platform.os.umount = lambda path: self.umounted.append(path)
+
+    def tearDown(self):
+        platform.simulator = self._orig_simulator
+        platform.reboot = self._orig_reboot
+        if self._orig_umount is not None:
+            platform.os.umount = self._orig_umount
+        else:
+            del platform.os.umount
+        if hasattr(pyb, "Flash"):
+            del pyb.Flash
+        clear_testdir()
+
+    def test_successful_wipe_overwrites_both_regions_and_reboots(self):
+        fake = FakeFlash()
+        pyb.Flash = lambda: fake
+
+        platform.wipe()
+
+        self.assertTrue(self.rebooted)
+        self.assertEqual(sorted(self.umounted), ["/flash", "/qspi"])
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        self.assertEqual(fake.written_blocks(), expected)
+        # never touch the fake MBR or the reserved/bootloader blocks
+        for start, n in fake.calls:
+            self.assertGreaterEqual(start, 256)
+
+    def test_failed_wipe_raises_and_does_not_reboot(self):
+        fake = FakeFlash(fail_at_blocks={platform.QSPI_START_BLOCK})
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        # a partial wipe must never look like a successful one
+        self.assertFalse(self.rebooted)

--- a/test/tests_native/test_platform_wipe.py
+++ b/test/tests_native/test_platform_wipe.py
@@ -14,24 +14,32 @@ from tests.util import clear_testdir
 
 class FakeFlash:
     """
-    Records every writeblocks() call so tests can check exactly which
-    blocks were (or were not) overwritten, without touching real hardware.
+    Records every writeblocks()/ioctl() call - including their relative
+    order in a shared `events` log - so tests can check exactly which
+    blocks were (or were not) overwritten, what data was written, and
+    that write/sync/reboot happen in the right order, without touching
+    real hardware.
     """
 
-    def __init__(self, block_size=512, fail_at_blocks=None, raise_at_blocks=None,
-                 fail_sync=False):
+    def __init__(self, block_size=512, block_count=None, fail_at_blocks=None,
+                 raise_at_blocks=None, fail_sync=False):
         self.block_size = block_size
+        self.block_count = block_count if block_count is not None else platform.QSPI_END_BLOCK
         self.calls = []  # list of (block_num, num_blocks)
         self.fail_at_blocks = set(fail_at_blocks or [])
         self.raise_at_blocks = set(raise_at_blocks or [])
         self.fail_sync = fail_sync
         self.ioctl_calls = []
+        self.events = []  # shared write/sync (and, externally, reboot) order log
 
     def ioctl(self, cmd, arg):
         self.ioctl_calls.append(cmd)
         if cmd == 5:  # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
             return self.block_size
+        if cmd == 4:  # MP_BLOCKDEV_IOCTL_BLOCK_COUNT
+            return self.block_count
         if cmd == 3:  # MP_BLOCKDEV_IOCTL_SYNC
+            self.events.append(("sync",))
             if self.fail_sync:
                 raise OSError("simulated sync failure")
         return None
@@ -40,6 +48,7 @@ class FakeFlash:
         assert len(buf) % self.block_size == 0
         n = len(buf) // self.block_size
         self.calls.append((block_num, n))
+        self.events.append(("write", block_num, n, bytes(buf)))
         if block_num in self.raise_at_blocks:
             raise OSError("simulated flash failure")
         if block_num in self.fail_at_blocks:
@@ -152,6 +161,27 @@ class SecureOverwriteBlocksTest(TestCase):
         self.assertFalse(ok)
         self.assertEqual(f.written_blocks(), set(range(0, 64)))
 
+    def test_writes_a_fixed_pattern_not_random_data(self):
+        # os.urandom() on this port draws one hardware RNG sample per byte
+        # (~10us each), which would make a 16 MiB QSPI wipe take minutes
+        # just to generate the buffers. A fixed pattern is just as
+        # effective against the "read the chip directly" threat model,
+        # since every touched sector gets erased and reprogrammed either
+        # way, so the loop must not depend on true randomness.
+        f = FakeFlash()
+        platform._secure_overwrite_blocks(f, 0, 64, 512, chunk_blocks=16)
+        for _, _, _, buf in f.events:
+            self.assertEqual(buf, bytes(len(buf)))
+
+    def test_reuses_one_buffer_instead_of_allocating_per_chunk(self):
+        f = FakeFlash()
+        platform._secure_overwrite_blocks(f, 0, 64, 512, chunk_blocks=16)
+        full_chunks = [buf for _, _, n, buf in f.events if n == 16]
+        self.assertGreater(len(full_chunks), 1)
+        # every full-size chunk must be the exact same underlying bytes
+        # object, not a freshly allocated one each iteration
+        self.assertTrue(all(buf is full_chunks[0] for buf in full_chunks))
+
 
 class WipeSimulatorTest(TestCase):
     def setUp(self):
@@ -204,10 +234,13 @@ class WipeHardwareTest(TestCase):
         self._orig_simulator = platform.simulator
         platform.simulator = False
 
+        self.fake = None
         self.rebooted = False
 
         def fake_reboot():
             self.rebooted = True
+            if self.fake is not None:
+                self.fake.events.append(("reboot",))
 
         self._orig_reboot = platform.reboot
         platform.reboot = fake_reboot
@@ -229,6 +262,7 @@ class WipeHardwareTest(TestCase):
 
     def test_successful_wipe_overwrites_both_regions_and_reboots(self):
         fake = FakeFlash()
+        self.fake = fake
         pyb.Flash = lambda: fake
 
         platform.wipe()
@@ -247,6 +281,7 @@ class WipeHardwareTest(TestCase):
 
     def test_failed_wipe_raises_and_does_not_reboot(self):
         fake = FakeFlash(fail_at_blocks={platform.QSPI_START_BLOCK})
+        self.fake = fake
         pyb.Flash = lambda: fake
 
         with self.assertRaises(Exception):
@@ -263,6 +298,7 @@ class WipeHardwareTest(TestCase):
 
         platform.os.umount = failing_umount
         fake = FakeFlash()
+        self.fake = fake
         pyb.Flash = lambda: fake
 
         with self.assertRaises(Exception):
@@ -286,6 +322,7 @@ class WipeHardwareTest(TestCase):
 
         platform.os.umount = failing_umount
         fake = FakeFlash()
+        self.fake = fake
         pyb.Flash = lambda: fake
 
         with self.assertRaises(Exception):
@@ -304,6 +341,7 @@ class WipeHardwareTest(TestCase):
 
         platform.os.umount = failing_umount
         fake = FakeFlash()
+        self.fake = fake
         pyb.Flash = lambda: fake
 
         with self.assertRaises(Exception):
@@ -316,6 +354,7 @@ class WipeHardwareTest(TestCase):
 
     def test_sync_failure_raises_and_does_not_reboot(self):
         fake = FakeFlash(fail_sync=True)
+        self.fake = fake
         pyb.Flash = lambda: fake
 
         with self.assertRaises(Exception):
@@ -326,3 +365,69 @@ class WipeHardwareTest(TestCase):
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
         expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
+
+    def test_wrong_block_size_aborts_before_any_destructive_action(self):
+        platform.maybe_mkdir(platform.fpath("/flash"))
+        with open(platform.fpath("/flash/secret.txt"), "w") as fh:
+            fh.write("still here")
+
+        fake = FakeFlash(block_size=4096)  # hardware map assumes 512
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
+        # a geometry mismatch must refuse before touching anything - not
+        # a single write, unmount, or delete
+        self.assertEqual(fake.calls, [])
+        self.assertEqual(self.umounted, [])
+        self.assertTrue(platform.file_exists(platform.fpath("/flash/secret.txt")))
+
+    def test_wrong_block_count_aborts_before_any_destructive_action(self):
+        platform.maybe_mkdir(platform.fpath("/qspi"))
+        with open(platform.fpath("/qspi/wallet.json"), "w") as fh:
+            fh.write("{}")
+
+        fake = FakeFlash(block_count=platform.QSPI_END_BLOCK - 1)  # off by one
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
+        self.assertEqual(fake.calls, [])
+        self.assertEqual(self.umounted, [])
+        self.assertTrue(platform.file_exists(platform.fpath("/qspi/wallet.json")))
+
+    def test_matching_geometry_does_not_block_the_wipe(self):
+        fake = FakeFlash(block_size=512, block_count=platform.QSPI_END_BLOCK)
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        platform.wipe()
+
+        self.assertTrue(self.rebooted)
+
+    def test_write_then_sync_then_reboot_ordering(self):
+        # Not just "sync was called somewhere" (that's covered above) but
+        # that it happens strictly after the last write and strictly
+        # before reboot - the actual ordering the write-behind cache
+        # depends on.
+        fake = FakeFlash()
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        platform.wipe()
+
+        kinds = [event[0] for event in fake.events]
+        self.assertIn("write", kinds)
+        self.assertIn("sync", kinds)
+        self.assertIn("reboot", kinds)
+        last_write_index = max(i for i, k in enumerate(kinds) if k == "write")
+        sync_index = kinds.index("sync")
+        reboot_index = kinds.index("reboot")
+        self.assertLess(last_write_index, sync_index)
+        self.assertLess(sync_index, reboot_index)

--- a/test/tests_native/test_platform_wipe.py
+++ b/test/tests_native/test_platform_wipe.py
@@ -22,13 +22,14 @@ class FakeFlash:
     """
 
     def __init__(self, block_size=512, block_count=None, fail_at_blocks=None,
-                 raise_at_blocks=None, fail_sync=False):
+                 raise_at_blocks=None, fail_sync=False, sync_error_code=None):
         self.block_size = block_size
         self.block_count = block_count if block_count is not None else platform.QSPI_END_BLOCK
         self.calls = []  # list of (block_num, num_blocks)
         self.fail_at_blocks = set(fail_at_blocks or [])
         self.raise_at_blocks = set(raise_at_blocks or [])
         self.fail_sync = fail_sync
+        self.sync_error_code = sync_error_code
         self.ioctl_calls = []
         self.events = []  # shared write/sync (and, externally, reboot) order log
 
@@ -42,6 +43,9 @@ class FakeFlash:
             self.events.append(("sync",))
             if self.fail_sync:
                 raise OSError("simulated sync failure")
+            if self.sync_error_code is not None:
+                return self.sync_error_code
+            return 0
         return None
 
     def writeblocks(self, block_num, buf):
@@ -276,8 +280,9 @@ class WipeHardwareTest(TestCase):
         for start, n in fake.calls:
             self.assertGreaterEqual(start, 256)
         # the write-behind cache must be forced out to physical flash
-        # before reboot, or the last dirty sector could be lost on reset
-        self.assertIn(platform.MP_BLOCKDEV_IOCTL_SYNC, fake.ioctl_calls)
+        # before reboot, or the last dirty sector could be lost on reset -
+        # once after the internal-flash loop, once after the QSPI loop
+        self.assertEqual(fake.ioctl_calls.count(platform.MP_BLOCKDEV_IOCTL_SYNC), 2)
 
     def test_failed_wipe_raises_and_does_not_reboot(self):
         fake = FakeFlash(fail_at_blocks={platform.QSPI_START_BLOCK})
@@ -352,7 +357,7 @@ class WipeHardwareTest(TestCase):
         expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
 
-    def test_sync_failure_raises_and_does_not_reboot(self):
+    def test_sync_exception_raises_and_does_not_reboot(self):
         fake = FakeFlash(fail_sync=True)
         self.fake = fake
         pyb.Flash = lambda: fake
@@ -362,6 +367,22 @@ class WipeHardwareTest(TestCase):
 
         self.assertFalse(self.rebooted)
         # the overwrite itself must still have completed fully
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        self.assertEqual(fake.written_blocks(), expected)
+
+    def test_sync_error_return_code_raises_and_does_not_reboot(self):
+        # A failed sync doesn't have to raise - the pinned driver can also
+        # just hand back a nonzero/negative-errno return code. That must
+        # be treated as a failure too, not just an exception.
+        fake = FakeFlash(sync_error_code=-5)
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
         expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
@@ -413,9 +434,12 @@ class WipeHardwareTest(TestCase):
 
     def test_write_then_sync_then_reboot_ordering(self):
         # Not just "sync was called somewhere" (that's covered above) but
-        # that it happens strictly after the last write and strictly
-        # before reboot - the actual ordering the write-behind cache
-        # depends on.
+        # that the *last* sync happens strictly after the *last* write and
+        # strictly before reboot - the actual ordering the write-behind
+        # cache depends on. There are two syncs (internal flash, then
+        # QSPI): the first one sits between the two write loops, so only
+        # the final sync is required to be the very last thing before
+        # reboot.
         fake = FakeFlash()
         self.fake = fake
         pyb.Flash = lambda: fake
@@ -423,11 +447,31 @@ class WipeHardwareTest(TestCase):
         platform.wipe()
 
         kinds = [event[0] for event in fake.events]
+        self.assertEqual(kinds.count("sync"), 2)
         self.assertIn("write", kinds)
-        self.assertIn("sync", kinds)
         self.assertIn("reboot", kinds)
         last_write_index = max(i for i, k in enumerate(kinds) if k == "write")
-        sync_index = kinds.index("sync")
+        last_sync_index = max(i for i, k in enumerate(kinds) if k == "sync")
         reboot_index = kinds.index("reboot")
-        self.assertLess(last_write_index, sync_index)
-        self.assertLess(sync_index, reboot_index)
+        self.assertLess(last_write_index, last_sync_index)
+        self.assertLess(last_sync_index, reboot_index)
+
+    def test_internal_flash_synced_before_qspi_overwrite_starts(self):
+        # The intermediate sync (added so a power loss during the long
+        # QSPI loop doesn't strand the internal-flash overwrite in RAM)
+        # must happen strictly between the two write loops, not after
+        # QSPI writes have already started.
+        fake = FakeFlash()
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        platform.wipe()
+
+        kinds = [event[0] for event in fake.events]
+        first_sync_index = kinds.index("sync")
+        qspi_write_indices = [
+            i for i, e in enumerate(fake.events)
+            if e[0] == "write" and e[1] >= platform.QSPI_START_BLOCK
+        ]
+        self.assertTrue(qspi_write_indices)
+        self.assertLess(first_sync_index, min(qspi_write_indices))

--- a/test/tests_native/test_platform_wipe.py
+++ b/test/tests_native/test_platform_wipe.py
@@ -18,15 +18,22 @@ class FakeFlash:
     blocks were (or were not) overwritten, without touching real hardware.
     """
 
-    def __init__(self, block_size=512, fail_at_blocks=None, raise_at_blocks=None):
+    def __init__(self, block_size=512, fail_at_blocks=None, raise_at_blocks=None,
+                 fail_sync=False):
         self.block_size = block_size
         self.calls = []  # list of (block_num, num_blocks)
         self.fail_at_blocks = set(fail_at_blocks or [])
         self.raise_at_blocks = set(raise_at_blocks or [])
+        self.fail_sync = fail_sync
+        self.ioctl_calls = []
 
     def ioctl(self, cmd, arg):
+        self.ioctl_calls.append(cmd)
         if cmd == 5:  # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
             return self.block_size
+        if cmd == 3:  # MP_BLOCKDEV_IOCTL_SYNC
+            if self.fail_sync:
+                raise OSError("simulated sync failure")
         return None
 
     def writeblocks(self, block_num, buf):
@@ -234,6 +241,9 @@ class WipeHardwareTest(TestCase):
         # never touch the fake MBR or the reserved/bootloader blocks
         for start, n in fake.calls:
             self.assertGreaterEqual(start, 256)
+        # the write-behind cache must be forced out to physical flash
+        # before reboot, or the last dirty sector could be lost on reset
+        self.assertIn(platform.MP_BLOCKDEV_IOCTL_SYNC, fake.ioctl_calls)
 
     def test_failed_wipe_raises_and_does_not_reboot(self):
         fake = FakeFlash(fail_at_blocks={platform.QSPI_START_BLOCK})
@@ -244,3 +254,75 @@ class WipeHardwareTest(TestCase):
 
         # a partial wipe must never look like a successful one
         self.assertFalse(self.rebooted)
+
+    def test_flash_unmount_failure_still_overwrites_and_raises(self):
+        def failing_umount(path):
+            if path == "/flash":
+                raise OSError("simulated unmount failure")
+            self.umounted.append(path)
+
+        platform.os.umount = failing_umount
+        fake = FakeFlash()
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        # a failed /flash unmount must not be silently treated as success
+        self.assertFalse(self.rebooted)
+        # but the raw overwrite must still have been attempted for both
+        # regions, to destroy as much data as safely possible
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        self.assertEqual(fake.written_blocks(), expected)
+        # /qspi unmount is independent and should still have happened
+        self.assertEqual(self.umounted, ["/qspi"])
+
+    def test_qspi_unmount_failure_still_overwrites_and_raises(self):
+        def failing_umount(path):
+            if path == "/qspi":
+                raise OSError("simulated unmount failure")
+            self.umounted.append(path)
+
+        platform.os.umount = failing_umount
+        fake = FakeFlash()
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        self.assertEqual(fake.written_blocks(), expected)
+        # /flash unmount is independent and should still have happened
+        self.assertEqual(self.umounted, ["/flash"])
+
+    def test_both_unmounts_failing_still_overwrites_and_raises(self):
+        def failing_umount(path):
+            raise OSError("simulated unmount failure")
+
+        platform.os.umount = failing_umount
+        fake = FakeFlash()
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        self.assertEqual(fake.written_blocks(), expected)
+
+    def test_sync_failure_raises_and_does_not_reboot(self):
+        fake = FakeFlash(fail_sync=True)
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
+        # the overwrite itself must still have completed fully
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        self.assertEqual(fake.written_blocks(), expected)

--- a/test/tests_native/test_platform_wipe.py
+++ b/test/tests_native/test_platform_wipe.py
@@ -12,6 +12,12 @@ import platform
 from tests.util import clear_testdir
 
 
+# The end of the QSPI region is no longer a platform constant - wipe()
+# reads it from the block device. Tests still pin the value the block map
+# was verified against, so a change in the wiped range stays visible here.
+VERIFIED_QSPI_END_BLOCK = 33216
+
+
 class FakeFlash:
     """
     Records every writeblocks()/ioctl() call - including their relative
@@ -24,7 +30,7 @@ class FakeFlash:
     def __init__(self, block_size=512, block_count=None, fail_at_blocks=None,
                  raise_at_blocks=None, fail_sync=False, sync_error_code=None):
         self.block_size = block_size
-        self.block_count = block_count if block_count is not None else platform.QSPI_END_BLOCK
+        self.block_count = block_count if block_count is not None else VERIFIED_QSPI_END_BLOCK
         self.calls = []  # list of (block_num, num_blocks)
         self.fail_at_blocks = set(fail_at_blocks or [])
         self.raise_at_blocks = set(raise_at_blocks or [])
@@ -83,14 +89,22 @@ class BlockMapConstantsTest(TestCase):
             192,
         )
 
-    def test_qspi_range(self):
+    def test_qspi_start(self):
+        # Only the start of the QSPI region is a constant. Its end comes
+        # from the block device at run time, so there is nothing here to
+        # go stale against a differently sized chip.
         self.assertEqual(platform.QSPI_START_BLOCK, 448)
-        self.assertEqual(platform.QSPI_END_BLOCK, 33216)
         # 32768 blocks * 512 bytes == 16 MiB == the on-board QSPI chip
         self.assertEqual(
-            platform.QSPI_END_BLOCK - platform.QSPI_START_BLOCK,
+            VERIFIED_QSPI_END_BLOCK - platform.QSPI_START_BLOCK,
             32768,
         )
+
+    def test_no_hardcoded_geometry_left_in_platform(self):
+        # Guards the point of this change: block size and total block
+        # count must not creep back in as module constants.
+        self.assertFalse(hasattr(platform, "FLASH_BLOCK_SIZE"))
+        self.assertFalse(hasattr(platform, "QSPI_END_BLOCK"))
 
     def test_qspi_starts_immediately_after_internal_flash(self):
         self.assertEqual(platform.QSPI_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK)
@@ -121,16 +135,16 @@ class SecureOverwriteBlocksTest(TestCase):
     def test_wipes_full_qspi_range(self):
         f = FakeFlash()
         ok = platform._secure_overwrite_blocks(
-            f, platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK, 512
+            f, platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK, 512
         )
         self.assertTrue(ok)
         self.assertEqual(
             f.written_blocks(),
-            set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK)),
+            set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK)),
         )
         self.assertIn(platform.QSPI_START_BLOCK, f.written_blocks())
-        self.assertIn(platform.QSPI_END_BLOCK - 1, f.written_blocks())
-        self.assertNotIn(platform.QSPI_END_BLOCK, f.written_blocks())
+        self.assertIn(VERIFIED_QSPI_END_BLOCK - 1, f.written_blocks())
+        self.assertNotIn(VERIFIED_QSPI_END_BLOCK, f.written_blocks())
 
     def test_never_touches_blocks_outside_requested_range(self):
         f = FakeFlash()
@@ -274,7 +288,7 @@ class WipeHardwareTest(TestCase):
         self.assertTrue(self.rebooted)
         self.assertEqual(sorted(self.umounted), ["/flash", "/qspi"])
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
-        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
         # never touch the fake MBR or the reserved/bootloader blocks
         for start, n in fake.calls:
@@ -314,7 +328,7 @@ class WipeHardwareTest(TestCase):
         # but the raw overwrite must still have been attempted for both
         # regions, to destroy as much data as safely possible
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
-        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
         # /qspi unmount is independent and should still have happened
         self.assertEqual(self.umounted, ["/qspi"])
@@ -335,7 +349,7 @@ class WipeHardwareTest(TestCase):
 
         self.assertFalse(self.rebooted)
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
-        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
         # /flash unmount is independent and should still have happened
         self.assertEqual(self.umounted, ["/flash"])
@@ -354,7 +368,7 @@ class WipeHardwareTest(TestCase):
 
         self.assertFalse(self.rebooted)
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
-        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
 
     def test_sync_exception_raises_and_does_not_reboot(self):
@@ -368,7 +382,7 @@ class WipeHardwareTest(TestCase):
         self.assertFalse(self.rebooted)
         # the overwrite itself must still have completed fully
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
-        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
 
     def test_sync_error_return_code_raises_and_does_not_reboot(self):
@@ -384,34 +398,80 @@ class WipeHardwareTest(TestCase):
 
         self.assertFalse(self.rebooted)
         expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
-        expected |= set(range(platform.QSPI_START_BLOCK, platform.QSPI_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, VERIFIED_QSPI_END_BLOCK))
         self.assertEqual(fake.written_blocks(), expected)
 
-    def test_wrong_block_size_aborts_before_any_destructive_action(self):
-        platform.maybe_mkdir(platform.fpath("/flash"))
-        with open(platform.fpath("/flash/secret.txt"), "w") as fh:
-            fh.write("still here")
-
-        fake = FakeFlash(block_size=4096)  # hardware map assumes 512
+    def test_larger_block_size_is_taken_from_the_device(self):
+        # Block size is read back, not assumed: a device reporting 4096
+        # must still be wiped, using its own size rather than refused.
+        fake = FakeFlash(block_size=4096,
+                         block_count=platform.QSPI_START_BLOCK + 64)
         self.fake = fake
         pyb.Flash = lambda: fake
 
-        with self.assertRaises(Exception):
-            platform.wipe()
+        platform.wipe()
 
-        self.assertFalse(self.rebooted)
-        # a geometry mismatch must refuse before touching anything - not
-        # a single write, unmount, or delete
-        self.assertEqual(fake.calls, [])
-        self.assertEqual(self.umounted, [])
-        self.assertTrue(platform.file_exists(platform.fpath("/flash/secret.txt")))
+        self.assertTrue(self.rebooted)
+        for _start, _n, buf in [e[1:] for e in fake.events if e[0] == "write"]:
+            self.assertEqual(len(buf) % 4096, 0)
 
-    def test_wrong_block_count_aborts_before_any_destructive_action(self):
+    def test_smaller_chip_is_wiped_to_its_reported_end(self):
+        # A chip smaller than the one the map was verified against used
+        # to abort the whole wipe. Wiping everything the device actually
+        # has is better than leaving all of it behind.
+        end = VERIFIED_QSPI_END_BLOCK - 4096
+        fake = FakeFlash(block_count=end)
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        platform.wipe()
+
+        self.assertTrue(self.rebooted)
+        expected = set(range(platform.INTERNAL_FLASH_START_BLOCK, platform.INTERNAL_FLASH_END_BLOCK))
+        expected |= set(range(platform.QSPI_START_BLOCK, end))
+        self.assertEqual(fake.written_blocks(), expected)
+        self.assertNotIn(end, fake.written_blocks())
+
+    def test_larger_chip_is_wiped_to_its_reported_end(self):
+        end = VERIFIED_QSPI_END_BLOCK + 1024
+        fake = FakeFlash(block_count=end)
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        platform.wipe()
+
+        self.assertTrue(self.rebooted)
+        self.assertIn(end - 1, fake.written_blocks())
+        self.assertNotIn(end, fake.written_blocks())
+
+    def test_device_not_reaching_the_split_point_aborts(self):
+        # The internal/QSPI boundary is the one value that cannot be read
+        # back. If the device does not extend past it, the assumed layout
+        # is wrong and the block numbers mean nothing - refuse.
         platform.maybe_mkdir(platform.fpath("/qspi"))
         with open(platform.fpath("/qspi/wallet.json"), "w") as fh:
             fh.write("{}")
 
-        fake = FakeFlash(block_count=platform.QSPI_END_BLOCK - 1)  # off by one
+        fake = FakeFlash(block_count=platform.QSPI_START_BLOCK)
+        self.fake = fake
+        pyb.Flash = lambda: fake
+
+        with self.assertRaises(Exception):
+            platform.wipe()
+
+        self.assertFalse(self.rebooted)
+        # must refuse before touching anything - not a single write,
+        # unmount, or delete
+        self.assertEqual(fake.calls, [])
+        self.assertEqual(self.umounted, [])
+        self.assertTrue(platform.file_exists(platform.fpath("/qspi/wallet.json")))
+
+    def test_unusable_block_size_aborts(self):
+        platform.maybe_mkdir(platform.fpath("/flash"))
+        with open(platform.fpath("/flash/secret.txt"), "w") as fh:
+            fh.write("still here")
+
+        fake = FakeFlash(block_size=0)
         self.fake = fake
         pyb.Flash = lambda: fake
 
@@ -421,10 +481,10 @@ class WipeHardwareTest(TestCase):
         self.assertFalse(self.rebooted)
         self.assertEqual(fake.calls, [])
         self.assertEqual(self.umounted, [])
-        self.assertTrue(platform.file_exists(platform.fpath("/qspi/wallet.json")))
+        self.assertTrue(platform.file_exists(platform.fpath("/flash/secret.txt")))
 
     def test_matching_geometry_does_not_block_the_wipe(self):
-        fake = FakeFlash(block_size=512, block_count=platform.QSPI_END_BLOCK)
+        fake = FakeFlash(block_size=512, block_count=VERIFIED_QSPI_END_BLOCK)
         self.fake = fake
         pyb.Flash = lambda: fake
 


### PR DESCRIPTION
## Problem

`platform.wipe()` deleted the QSPI filesystem but physically overwrote only the internal-flash range. Most of the 16 MiB QSPI user-data region could therefore remain recoverable from the chip.

## Resolution

- Replace the hardcoded range with the verified internal-flash and full-QSPI block map.
- Overwrite both regions in bounded chunks without loading the QSPI region into RAM.
- Validate flash geometry before destructive work and explicitly flush write-behind caches.
- Track write, sync, unmount, and wipe failures; never treat a partial wipe as successful.
- Build both `USE_DBOOT=0` and `USE_DBOOT=1` firmware configurations in CI.

## Note: this replaces #386

#386 was closed by accident, and the head branch was deleted in the same action. GitHub then refuses to reopen it: both `gh pr reopen` and the REST endpoint fail (`422 Validation Failed`), and the PR page offers no reopen control at all. Restoring the head branch to the exact commit it was closed at (`b93cdca`, via the PR page's own "Restore branch" button) did not lift the restriction. This PR therefore continues the same branch, `upstream/pr12-qspi-secure-wipe`, with no changes made for the move.

Please read #386 for the full review discussion — it is still worth reading and I have not copied it here.

## Review status carried over from #386

- @al-munazzim approved on 2026-08-26 after checking out the branch and running `python test/run_native_tests.py` (31 tests passing, CI green).
- @maggo83 raised five points on `src/platform.py`: comment length and fragile references into submodule paths, constants duplicating information the project already has, placement of the lower-level helpers relative to the existing architecture, wipe behaviour when `ioctl` reports unexpected sizes, and whether the `ok` flag should start pessimistic.

All five were answered in #386, and two led to code changes that are included here:

- `b93cdca` moves the block-map derivation into `docs/flash-block-map.md`, leaving a short block map plus a pointer in the code. The submodule references now live in the doc with a note to re-verify them on a submodule bump.
- `cd1012a` removes the block-size and QSPI-end constants; `wipe()` reads both back from the block device via `ioctl()`. The split point between `/flash` and `/qspi` remains, since no `ioctl` exposes it.

On the architectural placement I opened diybitcoinhardware/f469-disco#44 to get this exposed as a proper board-level API. Until that exists there is nothing to import, so the split point stays here for now.

The two remaining points (`ioctl`-controlling attacker, pessimistic `ok` flag) I argued against in #386 rather than changing; @maggo83, those are still open for you to push back on.

## Tests

The port includes native regression coverage for block boundaries, chunking, failures, geometry checks, sync ordering, and simulator behavior. CI also builds both firmware configurations.

## Previous testing and development history

This change was originally developed and tested in [Schnuartz/specter-diy#12](https://github.com/Schnuartz/specter-diy/pull/12). The original PR contains the full development history, test results, review discussion, and implementation details. The results below refer to the original source revision. Fresh CI on this upstream PR validates the cleanly ported revision against the current upstream master.

- `python3 test/run_native_tests.py`: 31/31 passed
- `python3 -m compileall src test`: successful
- Both firmware configurations (`USE_DBOOT=0` and `USE_DBOOT=1`) were built/tested on the source branch

## Remaining validation / limitations

The original #12 source revision was not tested on real hardware for completion of the full 16 MiB QSPI wipe. No hardware validation is claimed for this clean upstream revision. The pinned MicroPython drivers also do not expose every possible underlying erase/program failure to Python; this limitation is documented in the implementation.
