### PR TITLE
fix: derive Taproot single-sig wallets from BIP86 (m/86'), keep m/84' recovery

### DIFF
--- a/docs/descriptors.md
+++ b/docs/descriptors.md
@@ -37,7 +37,12 @@ key-origin in the descriptor always matches the key that actually signs:
 | Taproot                | `tr()`       | `m/86h/coin_type_h/account_h` (BIP86) |
 | Legacy Specter Taproot | `tr()`       | `m/84h/coin_type_h/account_h` (recovery only) |
 
-`coin_type` is `0` on mainnet and `1` on testnet/regtest.
+`coin_type` is `0` on mainnet and `1` on testnet/regtest — it is always taken
+from the active network, never from the key you were looking at. The account
+index is carried over from that key (or the account selected in the menu).
+The one exception is **Legacy Specter Taproot**, which reproduces the displayed
+`m/84h` path verbatim (a non-standard `coin_type` included) so an old wallet is
+recreated exactly.
 
 ### Legacy Specter Taproot
 

--- a/docs/descriptors.md
+++ b/docs/descriptors.md
@@ -26,36 +26,54 @@ The descriptor `wpkh(xpub)` will be converted into `wpkh(xpub/{0,1}/*)`.
 ## Single-sig wallet types and their derivations
 
 When you create a single-sig wallet from **Master public keys -> ... -> Create
-wallet**, the script type you pick fixes the account derivation, so the
-key-origin in the descriptor always matches the key that actually signs:
+wallet**, the script type you pick fixes the derivation, so the key-origin in
+the descriptor always matches the key that actually signs:
 
-| Wallet type            | Descriptor   | Account derivation        |
-|------------------------|--------------|---------------------------|
-| Legacy                 | `pkh()`      | `m/44h/coin_type_h/account_h` |
-| Nested Segwit          | `sh(wpkh())` | `m/49h/coin_type_h/account_h` |
-| Native Segwit          | `wpkh()`     | `m/84h/coin_type_h/account_h` |
-| Taproot                | `tr()`       | `m/86h/coin_type_h/account_h` (BIP86) |
-| Legacy Specter Taproot | `tr()`       | `m/84h/coin_type_h/account_h` (recovery only) |
+| Wallet type   | Descriptor   | Standard derivation                   |
+|---------------|--------------|---------------------------------------|
+| Legacy        | `pkh()`      | `m/44h/coin_type_h/account_h` (BIP44) |
+| Nested Segwit | `sh(wpkh())` | `m/49h/coin_type_h/account_h` (BIP49) |
+| Native Segwit | `wpkh()`     | `m/84h/coin_type_h/account_h` (BIP84) |
+| Taproot       | `tr()`       | `m/86h/coin_type_h/account_h` (BIP86) |
 
-`coin_type` is `0` on mainnet and `1` on testnet/regtest — it is always taken
-from the active network, never from the key you were looking at. The account
-index is carried over from that key (or the account selected in the menu).
-The one exception is **Legacy Specter Taproot**, which reproduces the displayed
-`m/84h` path verbatim (a non-standard `coin_type` included) so an old wallet is
-recreated exactly.
+`coin_type` is always taken from the **active network**, never from the key you
+were looking at: `0` on Bitcoin mainnet, `1` on testnet/regtest/signet, and the
+network's registered value on Liquid (`1776` on Liquid mainnet, `1` on Liquid
+testnet/regtest). The account index is carried over from the displayed key
+(element `[2]`, so `m/48h/0h/3h/2h` gives account `3`) or the account selected
+in the menu. If the key on screen is not already on the standard path, the
+account key is genuinely re-derived from it — the descriptor never carries one
+path's key-origin over another path's key.
 
-### Legacy Specter Taproot
+### Recovering a non-standard wallet
 
-Older Specter DIY versions could create a Taproot (`tr()`) wallet on top of an
-`m/84h` (BIP84) account key instead of the BIP86 `m/86h` key. Those wallets are
-non-standard but their addresses are valid and may hold funds.
+Older Specter DIY versions built the descriptor by wrapping *whatever key was on
+screen* in the chosen script, so valid but non-standard wallets exist in the
+wild — for example `tr()` over an `m/84h` key, `pkh()` over an `m/84h` key,
+`wpkh()` over an `m/48h/.../2h` key, or any script over a custom path.
 
