### PR TITLE
fix: only offer taproot descriptor for BIP-86 derivation paths

### DIFF
--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -318,6 +318,9 @@ class XpubApp(BaseApp):
             "taproot": ("tr(%s%s/{0,1}/*)" % (prefix, xpub), "Taproot"),
             # multisig is not supported yet - requires cosigners app
         })
+        # Only offer taproot for BIP-86 derivation paths
+        if "/86h/" not in derivation:
+            descriptors.pop("taproot", None)
 
         if version == net["ypub"]:
             buttons = [


### PR DESCRIPTION
## Problem

The `create_wallet()` menu at `src/apps/xpubs/xpubs.py:314-348` included taproot (`tr()`) as an option under "Other" for all derivation paths, including BIP-84 (`m/84h`). This let users create a taproot wallet from a BIP-86-incompatible xpub, producing a descriptor with the wrong script type for the derivation path.

Reported in #393.

## Fix

Only keep taproot in the descriptors dict when the derivation path contains `/86h/` (BIP-86). Pop it for all other paths before building the menu buttons:

```python
if "/86h/" not in derivation:
    descriptors.pop("taproot", None)
```

## Testing

- `python3 -c "import ast; ast.parse(open('src/apps/xpubs/xpubs.py').read())"` — syntax OK
- Verify on device: a BIP-84 xpub no longer offers taproot under "Other"; a BIP-86 xpub still offers taproot as "Recommended"

Fixes #393.
