### PR TITLE
refactor: remove dead experimental.taproot config

### DIFF
--- a/src/specter.py
+++ b/src/specter.py
@@ -532,42 +532,11 @@ class Specter:
                            key=self.keystore.settings_key
         )
 
-    async def experimental_settings(self):
-
-        controls = [{
-            "label": "Taproot",
-            "hint": "Taproot support only for single-key wallets\nwithout tap script trees",
-            "value": self.GLOBAL.get("experimental", {}).get("taproot", False)
-        }]
-
-        scr = HostSettings(
-            controls,
-            title="Experimental features",
-            note="Experimental features are unstable,\n"
-            "only enable them if you really want to try.\n"
-            "Report developers in case of any issues.",
-        )
-        res = await self.gui.show_screen()(scr)
-        if res is None:
-            return
-        taproot, *_ = res
-        # for now only experimental, can be extended
-        settings = {
-            "experimental": {
-                "taproot": taproot,
-            }
-        }
-        self.GLOBAL = settings
-        BaseApp.GLOBAL = settings
-        self.save_settings(settings)
-
     async def update_devsettings(self):
         buttons = [
             (None, "Categories")
         ] + [
             (1, "Communication"),
-            # (2, "Applications"),
-            # (3, "Experimental"),
         ] + [
             (None, "Global settings"),
             (42, "About this device"),
@@ -586,8 +555,6 @@ class Specter:
             )
             if menuitem == 255:
                 return
-            elif menuitem == 3:
-                await self.experimental_settings()
             elif menuitem == 456:
                 if await self.gui.prompt(
                     "Reboot the device?",


### PR DESCRIPTION
## Problem

The `experimental_settings()` function at `src/specter.py:535-562` wrote an `experimental.taproot` boolean to GLOBAL settings, but this value was never read anywhere in the codebase. The menu entry to reach it was already commented out (`# (3, "Experimental"),`). Taproot is supported unconditionally for BIP-86 single-key wallets via the xpubs app (`xpubs.py:318`).

This dead config was a source of confusion — see #316 where the user asked whether P2TR requires enabling an experimental toggle.

## Fix

Remove the dead `experimental_settings()` function, its unreachable `menuitem == 3` branch, and the commented-out menu entries.

## Testing

- `python3 -c "import ast; ast.parse(open('src/specter.py').read())"` — syntax OK
- `grep -n "experimental_settings\|experimental.*taproot" src/specter.py` — no remaining references
- Verify on device: settings menu still works; taproot wallet creation still works via xpubs app

Ref #316.
