### PR TITLE
Fix write-protection status shown on the About screen

### DIFF
--- a/src/platform.py
+++ b/src/platform.py
@@ -229,17 +229,19 @@ def get_flash_write_protection_status() -> str:
     except Exception:
         return "unknown"
 
-    lower = (option_control >> 16) & 0xFFFF
-    upper = 0xFFFF
+    # nWRP: one "not write-protected" bit per sector (1 = unprotected). The
+    # STM32F469 in its 2 MB dual-bank layout has 12 sectors per bank; the bits
+    # are FLASH_OPTCR[27:16] for bank 1 and FLASH_OPTCR1[27:16] for bank 2.
+    bank1_nwrp = (option_control >> 16) & 0xFFF
+    bank2_nwrp = 0xFFF
 
-    if stm is not None:
-        try:
-            option_control_1 = stm.mem32[0x40023C18]
-            upper = option_control_1 & 0xFFFF
-        except Exception:
-            pass
+    try:
+        option_control_1 = stm.mem32[0x40023C18]
+        bank2_nwrp = (option_control_1 >> 16) & 0xFFF
+    except Exception:
+        pass
 
-    if lower == 0xFFFF and upper == 0xFFFF:
+    if bank1_nwrp == 0xFFF and bank2_nwrp == 0xFFF:
         return "disabled"
     return "enabled"
 


### PR DESCRIPTION
## Problem

On the STM32F469-DISCO the About screen always shows **"Write protection: Enabled"**, even when no write protection is set. `get_flash_write_protection_status()` in `src/platform.py` misreads the nWRP option bytes:

- The nWRP field is **12 bits** (one "not-write-protected" bit per sector), but the code compares it against `0xFFFF`, which can never match.
- Bank 2's nWRP bits live in `FLASH_OPTCR1[27:16]`. The code reads `FLASH_OPTCR1[15:0]` instead — that field holds `BOOT_ADD0` — so `upper` is the boot address and is never `0xFFFF`.

So `if lower == 0xFFFF and upper == 0xFFFF` is unreachable and the function returns `"enabled"` unconditionally.

## Fix

Mask both banks' nWRP fields to 12 bits and check for the all-unprotected value `0xFFF`.

## Verification

Read live from a board with `FLASH_OPTCR = 0x0FFFAAED`, `FLASH_OPTCR1 = 0x0FFF0000` (RDP level 0, no WRP — confirmed by OpenOCD `flash info` showing every sector "not protected" and by STM32CubeProgrammer):

| | before | after |
|---|---|---|
| no protection | `enabled` (wrong) | `disabled` (correct) |
| one nWRP bit cleared (bank 1 or bank 2) | `enabled` | `enabled` (correct) |

`get_flash_read_protection_status()` was already correct and is unchanged.