-To recover such a wallet, repeat the flow you used originally:
-**Master public keys -> Single key -> Create wallet -> Taproot** (the "Single
-key" entry is an `m/84h` key). The device then asks whether you want a standard
-BIP86 wallet (it re-derives the `m/86h` key) or the legacy `m/84h` recovery
-wallet, and the legacy choice is confirmed with a warning. This dialog is the
-only way to get an `m/84h + tr()` wallet; it is never offered for new wallets.
+Fresh wallets never do this. But if you pick a wallet type whose standard path
+differs from the key you are viewing, the device offers a choice:
+
+```
+<type> derivation
+[ Standard <type>            m/<purpose>h/<coin>h/<account>h ]
+[ Recover using displayed key   <the path on screen>          ]
+```
+
+`Recover using displayed key` wraps the exact displayed key (its full
+key-origin path preserved — purpose, coin type, account, and deeper levels such
+as BIP48) in the selected script, reproducing the historical wallet
+byte-for-byte. It is confirmed with a warning: this derivation is non-standard,
+other wallet software may not discover it from the seed alone, and it should
+only be used to recover an existing wallet. Cancelling or declining creates
+nothing.
+
+The BIP86 fix from issue #393 is a special case of this: from the `m/84h`
+"Single key", **Create wallet -> Taproot** offers *Standard Taproot* (re-derives
+`m/86h`) and *Recover using displayed key* (`tr(m/84h...)`, the wallet older
+firmware would have made). Keep your wallet descriptors/backups so recovery is
+never guesswork.
 
 ## Miniscript
 

--- a/docs/descriptors.md
+++ b/docs/descriptors.md
@@ -23,6 +23,35 @@ If the descriptor contains master public keys but doesn't contain wildcard deriv
 
 The descriptor `wpkh(xpub)` will be converted into `wpkh(xpub/{0,1}/*)`.
 
+## Single-sig wallet types and their derivations
+
+When you create a single-sig wallet from **Master public keys -> ... -> Create
+wallet**, the script type you pick fixes the account derivation, so the
+key-origin in the descriptor always matches the key that actually signs:
+
+| Wallet type            | Descriptor   | Account derivation        |
+|------------------------|--------------|---------------------------|
+| Legacy                 | `pkh()`      | `m/44h/coin_type_h/account_h` |
+| Nested Segwit          | `sh(wpkh())` | `m/49h/coin_type_h/account_h` |
+| Native Segwit          | `wpkh()`     | `m/84h/coin_type_h/account_h` |
+| Taproot                | `tr()`       | `m/86h/coin_type_h/account_h` (BIP86) |
+| Legacy Specter Taproot | `tr()`       | `m/84h/coin_type_h/account_h` (recovery only) |
+
+`coin_type` is `0` on mainnet and `1` on testnet/regtest.
+
+### Legacy Specter Taproot
+
+Older Specter DIY versions could create a Taproot (`tr()`) wallet on top of an
+`m/84h` (BIP84) account key instead of the BIP86 `m/86h` key. Those wallets are
+non-standard but their addresses are valid and may hold funds. The
+**Legacy Specter Taproot** option under "Recovery only" recreates exactly that
+`m/84h + tr()` wallet so the funds stay recoverable. Do not use it for new
+wallets - new Taproot wallets must use BIP86.
+
+If you repeat the old "Single key -> Create wallet -> Taproot" flow (Single key
+is an `m/84h` key), the device asks whether you want a standard BIP86 wallet
+(it re-derives the `m/86h` key) or the legacy `m/84h` recovery wallet.
+
 ## Miniscript
 
 Specter supports miniscript, but doesn't support policy-to-miniscript compilation (because it's way too expensive). We perform some checks on the miniscipt, so only `B` scripts are allowed on the top level and all arguments in sub-miniscripts have to have properties according to the [spec](http://bitcoin.sipa.be/miniscript/).

--- a/docs/descriptors.md
+++ b/docs/descriptors.md
@@ -43,14 +43,14 @@ key-origin in the descriptor always matches the key that actually signs:
 
 Older Specter DIY versions could create a Taproot (`tr()`) wallet on top of an
 `m/84h` (BIP84) account key instead of the BIP86 `m/86h` key. Those wallets are
-non-standard but their addresses are valid and may hold funds. The
-**Legacy Specter Taproot** option under "Recovery only" recreates exactly that
-`m/84h + tr()` wallet so the funds stay recoverable. Do not use it for new
-wallets - new Taproot wallets must use BIP86.
+non-standard but their addresses are valid and may hold funds.
 
-If you repeat the old "Single key -> Create wallet -> Taproot" flow (Single key
-is an `m/84h` key), the device asks whether you want a standard BIP86 wallet
-(it re-derives the `m/86h` key) or the legacy `m/84h` recovery wallet.
+To recover such a wallet, repeat the flow you used originally:
+**Master public keys -> Single key -> Create wallet -> Taproot** (the "Single
+key" entry is an `m/84h` key). The device then asks whether you want a standard
+BIP86 wallet (it re-derives the `m/86h` key) or the legacy `m/84h` recovery
+wallet, and the legacy choice is confirmed with a warning. This dialog is the
+only way to get an `m/84h + tr()` wallet; it is never offered for new wallets.
 
 ## Miniscript
 

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -351,7 +351,8 @@ class XpubApp(BaseApp):
         wallets are always (re-)derived from the BIP purpose that matches their
         script type (see ``WALLET_TYPES``), so the descriptor key-origin and the
         actual signing key can never disagree. ``m/84' + tr()`` is only reachable
-        through the explicit "Legacy Specter Taproot" recovery option.
+        by picking Taproot from an m/84' key and choosing recovery in the
+        follow-up dialog.
         """
         net = NETWORKS[self.network]
         parsed = _parse_account_path(derivation)
@@ -365,22 +366,20 @@ class XpubApp(BaseApp):
         for key in WALLET_TYPES:
             if key != recommended:
                 buttons.append((key, WALLET_TYPES[key][2]))
-        buttons.append((None, "Recovery only"))
-        buttons.append(("legacy_taproot", LEGACY_SPECTER_TAPROOT[2]))
 
         menuitem = await show_screen(Menu(
             buttons, last=(255, None),
             title="Select wallet type to create",
-            note="Standard Taproot uses BIP86 (m/86h)",
         ))
-        if menuitem == 255 or menuitem is None:
+        if menuitem == 255 or menuitem is None or menuitem not in WALLET_TYPES:
             return
 
-        legacy = (menuitem == "legacy_taproot")
+        legacy = False
 
         # Repeating the historical "Single key -> Create Wallet -> Taproot" flow
         # ("Single key" is an m/84' key) must not silently create a legacy
-        # wallet - offer an explicit migration/recovery choice instead.
+        # wallet - offer an explicit standard/recovery choice instead. This is
+        # also the only way to reach the legacy m/84' + tr() derivation.
         if menuitem == "taproot" and parsed is not None and parsed[0] == 84:
             choice = await show_screen(Menu(
                 [

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -11,39 +11,67 @@ import platform
 from collections import OrderedDict
 
 # --- Standard single-sig wallet types --------------------------------------
-# Each script type is bound to the BIP purpose whose account key it MUST be
-# derived from. Older Specter DIY firmware let the wallet-creation menu pair
-# the currently displayed key with an arbitrary script wrapper, which made it
-# possible to build a Taproot tr() wallet on top of an m/84' (BIP84) account
-# key instead of the BIP86 m/86' key (issue #393). Keeping this mapping
-# explicit makes that class of mismatch impossible for the standard flow.
-# value: (bip_purpose, descriptor_template, human_name)
+# Each script type has exactly one standard BIP purpose and account-key
+# derivation. Fresh wallets are always built from that derivation - the
+# account key is re-derived when the key currently on screen sits on a
+# different path - so the descriptor key-origin and the signing key can never
+# disagree (issue #393).
+#
+# Older Specter DIY firmware instead wrapped *whatever key was on screen* in
+# the chosen script (issues #393, #281), so valid-but-non-standard wallets
+# exist in the wild: tr(m/84'...), pkh(m/84'...), wpkh(m/48'.../2'...),
+# tr(<custom>...), ... Those stay reproducible through a single generic
+# "recover using the displayed key" choice, shown only when the displayed
+# path differs from the standard one and guarded by a warning - never as an
+# ordinary wallet type.
+# value: (bip_purpose, descriptor_template, menu_label, name_prefix)
 WALLET_TYPES = OrderedDict([
-    ("wpkh",    (84, "wpkh(%s%s/{0,1}/*)",     "Native Segwit")),
-    ("nested",  (49, "sh(wpkh(%s%s/{0,1}/*))", "Nested Segwit")),
-    ("legacy",  (44, "pkh(%s%s/{0,1}/*)",      "Legacy")),
-    ("taproot", (86, "tr(%s%s/{0,1}/*)",       "Taproot")),
+    ("wpkh",    (84, "wpkh(%s%s/{0,1}/*)",     "Native Segwit", "Native")),
+    ("nested",  (49, "sh(wpkh(%s%s/{0,1}/*))", "Nested Segwit", "Nested")),
+    ("legacy",  (44, "pkh(%s%s/{0,1}/*)",      "Legacy",        "Legacy")),
+    ("taproot", (86, "tr(%s%s/{0,1}/*)",       "Taproot",       "Taproot")),
 ])
-_PURPOSE_TO_TYPE = {84: "wpkh", 49: "nested", 44: "legacy", 86: "taproot"}
-
-# Legacy Specter Taproot: recovery only. Older Specter DIY versions could
-# create P2TR wallets using an m/84' account key. This derivation is kept
-# ONLY so those wallets (and any funds on them) stay recoverable. New Taproot
-# wallets must use BIP86 (m/86').
-LEGACY_SPECTER_TAPROOT = (84, "tr(%s%s/{0,1}/*)", "Legacy Specter Taproot")
+_PURPOSE_TO_TYPE = {v[0]: k for k, v in WALLET_TYPES.items()}
 
 _HARDENED = 0x80000000
 
 
-def _parse_account_path(derivation):
-    """Return ``(purpose, coin, account)`` for an ``m/P'/C'/A'`` path, else None."""
+def _parse_path(derivation):
+    """Parsed index list for a derivation string, or None if unparseable."""
     try:
-        idxs = bip32.parse_path(derivation)
+        return bip32.parse_path(derivation)
     except Exception:
         return None
-    if len(idxs) != 3 or not all(i >= _HARDENED for i in idxs):
+
+
+def _same_path(a, b):
+    """True when two derivation strings denote the same BIP32 path."""
+    pa = _parse_path(a)
+    return pa is not None and pa == _parse_path(b)
+
+
+def _account_index(derivation):
+    """Best-effort account number: element [2] when the first three levels are
+    hardened. Covers ``m/P'/C'/A'`` and deeper paths (e.g. BIP48
+    ``m/48'/C'/A'/script'``). Returns None when there is no such element."""
+    idxs = _parse_path(derivation)
+    if idxs is None or len(idxs) < 3 or not all(i >= _HARDENED for i in idxs[:3]):
         return None
-    return tuple(i - _HARDENED for i in idxs)
+    return idxs[2] - _HARDENED
+
+
+def _standard_wallet_type(derivation, coin):
+    """The WALLET_TYPES key whose *standard* derivation the displayed path
+    already matches: exactly three hardened levels, a known purpose, and this
+    network's coin_type. None for non-standard / deeper / custom paths (so the
+    UI never calls a wrong-coin_type or multisig key "recommended")."""
+    idxs = _parse_path(derivation)
+    if idxs is None or len(idxs) != 3 or not all(i >= _HARDENED for i in idxs):
+        return None
+    purpose, coin_type = idxs[0] - _HARDENED, idxs[1] - _HARDENED
+    if coin_type != coin:
+        return None
+    return _PURPOSE_TO_TYPE.get(purpose)
 
 
 class XpubApp(BaseApp):
@@ -347,16 +375,16 @@ class XpubApp(BaseApp):
     async def create_wallet(self, derivation, xpub, prefix, show_screen):
         """Shows a wallet-creation menu and passes a descriptor to the wallets app.
 
-        The wallet type the user picks determines the derivation: standard
-        wallets are always (re-)derived from the BIP purpose that matches their
-        script type (see ``WALLET_TYPES``), so the descriptor key-origin and the
-        actual signing key can never disagree. ``m/84' + tr()`` is only reachable
-        by picking Taproot from an m/84' key and choosing recovery in the
-        follow-up dialog.
+        The script type the user picks fixes the derivation (see
+        ``WALLET_TYPES``). When the key on screen is not already on that path,
+        the user explicitly chooses between the standard wallet (account key
+        re-derived from the standard path) and a warned recovery wallet built
+        from the displayed key verbatim - the only way to reproduce the
+        non-standard script/derivation pairs older firmware could create.
         """
         net = NETWORKS[self.network]
-        parsed = _parse_account_path(derivation)
-        recommended = _PURPOSE_TO_TYPE.get(parsed[0]) if parsed else None
+        coin = net["bip32"]
+        recommended = _standard_wallet_type(derivation, coin)
 
         buttons = []
         if recommended:
@@ -374,74 +402,68 @@ class XpubApp(BaseApp):
         if menuitem == 255 or menuitem is None or menuitem not in WALLET_TYPES:
             return
 
-        legacy = False
+        purpose, template, type_name, name_prefix = WALLET_TYPES[menuitem]
+        # Standard wallets follow the BIP44 layout: purpose fixed by the script
+        # type, coin_type fixed by the active network, account carried over from
+        # the displayed key (or the account selected in the menu).
+        account = _account_index(derivation)
+        std_account = account if account is not None else self.account
+        std_target = "m/%dh/%dh/%dh" % (purpose, coin, std_account)
 
-        # Repeating the historical "Single key -> Create Wallet -> Taproot" flow
-        # ("Single key" is an m/84' key) must not silently create a legacy
-        # wallet - offer an explicit standard/recovery choice instead. This is
-        # also the only way to reach the legacy m/84' + tr() derivation.
-        if menuitem == "taproot" and parsed is not None and parsed[0] == 84:
+        use_displayed = False
+        if not _same_path(derivation, std_target):
+            # The displayed key would be discarded for a standard wallet. Make
+            # the choice - and the non-standard option - explicit.
             choice = await show_screen(Menu(
                 [
-                    ("standard", "Standard Taproot\nm/86h (BIP86)"),
-                    ("legacy", "Recover legacy Specter Taproot\nm/84h"),
+                    ("standard",
+                     "Standard %s\n%s" % (type_name, std_target)),
+                    ("recover",
+                     "Recover using displayed key\n%s\nNon-standard - recovery only"
+                     % derivation),
                 ],
                 last=(255, None),
-                title="Taproot derivation",
-                note=("Standard Taproot wallets use BIP86 (m/86h). Older "
-                      "Specter DIY versions could create Taproot wallets "
-                      "using m/84h."),
+                title="%s derivation" % type_name,
+                note=("New wallets use the standard path. Recovery reproduces a "
+                      "wallet made with older Specter DIY versions."),
             ))
             if choice == 255 or choice is None:
                 return
-            legacy = (choice == "legacy")
+            use_displayed = (choice == "recover")
 
-        if legacy:
-            purpose, template, type_name = LEGACY_SPECTER_TAPROOT
+        if use_displayed:
             confirm = await show_screen(Prompt(
-                "Legacy Specter Taproot",
-                "This recreates a Taproot wallet from the non-standard m/84h "
-                "derivation used by older Specter DIY firmware.\n\n"
-                "Use it only to recover existing funds. New Taproot wallets "
-                "must use BIP86 (m/86h).\n\nContinue?",
-                warning="Recovery only - not for new wallets",
+                "Recover non-standard wallet",
+                "This builds a %s wallet from the key you are viewing:\n\n"
+                "%s\n\n"
+                "This derivation is NOT standard. Other wallet software may "
+                "not discover it from your seed automatically. Only continue "
+                "if you are deliberately recovering an existing wallet."
+                "\n\nContinue?" % (type_name, derivation),
+                warning="Recovery only - non-standard derivation",
             ))
             if not confirm:
                 return
-            # Recovery must reproduce the displayed m/84' path *exactly*, incl.
-            # a non-standard coin_type from a custom derivation - that is what
-            # the older firmware signed with. `legacy` is only ever set when
-            # `parsed` is a hardened m/84'/coin'/account' path.
-            coin, account = parsed[1], parsed[2]
-        else:
-            purpose, template, type_name = WALLET_TYPES[menuitem]
-            # Standard wallets follow the BIP44 structure: coin_type is fixed by
-            # the active network (0 mainnet / 1 testnet), never taken from the
-            # displayed key. Only the account index is carried over.
-            coin = net["bip32"]
-            account = parsed[2] if parsed is not None else self.account
-
-        target = "m/%dh/%dh/%dh" % (purpose, coin, account)
-        if _parse_account_path(target) == parsed:
+            # displayed key + its exact key-origin path, wrapped in the chosen
+            # script - byte-for-byte what the older firmware produced.
+            key_prefix, key_xpub = prefix, xpub
+        elif _same_path(derivation, std_target):
             key_prefix, key_xpub = prefix, xpub
         else:
             self.show_loader(title="Deriving %s key..." % type_name)
-            hdkey = self.keystore.get_xpub(target)
+            hdkey = self.keystore.get_xpub(std_target)
             key_xpub = hdkey.to_base58(net["xpub"])
             fingerprint = hexlify(self.keystore.fingerprint).decode()
-            key_prefix = "[%s/%s]" % (fingerprint, target[2:])
+            key_prefix = "[%s/%s]" % (fingerprint, std_target[2:])
 
         desc = template % (key_prefix, key_xpub)
 
         # get wallet names from the wallets app
         s, _ = await self.communicate(BytesIO(b"listwallets"), app="wallets")
         names = json.load(s)
-        sel = "legacy_taproot" if legacy else menuitem
-        name_bases = {
-            "wpkh": "Native", "nested": "Nested", "legacy": "Legacy",
-            "taproot": "Taproot", "legacy_taproot": "Legacy Taproot",
-        }
-        nn = "%s %d" % (name_bases.get(sel, "Wallet"), account)
+        base_account = account if account is not None else std_account
+        nn = "%s %d%s" % (name_prefix, base_account,
+                          " recovery" if use_displayed else "")
         name_suggestion = nn
         i = 1
         # make sure we don't suggest an existing name

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -440,7 +440,7 @@ class XpubApp(BaseApp):
                 "not discover it from your seed automatically. Only continue "
                 "if you are deliberately recovering an existing wallet."
                 "\n\nContinue?" % (type_name, derivation),
-                warning="Recovery only - non-standard derivation",
+                warning="Non-standard - recovery only",
             ))
             if not confirm:
                 return

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -408,16 +408,18 @@ class XpubApp(BaseApp):
             ))
             if not confirm:
                 return
-        else:
-            purpose, template, type_name = WALLET_TYPES[menuitem]
-
-        # coin type / account: reuse the ones from the displayed path when it is
-        # a standard account path, otherwise fall back to the selected account
-        # and the network-default coin type.
-        if parsed is not None:
+            # Recovery must reproduce the displayed m/84' path *exactly*, incl.
+            # a non-standard coin_type from a custom derivation - that is what
+            # the older firmware signed with. `legacy` is only ever set when
+            # `parsed` is a hardened m/84'/coin'/account' path.
             coin, account = parsed[1], parsed[2]
         else:
-            coin, account = net["bip32"], self.account
+            purpose, template, type_name = WALLET_TYPES[menuitem]
+            # Standard wallets follow the BIP44 structure: coin_type is fixed by
+            # the active network (0 mainnet / 1 testnet), never taken from the
+            # displayed key. Only the account index is carried over.
+            coin = net["bip32"]
+            account = parsed[2] if parsed is not None else self.account
 
         target = "m/%dh/%dh/%dh" % (purpose, coin, account)
         if _parse_account_path(target) == parsed:

--- a/src/apps/xpubs/xpubs.py
+++ b/src/apps/xpubs/xpubs.py
@@ -10,6 +10,42 @@ from io import BytesIO
 import platform
 from collections import OrderedDict
 
+# --- Standard single-sig wallet types --------------------------------------
+# Each script type is bound to the BIP purpose whose account key it MUST be
+# derived from. Older Specter DIY firmware let the wallet-creation menu pair
+# the currently displayed key with an arbitrary script wrapper, which made it
+# possible to build a Taproot tr() wallet on top of an m/84' (BIP84) account
+# key instead of the BIP86 m/86' key (issue #393). Keeping this mapping
+# explicit makes that class of mismatch impossible for the standard flow.
+# value: (bip_purpose, descriptor_template, human_name)
+WALLET_TYPES = OrderedDict([
+    ("wpkh",    (84, "wpkh(%s%s/{0,1}/*)",     "Native Segwit")),
+    ("nested",  (49, "sh(wpkh(%s%s/{0,1}/*))", "Nested Segwit")),
+    ("legacy",  (44, "pkh(%s%s/{0,1}/*)",      "Legacy")),
+    ("taproot", (86, "tr(%s%s/{0,1}/*)",       "Taproot")),
+])
+_PURPOSE_TO_TYPE = {84: "wpkh", 49: "nested", 44: "legacy", 86: "taproot"}
+
+# Legacy Specter Taproot: recovery only. Older Specter DIY versions could
+# create P2TR wallets using an m/84' account key. This derivation is kept
+# ONLY so those wallets (and any funds on them) stay recoverable. New Taproot
+# wallets must use BIP86 (m/86').
+LEGACY_SPECTER_TAPROOT = (84, "tr(%s%s/{0,1}/*)", "Legacy Specter Taproot")
+
+_HARDENED = 0x80000000
+
+
+def _parse_account_path(derivation):
+    """Return ``(purpose, coin, account)`` for an ``m/P'/C'/A'`` path, else None."""
+    try:
+        idxs = bip32.parse_path(derivation)
+    except Exception:
+        return None
+    if len(idxs) != 3 or not all(i >= _HARDENED for i in idxs):
+        return None
+    return tuple(i - _HARDENED for i in idxs)
+
+
 class XpubApp(BaseApp):
     """
     WalletManager class manages your wallets.
@@ -296,7 +332,7 @@ class XpubApp(BaseApp):
             XPubScreen(xpub=canonical, slip132=slip132, prefix=prefix)
         )
         if res == XPubScreen.CREATE_WALLET:
-            await self.create_wallet(derivation, canonical, prefix, ver, show_screen)
+            await self.create_wallet(derivation, canonical, prefix, show_screen)
         elif res:
             filename = "%s-%s.txt" % (fingerprint, derivation[2:].replace("/", "-"))
             with platform.sdcard as sd:
@@ -308,83 +344,121 @@ class XpubApp(BaseApp):
                       button_text="Close")
             )
 
-    async def create_wallet(self, derivation, xpub, prefix, version, show_screen):
-        """Shows a wallet creation menu and passes descriptor to the wallets app"""
-        net = NETWORKS[self.network]
-        descriptors = OrderedDict({
-            "zpub": ("wpkh(%s%s/{0,1}/*)" % (prefix, xpub), "Native Segwit"),
-            "ypub": ("sh(wpkh(%s%s/{0,1}/*))" % (prefix, xpub), "Nested Segwit"),
-            "legacy": ("pkh(%s%s/{0,1}/*)" % (prefix, xpub), "Legacy"),
-            "taproot": ("tr(%s%s/{0,1}/*)" % (prefix, xpub), "Taproot"),
-            # multisig is not supported yet - requires cosigners app
-        })
+    async def create_wallet(self, derivation, xpub, prefix, show_screen):
+        """Shows a wallet-creation menu and passes a descriptor to the wallets app.
 
-        if version == net["ypub"]:
-            buttons = [
-                (None, "Recommended"),
-                descriptors.pop("ypub"),
-                (None, "Other"),
-            ]
-        elif version == net["zpub"]:
-            buttons = [
-                (None, "Recommended"),
-                descriptors.pop("zpub"),
-                (None, "Other"),
-            ]
-        elif "/86h/" in derivation:
-            buttons = [
-                (None, "Recommended"),
-                descriptors.pop("taproot"),
-                (None, "Other"),
-            ]
-        elif "/44h/" in derivation:
-            buttons = [
-                (None, "Recommended"),
-                descriptors.pop("legacy"),
-                (None, "Other"),
-            ]
-        else:
-            buttons = []
-        buttons += [descriptors[k] for k in descriptors]
-        menuitem = await show_screen(Menu(buttons, last=(255, None),
-                                     title="Select wallet type to create"))
-        if menuitem == 255:
+        The wallet type the user picks determines the derivation: standard
+        wallets are always (re-)derived from the BIP purpose that matches their
+        script type (see ``WALLET_TYPES``), so the descriptor key-origin and the
+        actual signing key can never disagree. ``m/84' + tr()`` is only reachable
+        through the explicit "Legacy Specter Taproot" recovery option.
+        """
+        net = NETWORKS[self.network]
+        parsed = _parse_account_path(derivation)
+        recommended = _PURPOSE_TO_TYPE.get(parsed[0]) if parsed else None
+
+        buttons = []
+        if recommended:
+            buttons.append((None, "Recommended"))
+            buttons.append((recommended, WALLET_TYPES[recommended][2]))
+        buttons.append((None, "Other"))
+        for key in WALLET_TYPES:
+            if key != recommended:
+                buttons.append((key, WALLET_TYPES[key][2]))
+        buttons.append((None, "Recovery only"))
+        buttons.append(("legacy_taproot", LEGACY_SPECTER_TAPROOT[2]))
+
+        menuitem = await show_screen(Menu(
+            buttons, last=(255, None),
+            title="Select wallet type to create",
+            note="Standard Taproot uses BIP86 (m/86h)",
+        ))
+        if menuitem == 255 or menuitem is None:
             return
-        else:
-            # get wallet names from the wallets app
-            s, _ = await self.communicate(BytesIO(b"listwallets"), app="wallets")
-            names = json.load(s)
-            if menuitem.startswith("pkh("):
-                name_suggestion = "Legacy %d" % self.account
-            elif menuitem.startswith("wpkh("):
-                name_suggestion = "Native %d" % self.account
-            elif menuitem.startswith("sh(wpkh("):
-                name_suggestion = "Nested %d" % self.account
-            elif menuitem.startswith("tr("):
-                name_suggestion = "Taproot %d" % self.account
-            else:
-                name_suggestion = "Wallet %d" % self.account
-            nn = name_suggestion
-            i = 1
-            # make sure we don't suggest existing name
-            while name_suggestion in names:
-                name_suggestion = "%s (%d)" % (nn, i)
-                i += 1
-            name = await show_screen(InputScreen(title="Name your wallet",
-                    note="",
-                    suggestion=name_suggestion,
-                    min_length=1, strip=True
+
+        legacy = (menuitem == "legacy_taproot")
+
+        # Repeating the historical "Single key -> Create Wallet -> Taproot" flow
+        # ("Single key" is an m/84' key) must not silently create a legacy
+        # wallet - offer an explicit migration/recovery choice instead.
+        if menuitem == "taproot" and parsed is not None and parsed[0] == 84:
+            choice = await show_screen(Menu(
+                [
+                    ("standard", "Standard Taproot\nm/86h (BIP86)"),
+                    ("legacy", "Recover legacy Specter Taproot\nm/84h"),
+                ],
+                last=(255, None),
+                title="Taproot derivation",
+                note=("Standard Taproot wallets use BIP86 (m/86h). Older "
+                      "Specter DIY versions could create Taproot wallets "
+                      "using m/84h."),
             ))
-            if not name:
+            if choice == 255 or choice is None:
                 return
-            # send the wallets app addwallet command with descriptor
-            desc = menuitem
-            # add blinding key on liquid
-            if is_liquid(self.network):
-                desc = "blinded(slip77(%s),%s)" % (self.keystore.slip77_key, desc)
-            data = "addwallet %s&%s" % (name, desc)
-            stream = BytesIO(data.encode())
-            await self.communicate(stream, app="wallets")
+            legacy = (choice == "legacy")
+
+        if legacy:
+            purpose, template, type_name = LEGACY_SPECTER_TAPROOT
+            confirm = await show_screen(Prompt(
+                "Legacy Specter Taproot",
+                "This recreates a Taproot wallet from the non-standard m/84h "
+                "derivation used by older Specter DIY firmware.\n\n"
+                "Use it only to recover existing funds. New Taproot wallets "
+                "must use BIP86 (m/86h).\n\nContinue?",
+                warning="Recovery only - not for new wallets",
+            ))
+            if not confirm:
+                return
+        else:
+            purpose, template, type_name = WALLET_TYPES[menuitem]
+
+        # coin type / account: reuse the ones from the displayed path when it is
+        # a standard account path, otherwise fall back to the selected account
+        # and the network-default coin type.
+        if parsed is not None:
+            coin, account = parsed[1], parsed[2]
+        else:
+            coin, account = net["bip32"], self.account
+
+        target = "m/%dh/%dh/%dh" % (purpose, coin, account)
+        if _parse_account_path(target) == parsed:
+            key_prefix, key_xpub = prefix, xpub
+        else:
+            self.show_loader(title="Deriving %s key..." % type_name)
+            hdkey = self.keystore.get_xpub(target)
+            key_xpub = hdkey.to_base58(net["xpub"])
+            fingerprint = hexlify(self.keystore.fingerprint).decode()
+            key_prefix = "[%s/%s]" % (fingerprint, target[2:])
+
+        desc = template % (key_prefix, key_xpub)
+
+        # get wallet names from the wallets app
+        s, _ = await self.communicate(BytesIO(b"listwallets"), app="wallets")
+        names = json.load(s)
+        sel = "legacy_taproot" if legacy else menuitem
+        name_bases = {
+            "wpkh": "Native", "nested": "Nested", "legacy": "Legacy",
+            "taproot": "Taproot", "legacy_taproot": "Legacy Taproot",
+        }
+        nn = "%s %d" % (name_bases.get(sel, "Wallet"), account)
+        name_suggestion = nn
+        i = 1
+        # make sure we don't suggest an existing name
+        while name_suggestion in names:
+            name_suggestion = "%s (%d)" % (nn, i)
+            i += 1
+        name = await show_screen(InputScreen(title="Name your wallet",
+                note="",
+                suggestion=name_suggestion,
+                min_length=1, strip=True
+        ))
+        if not name:
+            return
+        # add blinding key on liquid
+        if is_liquid(self.network):
+            desc = "blinded(slip77(%s),%s)" % (self.keystore.slip77_key, desc)
+        data = "addwallet %s&%s" % (name, desc)
+        await self.communicate(BytesIO(data.encode()), app="wallets")
 
 
     async def save_menu(self, show_screen):

--- a/src/gui/screens/prompt.py
+++ b/src/gui/screens/prompt.py
@@ -17,9 +17,6 @@ class Prompt(Screen):
         self.page.set_size(480, 600)
         self.message = add_label(message, scr=self.page)
         self.page.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 0)
-        # Initialize an empty icon label. It will display nothing until a symbol is set.
-        self.icon = lv.label(self)
-        self.icon.set_text("")
 
         (self.cancel_button, self.confirm_button) = add_button_pair(
             cancel_text,
@@ -30,15 +27,12 @@ class Prompt(Screen):
         )
 
         if warning:
-            self.warning = add_label(warning, scr=self, style="warning")
-            # Display warning symbol in the icon label 
-            self.icon.set_text(lv.SYMBOL.WARNING)
-            
-            # Align warning text
+            # Warning symbol inline with the orange warning text, above the
+            # buttons - not floating over the title.
+            self.warning = add_label(
+                lv.SYMBOL.WARNING + " " + warning, scr=self, style="warning"
+            )
             y_pos = self.cancel_button.get_y() - 60 # above the buttons
-            x_pos = self.get_width() // 2 - self.warning.get_width() // 2 # in the center of the prompt
+            x_pos = self.get_width() // 2 - self.warning.get_width() // 2 # centered
             self.warning.set_pos(x_pos, y_pos)
-            
-            # Align warning icon to the left of the title
-            self.icon.align(self.title, lv.ALIGN.IN_LEFT_MID, 90, 0)
 

--- a/test/native_support.py
+++ b/test/native_support.py
@@ -105,7 +105,13 @@ def setup_native_stubs():
         "DevSettings",
     ]:
         if not hasattr(screens, _name):
-            setattr(screens, _name, type(_name, (), {}))
+            # accept (and ignore) constructor args so app code that does
+            # `Menu(buttons, title=...)` can be exercised natively
+            setattr(
+                screens,
+                _name,
+                type(_name, (), {"__init__": lambda self, *a, **k: None}),
+            )
 
     _ensure_submodule("gui.screens", "mnemonic", {
         "ExportMnemonicScreen": type("ExportMnemonicScreen", (), {}),
@@ -123,6 +129,8 @@ def setup_native_stubs():
     common = _ensure_module("gui.common")
     if not hasattr(common, "HOR_RES"):
         common.HOR_RES = 480
+    if not hasattr(common, "PADDING"):
+        common.PADDING = 20
     if not hasattr(common, "styles"):
         common.styles = types.SimpleNamespace()
     for _name in [

--- a/test/tests/util.py
+++ b/test/tests/util.py
@@ -40,6 +40,14 @@ def get_keystore(mnemonic="ability "*11+"acid", password=""):
     ks.set_mnemonic(mnemonic, password)
     return ks
 
+def get_xpubs_app(keystore, network):
+    from apps.xpubs import App as XpubsApp
+    platform.maybe_mkdir(TEST_DIR)
+    platform.maybe_mkdir(TEST_DIR+"/xpubs")
+    app = XpubsApp(TEST_DIR+"/xpubs")
+    app.init(keystore, network, show_loader, communicate)
+    return app
+
 def get_wallets_app(keystore, network):
     platform.maybe_mkdir(TEST_DIR)
     platform.maybe_mkdir(TEST_DIR+"/wallets")

--- a/test/tests_native/__init__.py
+++ b/test/tests_native/__init__.py
@@ -1,1 +1,2 @@
 from .test_wallet_manager_parsing import *
+from .test_xpub_wallet_creation import *

--- a/test/tests_native/test_xpub_wallet_creation.py
+++ b/test/tests_native/test_xpub_wallet_creation.py
@@ -163,17 +163,15 @@ class TaprootWalletCreationTest(TestCase):
         indep = _address(expected, "main", 0, 0)
         self.assertEqual(_address(desc, "main", 0, 0), indep)
 
-    def test_legacy_taproot_menu_entry_without_migration(self):
+    def test_no_dedicated_legacy_menu_entry(self):
+        # the legacy m/84' + tr() derivation is only reachable through the
+        # migration dialog - there is no standalone wallet-type entry for it
         sink, _ = self._create(
             "m/86h/0h/0h",
             {"Menu": ["legacy_taproot"], "Prompt": [True],
              "InputScreen": ["l"]},
         )
-        _, desc = sink.added[0]
-        self.assertIn("/84h/0h/0h]", desc)
-        self.assertEqual(
-            desc, _expected_descriptor(self.app, "m/84h/0h/0h", "tr(%s%s/{0,1}/*)")
-        )
+        self.assertEqual(sink.added, [])
 
     # -- D: standard and legacy differ ------------------------------
     def test_standard_and_legacy_addresses_differ(self):
@@ -281,8 +279,8 @@ class TaprootWalletCreationTest(TestCase):
 
     def test_legacy_prompt_decline_creates_no_wallet(self):
         sink, _ = self._create(
-            "m/86h/0h/0h",
-            {"Menu": ["legacy_taproot"], "Prompt": [False]},
+            "m/84h/0h/0h",
+            {"Menu": ["taproot", "legacy"], "Prompt": [False]},
         )
         self.assertEqual(sink.added, [])
 

--- a/test/tests_native/test_xpub_wallet_creation.py
+++ b/test/tests_native/test_xpub_wallet_creation.py
@@ -1,7 +1,16 @@
 """
-Regression tests for issue #393 - Taproot wallet creation must use BIP86
-(m/86') while keeping the non-standard "legacy Specter Taproot" m/84' + tr()
-wallets explicitly recoverable.
+Regression tests for on-device single-sig wallet creation
+(``src/apps/xpubs/xpubs.py``).
+
+Covers:
+* issue #393 - fresh Taproot wallets must use BIP86 (m/86'), with the account
+  key genuinely re-derived, not relabelled;
+* the standard script -> BIP-purpose mapping for all four single-sig types;
+* the generic "recover using the displayed key" path that reproduces the
+  valid-but-non-standard script/derivation pairs older Specter DIY firmware
+  could create (issues #393, #281);
+* coin_type normalisation, accounts, testnet, Liquid, deep BIP48 paths,
+  cancel/back/decline.
 """
 import sys
 
@@ -12,13 +21,16 @@ if sys.implementation.name != 'micropython':
 
 import asyncio
 import gc
+import json
 from binascii import hexlify
 from io import BytesIO
 from unittest import TestCase
 
 from embit import bip32
 from embit.descriptor import Descriptor
-from embit.networks import NETWORKS
+# liquid.networks is a superset of the Bitcoin NETWORKS (adds liquidv1, ...) -
+# xpubs.py imports it too, so the tests must agree on coin_type / version bytes
+from embit.liquid.networks import NETWORKS
 
 from tests.util import get_keystore, get_xpubs_app, clear_testdir
 
@@ -61,7 +73,6 @@ class WalletSink:
     async def __call__(self, stream, app=None):
         data = stream.read()
         if data == b"listwallets":
-            import json
             return BytesIO(json.dumps(self.existing).encode()), {}
         text = data.decode()
         assert text.startswith("addwallet "), text
@@ -71,7 +82,7 @@ class WalletSink:
 
 
 def _shown_xpub(app, derivation):
-    """Reproduce what show_xpub() hands to create_wallet()."""
+    """Reproduce exactly what show_xpub() hands to create_wallet()."""
     net = NETWORKS[app.network]
     x = app.keystore.get_xpub(derivation)
     canonical = x.to_base58(net["xpub"])
@@ -80,12 +91,17 @@ def _shown_xpub(app, derivation):
     return derivation, canonical, prefix
 
 
-def _expected_descriptor(app, derivation, script_tmpl):
+def _origin_xpub(app, derivation):
+    """(key-origin string, base58 xpub) for a path, as the app would emit it."""
     net = NETWORKS[app.network]
-    x = app.keystore.get_xpub(derivation)
+    x = app.keystore.get_xpub(derivation).to_base58(net["xpub"])
     fp = hexlify(app.keystore.fingerprint).decode()
-    prefix = "[%s/%s]" % (fp, derivation[2:])
-    return script_tmpl % (prefix, x.to_base58(net["xpub"]))
+    return "[%s/%s]" % (fp, derivation[2:]), x
+
+
+def _expected_descriptor(app, derivation, script_tmpl):
+    origin, x = _origin_xpub(app, derivation)
+    return script_tmpl % (origin, x)
 
 
 def _address(descriptor, net_name, branch, index):
@@ -94,7 +110,7 @@ def _address(descriptor, net_name, branch, index):
     return d.derive(index, branch_index=branch).address(net)
 
 
-class TaprootWalletCreationTest(TestCase):
+class WalletCreationTest(TestCase):
     def setUp(self):
         clear_testdir()
         self.keystore = get_keystore()
@@ -104,7 +120,7 @@ class TaprootWalletCreationTest(TestCase):
         clear_testdir()
         gc.collect()
 
-    # -- helpers ----------------------------------------------------------
+    # -- helpers --------------------------------------------------------
     def _create(self, derivation, answers, network="main", account=0,
                 keystore=None):
         if keystore is not None:
@@ -118,227 +134,262 @@ class TaprootWalletCreationTest(TestCase):
         run(self.app.create_wallet(d, x, p, screens))
         return sink, screens
 
-    # -- A: BIP86 standard path -----------------------------------------
-    def test_standard_taproot_uses_bip86(self):
-        sink, _ = self._create(
-            "m/86h/0h/0h",
-            {"Menu": ["taproot"], "InputScreen": ["TR"]},
-        )
+    def _desc(self, *a, **k):
+        sink, _ = self._create(*a, **k)
         self.assertEqual(len(sink.added), 1)
-        name, desc = sink.added[0]
-        self.assertIn("/86h/0h/0h]", desc)
-        self.assertNotIn("/84h/", desc)
-        self.assertTrue(desc.startswith("tr("))
-        self.assertEqual(
-            desc, _expected_descriptor(self.app, "m/86h/0h/0h", "tr(%s%s/{0,1}/*)")
-        )
+        return sink.added[0][1]
 
-    # -- B: official BIP86 test vector ---------------------------------
+    # ================================================================
+    # standard creation: script type -> BIP purpose, genuine derivation
+    # ================================================================
+    def test_standard_types_derive_from_their_bip_purpose(self):
+        cases = {
+            "legacy":  (44, "pkh("),
+            "nested":  (49, "sh(wpkh("),
+            "wpkh":    (84, "wpkh("),
+            "taproot": (86, "tr("),
+        }
+        # display a key on a foreign purpose so a real re-derivation must happen
+        for key, (purpose, head) in cases.items():
+            desc = self._desc(
+                "m/45h/0h/0h",
+                {"Menu": [key, "standard"], "InputScreen": ["w"]},
+            )
+            self.assertTrue(desc.startswith(head), desc)
+            self.assertIn("/%dh/0h/0h]" % purpose, desc)
+            std_origin, std_xpub = _origin_xpub(self.app, "m/%dh/0h/0h" % purpose)
+            self.assertIn(std_xpub, desc)
+            # the displayed m/45' key must not appear
+            shown = self.keystore.get_xpub("m/45h/0h/0h").to_base58(
+                NETWORKS["main"]["xpub"])
+            self.assertNotIn(shown, desc)
+
+    def test_standard_taproot_uses_bip86_no_extra_prompt(self):
+        # key already on the standard path -> straight to naming, no dialog
+        sink, screens = self._create(
+            "m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["TR"]},
+        )
+        _, desc = sink.added[0]
+        self.assertEqual(screens.log.count("Menu"), 1)
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/86h/0h/0h", "tr(%s%s/{0,1}/*)"))
+        self.assertNotIn("/84h/", desc)
+
     def test_bip86_official_vector(self):
         ks = get_keystore(mnemonic=BIP86_MNEMONIC)
-        sink, screens = self._create(
+        desc = self._desc(
             "m/84h/0h/0h",
             {"Menu": ["taproot", "standard"], "InputScreen": ["v"]},
             keystore=ks,
         )
-        _, desc = sink.added[0]
         self.assertIn("/86h/0h/0h]", desc)
         self.assertEqual(_address(desc, "main", 0, 0), BIP86_FIRST_ADDR)
 
-    # -- C: legacy Specter regression --------------------------------
-    def test_legacy_specter_taproot_recovery_reproduces_m84_address(self):
-        sink, _ = self._create(
-            "m/84h/0h/0h",
-            {"Menu": ["taproot", "legacy"], "Prompt": [True],
-             "InputScreen": ["legacy"]},
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/84h/0h/0h]", desc)
-        self.assertTrue(desc.startswith("tr("))
-        expected = _expected_descriptor(
-            self.app, "m/84h/0h/0h", "tr(%s%s/{0,1}/*)"
-        )
-        self.assertEqual(desc, expected)
-        # address matches an independent m/84'/0'/0'/0/0 P2TR derivation
-        indep = _address(expected, "main", 0, 0)
-        self.assertEqual(_address(desc, "main", 0, 0), indep)
-
-    def test_no_dedicated_legacy_menu_entry(self):
-        # the legacy m/84' + tr() derivation is only reachable through the
-        # migration dialog - there is no standalone wallet-type entry for it
-        sink, _ = self._create(
-            "m/86h/0h/0h",
-            {"Menu": ["legacy_taproot"], "Prompt": [True],
-             "InputScreen": ["l"]},
-        )
-        self.assertEqual(sink.added, [])
-
-    # -- D: standard and legacy differ ------------------------------
-    def test_standard_and_legacy_addresses_differ(self):
-        std = self._create(
-            "m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["s"]}
-        )[0].added[0][1]
-        leg = self._create(
-            "m/84h/0h/0h",
-            {"Menu": ["taproot", "legacy"], "Prompt": [True],
-             "InputScreen": ["l"]},
-        )[0].added[0][1]
-        self.assertNotEqual(
-            _address(std, "main", 0, 0), _address(leg, "main", 0, 0)
-        )
-
-    # -- E: change addresses ---------------------------------------
-    def test_change_branch_addresses(self):
-        for der, answers in (
-            ("m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["x"]}),
-            ("m/84h/0h/0h",
-             {"Menu": ["taproot", "legacy"], "Prompt": [True],
-              "InputScreen": ["x"]}),
-        ):
-            sink, _ = self._create(der, answers)
-            _, desc = sink.added[0]
-            recv = _address(desc, "main", 0, 0)
-            chg = _address(desc, "main", 1, 0)
-            self.assertNotEqual(recv, chg)
-            self.assertEqual(
-                recv, _address(
-                    _expected_descriptor(self.app, der, "tr(%s%s/{0,1}/*)"),
-                    "main", 0, 0),
-            )
-            self.assertEqual(
-                chg, _address(
-                    _expected_descriptor(self.app, der, "tr(%s%s/{0,1}/*)"),
-                    "main", 1, 0),
-            )
-
-    # -- F: account numbers --------------------------------------
-    def test_non_zero_account(self):
-        sink, _ = self._create(
-            "m/86h/0h/5h",
-            {"Menu": ["taproot"], "InputScreen": ["a5"]},
-            account=5,
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/86h/0h/5h]", desc)
-
-        sink, _ = self._create(
-            "m/84h/0h/5h",
-            {"Menu": ["taproot", "legacy"], "Prompt": [True],
-             "InputScreen": ["a5"]},
-            account=5,
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/84h/0h/5h]", desc)
-
-    # -- G: testnet --------------------------------------------
-    def test_testnet_derivation(self):
-        sink, _ = self._create(
-            "m/86h/1h/0h",
-            {"Menu": ["taproot"], "InputScreen": ["t"]},
-            network="test",
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/86h/1h/0h]", desc)
-
-        sink, _ = self._create(
-            "m/84h/1h/0h",
-            {"Menu": ["taproot", "legacy"], "Prompt": [True],
-             "InputScreen": ["t"]},
-            network="test",
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/84h/1h/0h]", desc)
-
-    def test_standard_wallet_normalizes_coin_type_to_network(self):
-        # A displayed custom path with a foreign coin_type must not leak into a
-        # standard wallet: coin_type is fixed by the active network, the account
-        # index is carried over.
-        sink, _ = self._create(
-            "m/84h/1h/5h",
-            {"Menu": ["taproot", "standard"], "InputScreen": ["x"]},
-            account=5,
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/86h/0h/5h]", desc)
-        self.assertNotIn("/1h/", desc.split("]", 1)[0])
-
-        sink, _ = self._create(
-            "m/84h/0h/5h",
-            {"Menu": ["taproot", "standard"], "InputScreen": ["x"]},
-            network="test", account=5,
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/86h/1h/5h]", desc)
-
-    def test_legacy_recovery_preserves_displayed_coin_type(self):
-        # The explicit legacy path is the one place the exact historical
-        # derivation (incl. a non-standard coin_type) is reproduced.
-        sink, _ = self._create(
-            "m/84h/1h/0h",
-            {"Menu": ["taproot", "legacy"], "Prompt": [True],
-             "InputScreen": ["x"]},
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/84h/1h/0h]", desc)
-        self.assertEqual(
-            desc, _expected_descriptor(self.app, "m/84h/1h/0h", "tr(%s%s/{0,1}/*)")
-        )
-
-    # -- H: UI / menu behaviour --------------------------------
-    def test_taproot_from_m84_shows_migration_choice(self):
+    def test_issue393_single_key_taproot_rederives_m86(self):
+        # "Single key" is an m/84' key; Standard Taproot must re-derive m/86'
         sink, screens = self._create(
             "m/84h/0h/0h",
             {"Menu": ["taproot", "standard"], "InputScreen": ["m"]},
         )
-        # two Menu screens: wallet-type menu, then the migration choice
-        self.assertEqual(screens.log.count("Menu"), 2)
         _, desc = sink.added[0]
+        self.assertEqual(screens.log.count("Menu"), 2)
+        m86 = self.keystore.get_xpub("m/86h/0h/0h").to_base58(NETWORKS["main"]["xpub"])
+        m84 = self.keystore.get_xpub("m/84h/0h/0h").to_base58(NETWORKS["main"]["xpub"])
         self.assertIn("/86h/0h/0h]", desc)
-        # the m/86' key is actually re-derived, not the displayed m/84' one
-        net = NETWORKS["main"]
-        m86 = self.keystore.get_xpub("m/86h/0h/0h").to_base58(net["xpub"])
-        m84 = self.keystore.get_xpub("m/84h/0h/0h").to_base58(net["xpub"])
         self.assertIn(m86, desc)
         self.assertNotIn(m84, desc)
 
-    def test_migration_cancel_creates_no_wallet(self):
+    # ================================================================
+    # generic recovery: displayed key wrapped in the chosen script
+    # ================================================================
+    def _recover(self, derivation, wtype, network="main", account=0):
         sink, _ = self._create(
-            "m/84h/0h/0h",
-            {"Menu": ["taproot", 255]},
+            derivation,
+            {"Menu": [wtype, "recover"], "Prompt": [True], "InputScreen": ["r"]},
+            network=network, account=account,
         )
-        self.assertEqual(sink.added, [])
+        self.assertEqual(len(sink.added), 1)
+        return sink.added[0][1]
 
-    def test_wallet_type_menu_back_creates_no_wallet(self):
+    def test_recover_m84_with_legacy(self):
+        desc = self._recover("m/84h/0h/0h", "legacy")
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/84h/0h/0h", "pkh(%s%s/{0,1}/*)"))
+        self.assertNotIn("/44h/", desc)
+
+    def test_recover_m49_with_taproot(self):
+        desc = self._recover("m/49h/0h/0h", "taproot")
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/49h/0h/0h", "tr(%s%s/{0,1}/*)"))
+        self.assertNotIn("/86h/", desc)
+
+    def test_recover_bip48_multisig_path_with_native_segwit(self):
+        desc = self._recover("m/48h/0h/0h/2h", "wpkh")
+        # the full four-level path is preserved, not collapsed to m/84'
+        self.assertEqual(
+            desc,
+            _expected_descriptor(self.app, "m/48h/0h/0h/2h", "wpkh(%s%s/{0,1}/*)"))
+        self.assertIn("/48h/0h/0h/2h]", desc)
+        self.assertNotIn("/84h/", desc)
+        Descriptor.from_string(desc)  # parses
+
+    def test_recover_m84_with_nested_segwit(self):
+        desc = self._recover("m/84h/0h/0h", "nested")
+        self.assertEqual(
+            desc,
+            _expected_descriptor(self.app, "m/84h/0h/0h", "sh(wpkh(%s%s/{0,1}/*))"))
+
+    def test_recover_custom_path_with_taproot(self):
+        desc = self._recover("m/1234h/5h/6h", "taproot")
+        self.assertEqual(
+            desc,
+            _expected_descriptor(self.app, "m/1234h/5h/6h", "tr(%s%s/{0,1}/*)"))
+        self.assertIn("/1234h/5h/6h]", desc)
+        Descriptor.from_string(desc)
+
+    def test_recover_taproot_m84_reproduces_pre_pr405_wallet(self):
+        # the case PR #405 special-cased; the generic path must match exactly
+        desc = self._recover("m/84h/0h/0h", "taproot")
+        expected = _expected_descriptor(self.app, "m/84h/0h/0h", "tr(%s%s/{0,1}/*)")
+        self.assertEqual(desc, expected)
+        self.assertEqual(_address(desc, "main", 0, 0),
+                         _address(expected, "main", 0, 0))
+
+    # ================================================================
+    # standard vs recovery differ
+    # ================================================================
+    def test_standard_vs_recovery_same_key_differ(self):
+        # displayed m/84'/0'/0', wallet type Legacy
+        std = self._desc("m/84h/0h/0h",
+                         {"Menu": ["legacy", "standard"], "InputScreen": ["s"]})
+        rec = self._recover("m/84h/0h/0h", "legacy")
+        self.assertIn("/44h/0h/0h]", std)
+        self.assertIn("/84h/0h/0h]", rec)
+        self.assertNotEqual(_address(std, "main", 0, 0), _address(rec, "main", 0, 0))
+
+    def test_change_branch_addresses(self):
+        for desc in (
+            self._desc("m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["x"]}),
+            self._recover("m/84h/0h/0h", "taproot"),
+        ):
+            self.assertNotEqual(_address(desc, "main", 0, 0),
+                                _address(desc, "main", 1, 0))
+
+    # ================================================================
+    # coin_type
+    # ================================================================
+    def test_standard_normalises_coin_type_to_network(self):
+        # mainnet: displayed m/84'/1'/5' -> standard m/86'/0'/5'
+        desc = self._desc("m/84h/1h/5h",
+                          {"Menu": ["taproot", "standard"], "InputScreen": ["x"]},
+                          account=5)
+        self.assertIn("/86h/0h/5h]", desc)
+        self.assertNotIn("/1h/", desc.split("]", 1)[0])
+        # testnet: displayed m/84'/0'/5' -> standard m/86'/1'/5'
+        desc = self._desc("m/84h/0h/5h",
+                          {"Menu": ["taproot", "standard"], "InputScreen": ["x"]},
+                          network="test", account=5)
+        self.assertIn("/86h/1h/5h]", desc)
+
+    def test_recovery_preserves_coin_type(self):
+        desc = self._recover("m/84h/1h/0h", "taproot")
+        self.assertIn("/84h/1h/0h]", desc)
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/84h/1h/0h", "tr(%s%s/{0,1}/*)"))
+
+    def test_wrong_coin_type_is_not_recommended(self):
+        # mainnet, displayed m/84'/1'/5' - purpose matches wpkh but coin_type
+        # does not: the wallet-type menu must not preselect it, so picking wpkh
+        # still routes through the standard/recovery choice.
+        sink, screens = self._create(
+            "m/84h/1h/5h",
+            {"Menu": ["wpkh", "standard"], "InputScreen": ["x"]},
+            account=5,
+        )
+        self.assertEqual(screens.log.count("Menu"), 2)
+        self.assertIn("/84h/0h/5h]", sink.added[0][1])
+
+    # ================================================================
+    # accounts
+    # ================================================================
+    def test_account_zero_and_non_zero(self):
+        d0 = self._desc("m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["a"]})
+        self.assertIn("/86h/0h/0h]", d0)
+        d5 = self._desc("m/86h/0h/5h", {"Menu": ["taproot"], "InputScreen": ["a"]},
+                        account=5)
+        self.assertIn("/86h/0h/5h]", d5)
+        # account carried across a re-derivation
+        d7 = self._desc("m/84h/0h/7h",
+                        {"Menu": ["taproot", "standard"], "InputScreen": ["a"]},
+                        account=7)
+        self.assertIn("/86h/0h/7h]", d7)
+
+    def test_bip48_account_carried_into_standard_wallet(self):
+        # m/48'/0'/3'/2' -> Native Segwit standard uses account 3
+        desc = self._desc("m/48h/0h/3h/2h",
+                          {"Menu": ["wpkh", "standard"], "InputScreen": ["x"]})
+        self.assertIn("/84h/0h/3h]", desc)
+
+    # ================================================================
+    # testnet
+    # ================================================================
+    def test_testnet_standard_and_recovery(self):
+        std = self._desc("m/86h/1h/0h", {"Menu": ["taproot"], "InputScreen": ["t"]},
+                         network="test")
+        self.assertIn("/86h/1h/0h]", std)
+        rec = self._recover("m/84h/1h/0h", "taproot", network="test")
+        self.assertIn("/84h/1h/0h]", rec)
+
+    # ================================================================
+    # Liquid
+    # ================================================================
+    def test_liquid_standard_uses_registered_coin_type(self):
+        # liquidv1's coin_type is 1776 (embit NETWORKS), not 0
+        self.assertEqual(NETWORKS["liquidv1"]["bip32"], 1776)
+        desc = self._desc("m/84h/1776h/0h",
+                          {"Menu": ["wpkh"], "InputScreen": ["l"]},
+                          network="liquidv1")
+        self.assertTrue(desc.startswith("blinded(slip77("))
+        self.assertIn("wpkh([", desc)
+        self.assertIn("/84h/1776h/0h]", desc)
+
+    def test_liquid_recovery_preserves_displayed_path(self):
+        desc = self._recover("m/84h/0h/0h", "taproot", network="liquidv1")
+        self.assertTrue(desc.startswith("blinded(slip77("))
+        self.assertIn("tr([", desc)
+        self.assertIn("/84h/0h/0h]", desc)
+
+    # ================================================================
+    # cancel / back / decline -> nothing created
+    # ================================================================
+    def test_wallet_type_menu_back(self):
         sink, _ = self._create("m/86h/0h/0h", {"Menu": [255]})
         self.assertEqual(sink.added, [])
 
-    def test_legacy_prompt_decline_creates_no_wallet(self):
+    def test_choice_menu_cancel(self):
+        sink, _ = self._create("m/84h/0h/0h", {"Menu": ["taproot", 255]})
+        self.assertEqual(sink.added, [])
+
+    def test_recovery_warning_declined(self):
         sink, _ = self._create(
             "m/84h/0h/0h",
-            {"Menu": ["taproot", "legacy"], "Prompt": [False]},
+            {"Menu": ["taproot", "recover"], "Prompt": [False]},
         )
         self.assertEqual(sink.added, [])
 
-    def test_native_segwit_still_bip84(self):
+    def test_name_prompt_cancelled(self):
         sink, _ = self._create(
-            "m/84h/0h/0h", {"Menu": ["wpkh"], "InputScreen": ["n"]}
+            "m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": [""]},
         )
-        _, desc = sink.added[0]
-        self.assertTrue(desc.startswith("wpkh("))
-        self.assertIn("/84h/0h/0h]", desc)
+        self.assertEqual(sink.added, [])
 
-    def test_taproot_rederived_from_legacy_context_for_standard(self):
-        # from m/49' nested context, picking Taproot re-derives m/86'
-        sink, _ = self._create(
-            "m/49h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["x"]}
-        )
-        _, desc = sink.added[0]
-        self.assertIn("/86h/0h/0h]", desc)
-        self.assertTrue(desc.startswith("tr("))
+    def test_unknown_menu_value_creates_nothing(self):
+        sink, _ = self._create("m/86h/0h/0h", {"Menu": ["bogus"]})
+        self.assertEqual(sink.added, [])
 
 
 class LegacyDescriptorImportTest(TestCase):
-    """Old-style tr([fpr/84h/..]xpub/..) descriptors must still import."""
+    """Old-style non-standard descriptors must still import and match keys."""
 
     def setUp(self):
         clear_testdir()
@@ -351,13 +402,21 @@ class LegacyDescriptorImportTest(TestCase):
         clear_testdir()
         gc.collect()
 
-    def test_legacy_m84_taproot_descriptor_parses(self):
+    def _roundtrip(self, name, tmpl, der):
         net = NETWORKS["main"]
-        der = "m/84h/0h/0h"
         x = self.keystore.get_xpub(der).to_base58(net["xpub"])
         fp = hexlify(self.keystore.fingerprint).decode()
-        desc = "Legacy TR&tr([%s/84h/0h/0h]%s/{0,1}/*)" % (fp, x)
-        wallet = self.manager.parse_wallet(desc)
-        self.assertEqual(wallet.name, "Legacy TR")
-        self.assertIn("tr(", str(wallet.descriptor))
-        self.assertIn("84h/0h/0h", str(wallet.descriptor))
+        desc = "%s&%s" % (name, tmpl % ("[%s/%s]" % (fp, der[2:]), x))
+        w = self.manager.parse_wallet(desc)
+        self.assertEqual(w.name, name)
+        self.assertIn(der[2:], str(w.descriptor))
+        return w
+
+    def test_legacy_m84_taproot_descriptor_parses(self):
+        self._roundtrip("Legacy TR", "tr(%s%s/{0,1}/*)", "m/84h/0h/0h")
+
+    def test_legacy_m84_pkh_descriptor_parses(self):
+        self._roundtrip("Legacy PKH", "pkh(%s%s/{0,1}/*)", "m/84h/0h/0h")
+
+    def test_legacy_bip48_wpkh_descriptor_parses(self):
+        self._roundtrip("Legacy 48", "wpkh(%s%s/{0,1}/*)", "m/48h/0h/0h/2h")

--- a/test/tests_native/test_xpub_wallet_creation.py
+++ b/test/tests_native/test_xpub_wallet_creation.py
@@ -1,0 +1,330 @@
+"""
+Regression tests for issue #393 - Taproot wallet creation must use BIP86
+(m/86') while keeping the non-standard "legacy Specter Taproot" m/84' + tr()
+wallets explicitly recoverable.
+"""
+import sys
+
+if sys.implementation.name != 'micropython':
+    from native_support import setup_native_stubs
+
+    setup_native_stubs()
+
+import asyncio
+import gc
+from binascii import hexlify
+from io import BytesIO
+from unittest import TestCase
+
+from embit import bip32
+from embit.descriptor import Descriptor
+from embit.networks import NETWORKS
+
+from tests.util import get_keystore, get_xpubs_app, clear_testdir
+
+# Official BIP86 test vector (mnemonic + first receive address).
+BIP86_MNEMONIC = "abandon " * 11 + "about"
+BIP86_FIRST_ADDR = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class ScriptedScreens:
+    """Scriptable show_screen double. Answers keyed by screen class name."""
+
+    def __init__(self, answers):
+        self.answers = {k: list(v) for k, v in answers.items()}
+        self.log = []
+
+    async def __call__(self, screen):
+        name = type(screen).__name__
+        self.log.append(name)
+        queue = self.answers.get(name)
+        if queue:
+            return queue.pop(0)
+        return None
+
+
+class WalletSink:
+    """Captures `addwallet` descriptors sent to the wallets app."""
+
+    def __init__(self, existing=None):
+        self.existing = existing or []
+        self.added = []
+
+    async def __call__(self, stream, app=None):
+        data = stream.read()
+        if data == b"listwallets":
+            import json
+            return BytesIO(json.dumps(self.existing).encode()), {}
+        text = data.decode()
+        assert text.startswith("addwallet "), text
+        name, desc = text[len("addwallet "):].split("&", 1)
+        self.added.append((name, desc))
+        return BytesIO(b""), {}
+
+
+def _shown_xpub(app, derivation):
+    """Reproduce what show_xpub() hands to create_wallet()."""
+    net = NETWORKS[app.network]
+    x = app.keystore.get_xpub(derivation)
+    canonical = x.to_base58(net["xpub"])
+    fp = hexlify(app.keystore.fingerprint).decode()
+    prefix = "[%s%s]" % (fp, derivation[1:])
+    return derivation, canonical, prefix
+
+
+def _expected_descriptor(app, derivation, script_tmpl):
+    net = NETWORKS[app.network]
+    x = app.keystore.get_xpub(derivation)
+    fp = hexlify(app.keystore.fingerprint).decode()
+    prefix = "[%s/%s]" % (fp, derivation[2:])
+    return script_tmpl % (prefix, x.to_base58(net["xpub"]))
+
+
+def _address(descriptor, net_name, branch, index):
+    net = NETWORKS[net_name]
+    d = Descriptor.from_string(descriptor)
+    return d.derive(index, branch_index=branch).address(net)
+
+
+class TaprootWalletCreationTest(TestCase):
+    def setUp(self):
+        clear_testdir()
+        self.keystore = get_keystore()
+        self.app = get_xpubs_app(self.keystore, "main")
+
+    def tearDown(self):
+        clear_testdir()
+        gc.collect()
+
+    # -- helpers ----------------------------------------------------------
+    def _create(self, derivation, answers, network="main", account=0,
+                keystore=None):
+        if keystore is not None:
+            self.keystore = keystore
+        self.app = get_xpubs_app(self.keystore, network)
+        self.app.account = account
+        sink = WalletSink()
+        self.app.communicate = sink
+        screens = ScriptedScreens(answers)
+        d, x, p = _shown_xpub(self.app, derivation)
+        run(self.app.create_wallet(d, x, p, screens))
+        return sink, screens
+
+    # -- A: BIP86 standard path -----------------------------------------
+    def test_standard_taproot_uses_bip86(self):
+        sink, _ = self._create(
+            "m/86h/0h/0h",
+            {"Menu": ["taproot"], "InputScreen": ["TR"]},
+        )
+        self.assertEqual(len(sink.added), 1)
+        name, desc = sink.added[0]
+        self.assertIn("/86h/0h/0h]", desc)
+        self.assertNotIn("/84h/", desc)
+        self.assertTrue(desc.startswith("tr("))
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/86h/0h/0h", "tr(%s%s/{0,1}/*)")
+        )
+
+    # -- B: official BIP86 test vector ---------------------------------
+    def test_bip86_official_vector(self):
+        ks = get_keystore(mnemonic=BIP86_MNEMONIC)
+        sink, screens = self._create(
+            "m/84h/0h/0h",
+            {"Menu": ["taproot", "standard"], "InputScreen": ["v"]},
+            keystore=ks,
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/86h/0h/0h]", desc)
+        self.assertEqual(_address(desc, "main", 0, 0), BIP86_FIRST_ADDR)
+
+    # -- C: legacy Specter regression --------------------------------
+    def test_legacy_specter_taproot_recovery_reproduces_m84_address(self):
+        sink, _ = self._create(
+            "m/84h/0h/0h",
+            {"Menu": ["taproot", "legacy"], "Prompt": [True],
+             "InputScreen": ["legacy"]},
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/84h/0h/0h]", desc)
+        self.assertTrue(desc.startswith("tr("))
+        expected = _expected_descriptor(
+            self.app, "m/84h/0h/0h", "tr(%s%s/{0,1}/*)"
+        )
+        self.assertEqual(desc, expected)
+        # address matches an independent m/84'/0'/0'/0/0 P2TR derivation
+        indep = _address(expected, "main", 0, 0)
+        self.assertEqual(_address(desc, "main", 0, 0), indep)
+
+    def test_legacy_taproot_menu_entry_without_migration(self):
+        sink, _ = self._create(
+            "m/86h/0h/0h",
+            {"Menu": ["legacy_taproot"], "Prompt": [True],
+             "InputScreen": ["l"]},
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/84h/0h/0h]", desc)
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/84h/0h/0h", "tr(%s%s/{0,1}/*)")
+        )
+
+    # -- D: standard and legacy differ ------------------------------
+    def test_standard_and_legacy_addresses_differ(self):
+        std = self._create(
+            "m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["s"]}
+        )[0].added[0][1]
+        leg = self._create(
+            "m/84h/0h/0h",
+            {"Menu": ["taproot", "legacy"], "Prompt": [True],
+             "InputScreen": ["l"]},
+        )[0].added[0][1]
+        self.assertNotEqual(
+            _address(std, "main", 0, 0), _address(leg, "main", 0, 0)
+        )
+
+    # -- E: change addresses ---------------------------------------
+    def test_change_branch_addresses(self):
+        for der, answers in (
+            ("m/86h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["x"]}),
+            ("m/84h/0h/0h",
+             {"Menu": ["taproot", "legacy"], "Prompt": [True],
+              "InputScreen": ["x"]}),
+        ):
+            sink, _ = self._create(der, answers)
+            _, desc = sink.added[0]
+            recv = _address(desc, "main", 0, 0)
+            chg = _address(desc, "main", 1, 0)
+            self.assertNotEqual(recv, chg)
+            self.assertEqual(
+                recv, _address(
+                    _expected_descriptor(self.app, der, "tr(%s%s/{0,1}/*)"),
+                    "main", 0, 0),
+            )
+            self.assertEqual(
+                chg, _address(
+                    _expected_descriptor(self.app, der, "tr(%s%s/{0,1}/*)"),
+                    "main", 1, 0),
+            )
+
+    # -- F: account numbers --------------------------------------
+    def test_non_zero_account(self):
+        sink, _ = self._create(
+            "m/86h/0h/5h",
+            {"Menu": ["taproot"], "InputScreen": ["a5"]},
+            account=5,
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/86h/0h/5h]", desc)
+
+        sink, _ = self._create(
+            "m/84h/0h/5h",
+            {"Menu": ["taproot", "legacy"], "Prompt": [True],
+             "InputScreen": ["a5"]},
+            account=5,
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/84h/0h/5h]", desc)
+
+    # -- G: testnet --------------------------------------------
+    def test_testnet_derivation(self):
+        sink, _ = self._create(
+            "m/86h/1h/0h",
+            {"Menu": ["taproot"], "InputScreen": ["t"]},
+            network="test",
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/86h/1h/0h]", desc)
+
+        sink, _ = self._create(
+            "m/84h/1h/0h",
+            {"Menu": ["taproot", "legacy"], "Prompt": [True],
+             "InputScreen": ["t"]},
+            network="test",
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/84h/1h/0h]", desc)
+
+    # -- H: UI / menu behaviour --------------------------------
+    def test_taproot_from_m84_shows_migration_choice(self):
+        sink, screens = self._create(
+            "m/84h/0h/0h",
+            {"Menu": ["taproot", "standard"], "InputScreen": ["m"]},
+        )
+        # two Menu screens: wallet-type menu, then the migration choice
+        self.assertEqual(screens.log.count("Menu"), 2)
+        _, desc = sink.added[0]
+        self.assertIn("/86h/0h/0h]", desc)
+        # the m/86' key is actually re-derived, not the displayed m/84' one
+        net = NETWORKS["main"]
+        m86 = self.keystore.get_xpub("m/86h/0h/0h").to_base58(net["xpub"])
+        m84 = self.keystore.get_xpub("m/84h/0h/0h").to_base58(net["xpub"])
+        self.assertIn(m86, desc)
+        self.assertNotIn(m84, desc)
+
+    def test_migration_cancel_creates_no_wallet(self):
+        sink, _ = self._create(
+            "m/84h/0h/0h",
+            {"Menu": ["taproot", 255]},
+        )
+        self.assertEqual(sink.added, [])
+
+    def test_wallet_type_menu_back_creates_no_wallet(self):
+        sink, _ = self._create("m/86h/0h/0h", {"Menu": [255]})
+        self.assertEqual(sink.added, [])
+
+    def test_legacy_prompt_decline_creates_no_wallet(self):
+        sink, _ = self._create(
+            "m/86h/0h/0h",
+            {"Menu": ["legacy_taproot"], "Prompt": [False]},
+        )
+        self.assertEqual(sink.added, [])
+
+    def test_native_segwit_still_bip84(self):
+        sink, _ = self._create(
+            "m/84h/0h/0h", {"Menu": ["wpkh"], "InputScreen": ["n"]}
+        )
+        _, desc = sink.added[0]
+        self.assertTrue(desc.startswith("wpkh("))
+        self.assertIn("/84h/0h/0h]", desc)
+
+    def test_taproot_rederived_from_legacy_context_for_standard(self):
+        # from m/49' nested context, picking Taproot re-derives m/86'
+        sink, _ = self._create(
+            "m/49h/0h/0h", {"Menu": ["taproot"], "InputScreen": ["x"]}
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/86h/0h/0h]", desc)
+        self.assertTrue(desc.startswith("tr("))
+
+
+class LegacyDescriptorImportTest(TestCase):
+    """Old-style tr([fpr/84h/..]xpub/..) descriptors must still import."""
+
+    def setUp(self):
+        clear_testdir()
+        from tests.util import get_wallets_app
+        self.keystore = get_keystore()
+        self.wallets_app = get_wallets_app(self.keystore, "main")
+        self.manager = self.wallets_app.manager
+
+    def tearDown(self):
+        clear_testdir()
+        gc.collect()
+
+    def test_legacy_m84_taproot_descriptor_parses(self):
+        net = NETWORKS["main"]
+        der = "m/84h/0h/0h"
+        x = self.keystore.get_xpub(der).to_base58(net["xpub"])
+        fp = hexlify(self.keystore.fingerprint).decode()
+        desc = "Legacy TR&tr([%s/84h/0h/0h]%s/{0,1}/*)" % (fp, x)
+        wallet = self.manager.parse_wallet(desc)
+        self.assertEqual(wallet.name, "Legacy TR")
+        self.assertIn("tr(", str(wallet.descriptor))
+        self.assertIn("84h/0h/0h", str(wallet.descriptor))

--- a/test/tests_native/test_xpub_wallet_creation.py
+++ b/test/tests_native/test_xpub_wallet_creation.py
@@ -249,6 +249,41 @@ class TaprootWalletCreationTest(TestCase):
         _, desc = sink.added[0]
         self.assertIn("/84h/1h/0h]", desc)
 
+    def test_standard_wallet_normalizes_coin_type_to_network(self):
+        # A displayed custom path with a foreign coin_type must not leak into a
+        # standard wallet: coin_type is fixed by the active network, the account
+        # index is carried over.
+        sink, _ = self._create(
+            "m/84h/1h/5h",
+            {"Menu": ["taproot", "standard"], "InputScreen": ["x"]},
+            account=5,
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/86h/0h/5h]", desc)
+        self.assertNotIn("/1h/", desc.split("]", 1)[0])
+
+        sink, _ = self._create(
+            "m/84h/0h/5h",
+            {"Menu": ["taproot", "standard"], "InputScreen": ["x"]},
+            network="test", account=5,
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/86h/1h/5h]", desc)
+
+    def test_legacy_recovery_preserves_displayed_coin_type(self):
+        # The explicit legacy path is the one place the exact historical
+        # derivation (incl. a non-standard coin_type) is reproduced.
+        sink, _ = self._create(
+            "m/84h/1h/0h",
+            {"Menu": ["taproot", "legacy"], "Prompt": [True],
+             "InputScreen": ["x"]},
+        )
+        _, desc = sink.added[0]
+        self.assertIn("/84h/1h/0h]", desc)
+        self.assertEqual(
+            desc, _expected_descriptor(self.app, "m/84h/1h/0h", "tr(%s%s/{0,1}/*)")
+        )
+
     # -- H: UI / menu behaviour --------------------------------
     def test_taproot_from_m84_shows_migration_choice(self):
         sink, screens = self._create(


### PR DESCRIPTION
## Problem

**#393**: *Master public keys → Single key → Create wallet → Taproot* produced
`tr([fingerprint/84h/0h/0h]xpub.../{0,1}/*)` — a P2TR descriptor carrying a
BIP84 account key. Root cause: `create_wallet()` wrapped *whatever key was on
screen* in the chosen script, with nothing tying script to derivation purpose.

That same behaviour let **older firmware create many valid-but-non-standard
wallets** (see #281): `pkh(m/84'…)`, `tr(m/49'…)`, `wpkh(m/48'/…/2'…)`,
`sh(wpkh(m/84'…))`, `tr(<custom>…)`, … A user who made one of those must still
be able to recreate it from the same seed + displayed key.

## Solution — one generic mechanism

`WALLET_TYPES` maps each script to its standard BIP purpose
(`pkh`→44, `sh(wpkh)`→49, `wpkh`→84, `tr`→86). In `create_wallet()`:

1. **Pick a wallet type.** Its standard derivation is
   `m/<purpose>h/<coin_type>h/<account>h` — purpose from the script,
   `coin_type` **from the active network** (Bitcoin `0`/`1`, Liquid `1776`/`1`),
   `account` from the displayed key's level `[2]` (so BIP48
   `m/48'/0'/A'/2'` keeps account `A`) or the account chosen in the menu.
2. **Displayed path already equals that target** → create straight away, no
   extra prompt.
3. **Otherwise the user chooses**, on one screen:
   * `Standard <type>  m/<purpose>h/<coin>h/<account>h` — the account key is
     **genuinely re-derived** from the standard path (never a relabelled
     origin);
   * `Recover using displayed key  <path on screen>` — wraps the displayed key
     **verbatim**, preserving its full key-origin (purpose, coin type, account,
     deeper BIP48 levels, valid custom paths). Behind a **warning**: this
     derivation is non-standard, other wallets may not find it from the seed
     alone, use it only to recover an existing wallet.
4. **Cancel / back / decline → nothing is created.**

`tr(m/84')` recovery is now just an instance of (3); the `LEGACY_SPECTER_TAPROOT`
special case and `_parse_account_path` are removed.

**Recommendation** (`_standard_wallet_type`) now requires the network's
`coin_type` to match, so on mainnet `m/84'/1'/5'` is no longer offered as
"recommended" Native Segwit.

## Files changed

| File | Change |
|---|---|
| `src/apps/xpubs/xpubs.py` | `WALLET_TYPES` (+ `name_prefix`); new helpers `_parse_path` / `_same_path` / `_account_index` / `_standard_wallet_type`; `create_wallet()` rewritten around the generic standard/recovery choice; `LEGACY_SPECTER_TAPROOT`, `_parse_account_path` removed |
| `test/tests_native/test_xpub_wallet_creation.py` | rewritten around the generic mechanism (33 tests) |
| `docs/descriptors.md` | standard mapping table, coin_type rule (incl. Liquid), the generic recovery flow and warning |

## Tests (`test/tests_native/test_xpub_wallet_creation.py`, 33)

* **Standard creation** — all four script→purpose mappings, each proving the
  *derived xpub itself* changes (not just the descriptor string); no extra
  prompt when the key is already standard.
* **Official BIP86 vector** kept → `bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr`.
* **#393** — Single key (m/84') → Standard Taproot re-derives m/86' (m/84'
  xpub absent from the descriptor).
* **Generic recovery** — `m/84'+pkh`, `m/49'+tr`, `m/48'/0'/0'/2'+wpkh`,
  `m/84'+sh(wpkh)`, `m/1234'/5'/6'+tr`: exact displayed xpub used, exact
  origin path retained, no standard-path xpub leaks in, descriptor parses.
* `tr(m/84')` recovery reproduces the pre-#405 descriptor + address exactly.
* **Standard vs recovery** for the same key produce different addresses.
* **coin_type** — normalised to network for standard (mainnet `m/84'/1'/5'` →
  `m/86'/0'/5'`; testnet inverse), preserved for recovery; wrong coin_type is
  not "recommended".
* **Accounts** — 0 and non-zero; carried across a re-derivation; BIP48 account.
* **testnet**, **Liquid** (`liquidv1` standard uses `1776`; recovery preserves
  displayed path; `blinded(slip77(...))` wrapper intact).
* **cancel / back / decline / empty name / unknown menu value** → nothing.
* **Import** — old `tr(m/84')`, `pkh(m/84')`, `wpkh(m/48'/…/2')` descriptors
  still parse.

```
cd test && python3 run_native_tests.py && python3 -m compileall ../src ../test
```
→ 33 native tests green, compileall clean (run under WSL; native Windows takes
the hardware `import sdram` path).

### Simulator (Unix)

Rebuilt and driven through: #393 Standard Taproot → `tr(m/86')`; Taproot +
Recover → `tr(m/84')` after warning; Legacy + Recover → `pkh(m/84')` while
Standard Legacy would be `pkh(m/44')`; Multisig key `m/48'/0'/0'/2'` + Native
Segwit + Recover → `wpkh(m/48'/0'/0'/2')` (full path kept). Screenshots below.

## Security

Descriptor key-origin and signing key always agree: standard re-derives the
key for the origin it writes; recovery keeps both from the on-screen key. No
path is inferred from XPUB version bytes. `coin_type` is read from the active
network, so no cross-network derivation. Unparseable / short / deep paths are
handled (`_parse_path` returns `None`, `_account_index` falls back). No seed or
private-key material is logged or exported.

## Not verified without hardware

On-device LVGL rendering of the choice/warning screens; a real
QR/USB descriptor round-trip + signature for a created wallet.

Fixes #393. Ref #281.
