### PR TITLE
ci: Add PR security & change guard workflow

### DIFF
--- a/.github/workflows/pr-security-change-guard.yml
+++ b/.github/workflows/pr-security-change-guard.yml
@@ -74,9 +74,11 @@ jobs:
     steps:
       - name: Build & publish report
         # Pinned to a full commit SHA. This SHA is the actions/github-script
-        # v7.1.0 release (also where the moving `v7` tag points). Update the
-        # SHA and the trailing comment together when bumping.
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        # v8.0.0 release (also where the moving `v8` tag points). v8 runs on
+        # the Node 24 runtime; GitHub is removing Node 20 from hosted runners
+        # in 2026, so v7 must not be used for a newly introduced workflow.
+        # Update the SHA and the trailing comment together when bumping.
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           # Default GITHUB_TOKEN. Scope is limited by `permissions:` above.
           script: |
@@ -187,6 +189,29 @@ jobs:
             const short = (sha) => (sha ? sha.substring(0, 12) : '(none)');
 
             // ---------------------------------------------------------------
+            // Baseline for "what did THIS PR change?"
+            // ---------------------------------------------------------------
+            // `pr.base.sha` is the *current* tip of the base branch, which may
+            // have moved on with unrelated commits since the PR was opened.
+            // Comparing submodule / signing config against it would attribute
+            // those unrelated base-branch changes to this PR. The correct
+            // baseline is the merge-base of base...head. Fall back to
+            // `pr.base.sha` only if the compare API is unavailable.
+            let mergeBaseSha = baseSha;
+            try {
+              const mb = await github.rest.repos.compareCommitsWithBasehead({
+                owner, repo, basehead: `${baseSha}...${headSha}`,
+              });
+              if (mb.data.merge_base_commit && mb.data.merge_base_commit.sha) {
+                mergeBaseSha = mb.data.merge_base_commit.sha;
+              }
+            } catch (e) {
+              note(`Could not determine the base/head merge-base (${e.message}); ` +
+                   `comparing against the base branch tip \`${short(baseSha)}\` instead — ` +
+                   `unrelated base-branch changes may be misattributed to this PR.`);
+            }
+
+            // ---------------------------------------------------------------
             // Security-sensitive path catalogue
             // (derived from an inspection of the current repository layout)
             // ---------------------------------------------------------------
@@ -261,10 +286,32 @@ jobs:
               note(`Could not list PR files: ${e.message}`);
             }
 
-            const securityHits = new Map(); // file -> [areas]
+            // The pulls "list files" endpoint is capped at 3000 files. Past
+            // that the scan below is provably incomplete, so treat it the same
+            // as an API failure ("unknown", not "clean").
+            const filesTruncated = filesOk && files.length >= 3000;
+            if (filesTruncated) {
+              note('This PR changes ≥3000 files; GitHub caps the file list at 3000. ' +
+                   'The security-file scan is incomplete — manual review required.');
+            }
+
+            // display name -> [areas]. For a rename, BOTH the old and the new
+            // path are classified: a security-sensitive file moved to a path
+            // that is not on the catalogue would otherwise slip through as
+            // "no security-sensitive files changed".
+            const securityHits = new Map();
             for (const f of files) {
-              const areas = matchAreas(f.filename);
-              if (areas.length) securityHits.set(f.filename, areas);
+              const names = [f.filename];
+              if (f.status === 'renamed' && f.previous_filename) {
+                names.push(f.previous_filename);
+              }
+              const areas = [...new Set(names.flatMap(matchAreas))];
+              if (areas.length) {
+                const display = (f.status === 'renamed' && f.previous_filename)
+                  ? `${f.previous_filename} → ${f.filename}`
+                  : f.filename;
+                securityHits.set(display, areas);
+              }
             }
 
             // ---------------------------------------------------------------
@@ -345,7 +392,7 @@ jobs:
             }
 
             for (const path of TOP_SUBMODULES) {
-              const before = await pathState(owner, repo, path, baseSha);
+              const before = await pathState(owner, repo, path, mergeBaseSha);
               const after = await pathState(owner, repo, path, headRefs);
               const state = classify(before, after);
 
@@ -609,19 +656,33 @@ jobs:
                   // misrepresent that as a normal post-approval diff.
                   if (cmp && cmp.data.status === 'ahead') {
                     const c = cmp.data;
-                    const add = (c.files || []).reduce((a, f) => a + (f.additions || 0), 0);
-                    const del = (c.files || []).reduce((a, f) => a + (f.deletions || 0), 0);
+                    const cFiles = c.files || [];
+                    const add = cFiles.reduce((a, f) => a + (f.additions || 0), 0);
+                    const del = cFiles.reduce((a, f) => a + (f.deletions || 0), 0);
                     L.push(`Changes after approval: **${c.total_commits} commit(s)**, ` +
-                           `**${(c.files || []).length} file(s)**, **+${add} / -${del}** lines`);
+                           `**${cFiles.length} file(s)**, **+${add} / -${del}** lines`);
                     L.push('');
-                    const changed = (c.files || []).map((f) => f.filename);
-                    L.push('Files changed since approval:');
-                    for (const f of changed.slice(0, 40)) {
-                      const areas = matchAreas(f);
-                      const sub = TOP_SUBMODULES.includes(f) ? ' _(submodule pointer)_' : '';
-                      L.push(`- \`${mdEsc(f)}\`${areas.length ? ' — ⚠️ ' + areas.map(mdEsc).join('; ') : ''}${sub}`);
+                    // The compare endpoint caps its file list at 300. Past that
+                    // the classification below is incomplete -> say so.
+                    if (cFiles.length >= 300) {
+                      L.push('❓ The compare API caps the changed-file list at 300 entries; ' +
+                             'the list below may be incomplete. **Manual review required.**');
+                      L.push('');
                     }
-                    if (changed.length > 40) L.push(`- … and ${changed.length - 40} more`);
+                    L.push('Files changed since approval:');
+                    for (const f of cFiles.slice(0, 40)) {
+                      const names = [f.filename];
+                      if (f.status === 'renamed' && f.previous_filename) {
+                        names.push(f.previous_filename);
+                      }
+                      const areas = [...new Set(names.flatMap(matchAreas))];
+                      const disp = (f.status === 'renamed' && f.previous_filename)
+                        ? `${f.previous_filename} → ${f.filename}`
+                        : f.filename;
+                      const sub = TOP_SUBMODULES.includes(f.filename) ? ' _(submodule pointer)_' : '';
+                      L.push(`- \`${mdEsc(disp)}\`${areas.length ? ' — ⚠️ ' + areas.map(mdEsc).join('; ') : ''}${sub}`);
+                    }
+                    if (cFiles.length > 40) L.push(`- … and ${cFiles.length - 40} more`);
                   } else if (cmp) {
                     L.push(`❓ The approved commit \`${short(lastSha)}\` is no longer a clean ` +
                            `ancestor of the current HEAD (compare status: \`${cmp.data.status}\`). ` +
@@ -648,12 +709,26 @@ jobs:
             out.push('');
             out.push('_Informational only — none of the findings below block this PR. ' +
                      '❓ marks something the workflow could not verify (treat as "unknown", not "safe")._');
-            out.push(`<sub>base \`${short(baseSha)}\` · head \`${short(headSha)}\` · updated ${new Date().toISOString()}</sub>`);
+            out.push(`<sub>merge-base \`${short(mergeBaseSha)}\` · base tip \`${short(baseSha)}\` · ` +
+                     `head \`${short(headSha)}\` · updated ${new Date().toISOString()}</sub>`);
             out.push('');
 
             out.push('### Security-sensitive files');
             if (!filesOk) {
               out.push('❓ Could not retrieve the list of changed files (API error). Manual review required.');
+            } else if (filesTruncated) {
+              out.push('❓ The changed-file list is truncated (≥3000 files) — the scan is ' +
+                       'incomplete. **Manual review required.**');
+              if (securityHits.size) {
+                out.push('');
+                out.push('Security-sensitive files seen so far:');
+                out.push('');
+                out.push('| File | Area |');
+                out.push('| --- | --- |');
+                for (const [f, areas] of securityHits) {
+                  out.push(`| \`${mdEsc(f)}\` | ${areas.map(mdEsc).join('; ')} |`);
+                }
+              }
             } else if (securityHits.size === 0) {
               out.push('✅ No security-sensitive files changed.');
             } else {

--- a/.github/workflows/pr-security-change-guard.yml
+++ b/.github/workflows/pr-security-change-guard.yml
@@ -10,11 +10,17 @@ name: PR Security & Change Guard
 #   1. Were security-sensitive files touched?
 #   2. Were production signing keys or signature thresholds changed?
 #      (these live in the `bootloader` submodule -> keys/production/pubkeys.c)
-#   3. Was a submodule pointer moved (top level *and* one level of nesting)?
-#   4. What changed since the most recent APPROVED review?
+#   3. Was a submodule pointer moved / added / removed (top level *and* one
+#      level of nesting)?
+#   4. What changed since the most recent APPROVED review (including an
+#      approval that was later dismissed as stale)?
 #
 # This workflow is INFORMATIONAL ONLY. It never fails the PR, never blocks a
 # merge, never dismisses reviews and never edits branch-protection rules.
+#
+# It is, however, "fail closed" for its own reporting: when it cannot
+# determine something (API error, unparseable file, ...) it says so with a
+# ❓ marker and asks for manual review instead of printing a green ✅.
 #
 # ---------------------------------------------------------------------------
 # Security model (fork PRs)
@@ -26,8 +32,10 @@ name: PR Security & Change Guard
 #   * never checks out the PR head (no `actions/checkout` at all),
 #   * never runs any script, action or tool that comes from the PR,
 #   * only reads PR data through authenticated GitHub REST API calls,
-#   * only executes `actions/github-script` (pinned) with code that lives on
-#     the base repo default branch (i.e. this file).
+#   * only executes `actions/github-script` (pinned to a full commit SHA)
+#     with code that lives on the base repo default branch (i.e. this file),
+#   * never interpolates PR-controlled text (`${{ github.event.* }}`) into a
+#     shell `run:` step (there are no `run:` steps at all).
 #
 # Because nothing from the PR is executed, the write-capable token is never
 # exposed to attacker-controlled code.
@@ -60,11 +68,14 @@ jobs:
       github.event.pull_request.state == 'open'
     steps:
       - name: Build & publish report
-        uses: actions/github-script@v7
+        # Pinned to the commit the `v7` tag pointed at (v7.0.1). Update the
+        # SHA and the trailing comment together when bumping.
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           # Default GITHUB_TOKEN. Scope is limited by `permissions:` above.
           script: |
             const STICKY_MARKER = '<!-- pr-security-change-guard -->';
+            const BOT_LOGIN = 'github-actions[bot]';
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -72,9 +83,9 @@ jobs:
             const prNumber = pr.number;
             const baseSha = pr.base.sha;
             const headSha = pr.head.sha;
-            // PR head commits are always reachable in the BASE repo under this
-            // ref, so we never need the fork remote for tree reads.
-            const headRef = [headSha, `refs/pull/${prNumber}/head`];
+            // PR head commits are reachable in the BASE repo both as the head
+            // SHA and as refs/pull/<n>/head; try both.
+            const headRefs = [headSha, `refs/pull/${prNumber}/head`];
             const headRepoFull =
               (pr.head.repo && pr.head.repo.full_name) || `${owner}/${repo}`;
 
@@ -84,6 +95,16 @@ jobs:
             // ---------------------------------------------------------------
             // Helpers
             // ---------------------------------------------------------------
+            // Escape a string that came from outside (file names, key owner
+            // comments, ...) so it cannot break out of the surrounding
+            // Markdown / inline-code context in the generated report.
+            function mdEsc(s) {
+              return String(s)
+                .replace(/[\r\n]+/g, ' ')
+                .replace(/[`|*_~<>\[\]\\]/g, '\\$&')
+                .trim();
+            }
+
             async function getRaw(o, r, path, ref) {
               const res = await github.rest.repos.getContent({
                 owner: o, repo: r, path, ref,
@@ -94,12 +115,12 @@ jobs:
                 : Buffer.from(res.data.content, 'base64').toString('utf8');
             }
 
-            // Submodule pointer at `path` for a given ref, or null.
-            // `ref` may be a string or an array of candidate refs (first hit wins);
-            // this is used for the PR head, which is reachable in the base repo
-            // both as the head SHA and as refs/pull/<n>/head depending on setup.
-            async function submodulePointer(o, r, path, ref) {
+            // Resolve what is at `path` for a given ref (or list of candidate
+            // refs). Returns { kind, sha?, url? } where kind is one of:
+            //   'submodule' | 'other' | 'absent' | 'error'
+            async function pathState(o, r, path, ref) {
               const refs = Array.isArray(ref) ? ref : [ref];
+              let lastErr = null;
               for (const rf of refs) {
                 try {
                   const res = await github.rest.repos.getContent({
@@ -107,20 +128,21 @@ jobs:
                   });
                   const d = res.data;
                   if (d && d.type === 'submodule') {
-                    return { sha: d.sha, url: d.submodule_git_url || null };
+                    return { kind: 'submodule', sha: d.sha, url: d.submodule_git_url || null };
                   }
+                  return { kind: 'other' };
                 } catch (e) {
-                  // try next candidate ref
+                  if (e.status === 404) return { kind: 'absent' };
+                  lastErr = e;
                 }
               }
-              return null;
+              return { kind: 'error', message: lastErr ? lastErr.message : 'unknown' };
             }
 
-            // Parse a .gitmodules file into [{ name, path, url }].
             function parseGitmodules(text) {
               const out = [];
               let cur = null;
-              for (const line of text.split('\n')) {
+              for (const line of String(text).split('\n')) {
                 const s = line.trim();
                 const h = s.match(/^\[submodule "(.+)"\]$/);
                 if (h) { cur = { name: h[1], path: null, url: null }; out.push(cur); continue; }
@@ -133,27 +155,25 @@ jobs:
               return out.filter((m) => m.path);
             }
 
-            // Resolve a submodule URL (absolute or relative) to
-            // { host, owner, repo } when it is a GitHub repo, else null.
             function resolveRepo(url, parentOwner) {
               if (!url) return null;
               let u = url.replace(/\.git$/, '');
-              const rel = u.match(/^\.\.\/\.\.\/([^/]+)\/(.+)$/); // ../../owner/repo
-              if (rel) return { host: 'github.com', owner: rel[1], repo: rel[2] };
-              const rel1 = u.match(/^\.\.\/([^/]+)$/);            // ../repo (same owner)
-              if (rel1) return { host: 'github.com', owner: parentOwner, repo: rel1[1] };
+              const rel2 = u.match(/^\.\.\/\.\.\/([^/]+)\/(.+)$/); // ../../owner/repo
+              if (rel2) return { owner: rel2[1], repo: rel2[2] };
+              const rel1 = u.match(/^\.\.\/([^/]+)$/);             // ../repo (same owner)
+              if (rel1) return { owner: parentOwner, repo: rel1[1] };
               const m = u.match(/github\.com[/:]([^/]+)\/(.+)$/);
-              if (m) return { host: 'github.com', owner: m[1], repo: m[2] };
+              if (m) return { owner: m[1], repo: m[2] };
               return null;
             }
 
             function compareLink(url, parentOwner, oldSha, newSha) {
               const g = resolveRepo(url, parentOwner);
-              if (!g) return null;
+              if (!g || !oldSha || !newSha) return null;
               return `https://github.com/${g.owner}/${g.repo}/compare/${oldSha}...${newSha}`;
             }
 
-            function short(sha) { return sha ? sha.substring(0, 12) : '(none)'; }
+            const short = (sha) => (sha ? sha.substring(0, 12) : '(none)');
 
             // ---------------------------------------------------------------
             // Security-sensitive path catalogue
@@ -170,7 +190,7 @@ jobs:
                 globs: ['boot/**'] },
               { label: 'Build / release tooling',
                 globs: ['build_firmware.sh', 'Dockerfile', 'Makefile',
-                        'flake.nix', 'flake.lock', 'shell.nix',
+                        'flake.nix', 'flake.lock', 'shell.nix', 'simulate.py',
                         'manifests/**', 'tools/**'] },
               { label: 'CI / GitHub Actions',
                 globs: ['.github/workflows/**', '.github/actions/**'] },
@@ -183,6 +203,8 @@ jobs:
                 globs: ['src/rng.py', 'src/apps/getrandom.py'] },
               { label: 'Wallet / PSBT / descriptor / transaction handling',
                 globs: ['src/apps/wallets/**', 'src/gui/screens/transaction.py'] },
+              { label: 'XPUB export / authorization',
+                globs: ['src/apps/xpubs/**'] },
               { label: 'Message signing',
                 globs: ['src/apps/signmessage/**'] },
               { label: 'Blinding keys (Liquid)',
@@ -218,11 +240,13 @@ jobs:
             // 1. Changed files in the PR (via API, no checkout)
             // ---------------------------------------------------------------
             let files = [];
+            let filesOk = true;
             try {
               files = await github.paginate(github.rest.pulls.listFiles, {
                 owner, repo, pull_number: prNumber, per_page: 100,
               });
             } catch (e) {
+              filesOk = false;
               note(`Could not list PR files: ${e.message}`);
             }
 
@@ -239,62 +263,94 @@ jobs:
             const submoduleReport = [];
             let bootloaderOld = null;
             let bootloaderNew = null;
+            let bootloaderResolved = true;
+
+            function classify(before, after) {
+              const b = before.kind === 'submodule';
+              const a = after.kind === 'submodule';
+              if (before.kind === 'error' || after.kind === 'error') return 'unverified';
+              if (b && a) return before.sha === after.sha ? 'unchanged' : 'changed';
+              if (!b && a) return 'added';
+              if (b && !a) return 'removed';
+              return 'none';
+            }
+
+            async function nestedChanges(parentUrl, parentOwner, oldSha, newSha) {
+              const g = resolveRepo(parentUrl, parentOwner);
+              const result = { ok: true, entries: [] };
+              if (!g) { result.ok = false; return result; }
+              let gmOld = '';
+              let gmNew = '';
+              try {
+                [gmOld, gmNew] = await Promise.all([
+                  getRaw(g.owner, g.repo, '.gitmodules', oldSha).catch(() => ''),
+                  getRaw(g.owner, g.repo, '.gitmodules', newSha).catch(() => ''),
+                ]);
+              } catch (e) {
+                result.ok = false;
+                return result;
+              }
+              const modsOld = parseGitmodules(gmOld);
+              const modsNew = parseGitmodules(gmNew);
+              const paths = new Set([
+                ...modsOld.map((m) => m.path),
+                ...modsNew.map((m) => m.path),
+              ]);
+              for (const np of paths) {
+                const nb = await pathState(g.owner, g.repo, np, oldSha);
+                const na = await pathState(g.owner, g.repo, np, newSha);
+                const state = classify(nb, na);
+                if (state === 'unchanged' || state === 'none') continue;
+                const nurl =
+                  na.url || nb.url ||
+                  (modsNew.find((m) => m.path === np) || {}).url ||
+                  (modsOld.find((m) => m.path === np) || {}).url;
+                result.entries.push({
+                  path: np,
+                  state,
+                  old: nb.sha || null,
+                  new: na.sha || null,
+                  link: compareLink(nurl, g.owner, nb.sha, na.sha),
+                });
+              }
+              return result;
+            }
 
             for (const path of TOP_SUBMODULES) {
-              const before = await submodulePointer(owner, repo, path, baseSha);
-              const after = await submodulePointer(owner, repo, path, headRef);
-              if (!before || !after) {
-                if (!before && !after) continue; // not a submodule here
-                note(`Could not resolve both pointers for submodule '${path}'.`);
+              const before = await pathState(owner, repo, path, baseSha);
+              const after = await pathState(owner, repo, path, headRefs);
+              const state = classify(before, after);
+
+              if (path === 'bootloader') {
+                if (before.kind === 'submodule') bootloaderOld = before.sha;
+                if (after.kind === 'submodule') bootloaderNew = after.sha;
+                if (state === 'unverified') bootloaderResolved = false;
+              }
+
+              if (state === 'none' || state === 'unchanged') continue;
+
+              if (state === 'unverified') {
+                note(`Could not resolve the '${path}' submodule pointer on both sides.`);
+                submoduleReport.push({ path, state, old: before.sha || null,
+                                       new: after.sha || null, nested: [], nestedOk: false });
                 continue;
               }
-              if (path === 'bootloader') {
-                bootloaderOld = before.sha;
-                bootloaderNew = after.sha;
-              }
-              if (before.sha === after.sha) continue;
 
               const entry = {
                 path,
-                old: before.sha,
-                new: after.sha,
-                url: before.url || after.url,
+                state,
+                old: before.sha || null,
+                new: after.sha || null,
+                url: (before.url || after.url),
                 link: compareLink(before.url || after.url, owner, before.sha, after.sha),
                 nested: [],
+                nestedOk: true,
               };
-
-              // one level of nesting
-              const g = resolveRepo(entry.url, owner);
-              if (g) {
-                try {
-                  const [gmOld, gmNew] = await Promise.all([
-                    getRaw(g.owner, g.repo, '.gitmodules', before.sha).catch(() => ''),
-                    getRaw(g.owner, g.repo, '.gitmodules', after.sha).catch(() => ''),
-                  ]);
-                  const modsOld = parseGitmodules(gmOld);
-                  const modsNew = parseGitmodules(gmNew);
-                  const paths = new Set([
-                    ...modsOld.map((m) => m.path),
-                    ...modsNew.map((m) => m.path),
-                  ]);
-                  for (const np of paths) {
-                    const nOld = await submodulePointer(g.owner, g.repo, np, before.sha);
-                    const nNew = await submodulePointer(g.owner, g.repo, np, after.sha);
-                    if (!nOld || !nNew) continue;
-                    if (nOld.sha === nNew.sha) continue;
-                    const nurl = nNew.url || nOld.url ||
-                      (modsNew.find((m) => m.path === np) || {}).url ||
-                      (modsOld.find((m) => m.path === np) || {}).url;
-                    entry.nested.push({
-                      path: np,
-                      old: nOld.sha,
-                      new: nNew.sha,
-                      link: compareLink(nurl, g.owner, nOld.sha, nNew.sha),
-                    });
-                  }
-                } catch (e) {
-                  note(`Nested submodule scan for '${path}' failed: ${e.message}`);
-                }
+              if (state === 'changed' && before.sha && after.sha) {
+                const nc = await nestedChanges(entry.url, owner, before.sha, after.sha);
+                entry.nestedOk = nc.ok;
+                entry.nested = nc.entries;
+                if (!nc.ok) note(`Nested submodule scan for '${path}' could not be completed.`);
               }
               submoduleReport.push(entry);
             }
@@ -306,35 +362,51 @@ jobs:
             let signingSection = '';
 
             function parsePubkeys(src) {
-              const res = { thresholds: {}, lists: {} };
+              const res = { thresholds: {}, lists: {}, ok: true, problems: [] };
               const t1 = src.match(/\.bootloader_sig_threshold\s*=\s*(\d+)/);
               const t2 = src.match(/\.main_fw_sig_threshold\s*=\s*(\d+)/);
-              res.thresholds.bootloader = t1 ? t1[1] : null;
-              res.thresholds.main_fw = t2 ? t2[1] : null;
+              res.thresholds.bootloader = t1 ? Number(t1[1]) : null;
+              res.thresholds.main_fw = t2 ? Number(t2[1]) : null;
+              if (!t1) res.problems.push('bootloader_sig_threshold not found');
+              if (!t2) res.problems.push('main_fw_sig_threshold not found');
 
               for (const listName of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
-                // list body runs from `name[] = {` to the first `};`
-                // (individual entries end in `}},` so `};` is unambiguous)
+                // list body: from `name[] = {` to the first `};`
                 const re = new RegExp(
                   listName + '\\s*\\[\\]\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*;');
                 const m = src.match(re);
                 const keys = [];
-                if (m) {
+                if (!m) {
+                  res.problems.push(`${listName} not found`);
+                } else {
                   const body = m[1];
-                  // split into "{.bytes = { ... }}" blocks, keep preceding // comment
-                  const blockRe = /(?:\/\/\s*(.*)\s*\n\s*)?\{\s*\.bytes\s*=\s*\{([\s\S]*?)\}\s*\}/g;
+                  const blockRe = /(?:\/\/\s*([^\n]*?)\s*\n\s*)?\{\s*\.bytes\s*=\s*\{([\s\S]*?)\}\s*\}/g;
                   let bm;
                   while ((bm = blockRe.exec(body)) !== null) {
-                    const owner = (bm[1] || '').trim() || '(unlabelled)';
+                    const keyOwner = (bm[1] || '').trim() || '(unlabelled)';
                     const bytes = (bm[2].match(/0x[0-9a-fA-F]{1,2}/g) || [])
                       .map((h) => parseInt(h, 16).toString(16).padStart(2, '0'))
                       .join('');
-                    if (!bytes) continue;
-                    keys.push({ owner, bytes });
+                    keys.push({ owner: keyOwner, bytes });
                   }
+                  if (!keys.length) res.problems.push(`${listName} parsed as empty`);
                 }
                 res.lists[listName] = keys;
               }
+
+              // Validate: thresholds present & sane, both lists non-empty, each
+              // key a plausible uncompressed EC point (65 bytes, 0x04 prefix).
+              const tOk = [res.thresholds.bootloader, res.thresholds.main_fw]
+                .every((v) => Number.isInteger(v) && v >= 1 && v <= 16);
+              if (!tOk) res.problems.push('threshold values missing or out of range');
+              for (const listName of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
+                for (const k of res.lists[listName]) {
+                  if (k.bytes.length !== 130 || !k.bytes.startsWith('04')) {
+                    res.problems.push(`${listName}: key "${k.owner}" has unexpected format`);
+                  }
+                }
+              }
+              res.ok = res.problems.length === 0;
               return res;
             }
 
@@ -351,7 +423,11 @@ jobs:
               return sha256(parts.join('|'));
             }
 
-            if (bootloaderOld && bootloaderNew && bootloaderOld !== bootloaderNew) {
+            if (!bootloaderResolved) {
+              signingSection =
+                '❓ Could not resolve the `bootloader` submodule pointer on both sides — ' +
+                'production signing configuration **not verified**. Manual review recommended.';
+            } else if (bootloaderOld && bootloaderNew && bootloaderOld !== bootloaderNew) {
               try {
                 const [srcOld, srcNew] = await Promise.all([
                   getRaw('cryptoadvance', 'specter-bootloader', PUBKEYS_PATH, bootloaderOld),
@@ -360,56 +436,66 @@ jobs:
                 const pOld = parsePubkeys(srcOld);
                 const pNew = parsePubkeys(srcNew);
 
-                const digOld = keysetDigest(pOld);
-                const digNew = keysetDigest(pNew);
-
-                const lines = [];
-                const tChanged =
-                  pOld.thresholds.bootloader !== pNew.thresholds.bootloader ||
-                  pOld.thresholds.main_fw !== pNew.thresholds.main_fw;
-                const kChanged = digOld !== digNew;
-
-                if (!tChanged && !kChanged) {
-                  lines.push('✅ **Production signing configuration unchanged**');
-                  lines.push('');
-                  lines.push('The `bootloader` pointer moved, but the vendor / maintainer');
-                  lines.push('public keys and both signature thresholds are identical.');
+                if (!pOld.ok || !pNew.ok) {
+                  const probs = [...new Set([...pOld.problems, ...pNew.problems])];
+                  signingSection = [
+                    '❓ **Unable to verify production signing configuration — manual review required.**',
+                    '',
+                    `\`${PUBKEYS_PATH}\` could not be parsed with confidence ` +
+                    `(old \`${short(bootloaderOld)}\` → new \`${short(bootloaderNew)}\`):`,
+                    ...probs.slice(0, 8).map((p) => `- ${mdEsc(p)}`),
+                    '',
+                    'The parser is intentionally strict; treat this as "unknown", not "unchanged".',
+                  ].join('\n');
                 } else {
-                  lines.push('⚠️ **Production signing configuration changed**');
-                  lines.push('');
-                  lines.push('| Setting | Old | New |');
-                  lines.push('| --- | --- | --- |');
-                  lines.push(`| \`bootloader_sig_threshold\` | ${pOld.thresholds.bootloader ?? '?'} | ${pNew.thresholds.bootloader ?? '?'} |`);
-                  lines.push(`| \`main_fw_sig_threshold\` | ${pOld.thresholds.main_fw ?? '?'} | ${pNew.thresholds.main_fw ?? '?'} |`);
-                  lines.push(`| Production key set | ${kChanged ? '**CHANGED**' : 'unchanged'} | |`);
-                  lines.push('');
-                  lines.push(`Old key-set SHA256: \`${digOld}\``);
-                  lines.push(`New key-set SHA256: \`${digNew}\``);
-
-                  for (const ln of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
-                    const before = new Map(pOld.lists[ln].map((k) => [k.bytes, k.owner]));
-                    const after = new Map(pNew.lists[ln].map((k) => [k.bytes, k.owner]));
-                    const added = [...after].filter(([b]) => !before.has(b));
-                    const removed = [...before].filter(([b]) => !after.has(b));
-                    if (added.length || removed.length) {
-                      lines.push('');
-                      lines.push(`**${ln.replace('_pubkey_list', '')} keys**`);
-                      for (const [b, o] of added)
-                        lines.push(`- ➕ added — owner \`${o}\`, fingerprint \`${fpr(b)}\``);
-                      for (const [b, o] of removed)
-                        lines.push(`- ➖ removed — owner \`${o}\`, fingerprint \`${fpr(b)}\``);
+                  const digOld = keysetDigest(pOld);
+                  const digNew = keysetDigest(pNew);
+                  const tChanged =
+                    pOld.thresholds.bootloader !== pNew.thresholds.bootloader ||
+                    pOld.thresholds.main_fw !== pNew.thresholds.main_fw;
+                  const kChanged = digOld !== digNew;
+                  const lines = [];
+                  if (!tChanged && !kChanged) {
+                    lines.push('✅ **Production signing configuration unchanged**');
+                    lines.push('');
+                    lines.push('The `bootloader` pointer moved, but the vendor / maintainer');
+                    lines.push('public keys and both signature thresholds are identical.');
+                  } else {
+                    lines.push('⚠️ **Production signing configuration changed**');
+                    lines.push('');
+                    lines.push('| Setting | Old | New |');
+                    lines.push('| --- | --- | --- |');
+                    lines.push(`| \`bootloader_sig_threshold\` | ${pOld.thresholds.bootloader} | ${pNew.thresholds.bootloader} |`);
+                    lines.push(`| \`main_fw_sig_threshold\` | ${pOld.thresholds.main_fw} | ${pNew.thresholds.main_fw} |`);
+                    lines.push(`| Production key set | ${kChanged ? '**CHANGED**' : 'unchanged'} | |`);
+                    lines.push('');
+                    lines.push(`Old key-set SHA256: \`${digOld}\``);
+                    lines.push(`New key-set SHA256: \`${digNew}\``);
+                    for (const ln of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
+                      const before = new Map(pOld.lists[ln].map((k) => [k.bytes, k.owner]));
+                      const after = new Map(pNew.lists[ln].map((k) => [k.bytes, k.owner]));
+                      const added = [...after].filter(([b]) => !before.has(b));
+                      const removed = [...before].filter(([b]) => !after.has(b));
+                      if (added.length || removed.length) {
+                        lines.push('');
+                        lines.push(`**${ln.replace('_pubkey_list', '')} keys**`);
+                        for (const [b, o] of added)
+                          lines.push(`- ➕ added — owner \`${mdEsc(o)}\`, fingerprint \`${fpr(b)}\``);
+                        for (const [b, o] of removed)
+                          lines.push(`- ➖ removed — owner \`${mdEsc(o)}\`, fingerprint \`${fpr(b)}\``);
+                      }
                     }
+                    lines.push('');
+                    lines.push('> Flagged prominently but **not blocking**. A production');
+                    lines.push('> signing-config change must be reviewed by the maintainers.');
                   }
-                  lines.push('');
-                  lines.push('> This is flagged prominently but **not blocking**. A production');
-                  lines.push('> signing-config change must be reviewed by the maintainers.');
+                  signingSection = lines.join('\n');
                 }
-                signingSection = lines.join('\n');
               } catch (e) {
                 signingSection =
-                  `ℹ️ Could not load \`${PUBKEYS_PATH}\` from one/both bootloader commits ` +
-                  `(\`${short(bootloaderOld)}\` → \`${short(bootloaderNew)}\`): ${e.message}. ` +
-                  `Manual review of the bootloader bump is recommended.`;
+                  `❓ Could not load \`${PUBKEYS_PATH}\` from one/both bootloader commits ` +
+                  `(\`${short(bootloaderOld)}\` → \`${short(bootloaderNew)}\`): ${mdEsc(e.message)}. ` +
+                  `Production signing configuration **not verified** — manual review recommended.`;
               }
             } else if (bootloaderOld && bootloaderNew) {
               signingSection =
@@ -417,30 +503,55 @@ jobs:
                 'submodule pointer was not modified by this PR.';
             } else {
               signingSection =
-                'ℹ️ Could not resolve the `bootloader` submodule pointer on both sides; ' +
-                'skipping signing-config comparison.';
+                '❓ The `bootloader` submodule was added or removed by this PR — ' +
+                'production signing configuration **not verified**. Manual review required.';
             }
 
             // ---------------------------------------------------------------
-            // 4. Changes since last approval
+            // 4. Changes since last approval (incl. approvals dismissed as stale)
             // ---------------------------------------------------------------
             let approvalSection = '';
             try {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner, repo, pull_number: prNumber, per_page: 100,
               });
-              const approved = reviews.filter((r) => r.state === 'APPROVED');
-              const last = approved[approved.length - 1];
+
+              // Reviews that were APPROVED and later dismissed still matter as
+              // "the last approval". Recover them from the timeline.
+              const dismissedApprovalIds = new Set();
+              try {
+                const timeline = await github.paginate(
+                  github.rest.issues.listEventsForTimeline,
+                  { owner, repo, issue_number: prNumber, per_page: 100 });
+                for (const ev of timeline) {
+                  if (ev.event === 'review_dismissed' && ev.dismissed_review &&
+                      String(ev.dismissed_review.state).toLowerCase() === 'approved') {
+                    if (ev.dismissed_review.review_id != null)
+                      dismissedApprovalIds.add(ev.dismissed_review.review_id);
+                  }
+                }
+              } catch (e) {
+                note(`Could not read PR timeline for dismissed approvals: ${e.message}`);
+              }
+
+              const approvals = reviews
+                .filter((r) => r.state === 'APPROVED' || dismissedApprovalIds.has(r.id))
+                .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at));
+              const last = approvals[approvals.length - 1];
+
               if (!last) {
                 approvalSection = 'ℹ️ No previous approval found. (This is not an error.)';
               } else {
                 const lastSha = last.commit_id;
+                const staleTag = last.state !== 'APPROVED'
+                  ? ' _(this approval was later dismissed — likely stale; comparing against it anyway)_'
+                  : '';
                 if (lastSha === headSha) {
                   approvalSection =
                     `✅ No changes since last approval.\n\n` +
-                    `Approved by \`${last.user.login}\` at \`${short(lastSha)}\` (current HEAD).`;
+                    `Approved by \`${mdEsc(last.user.login)}\` at \`${short(lastSha)}\` (current HEAD).${staleTag}`;
                 } else {
-                  let cmp;
+                  let cmp = null;
                   try {
                     cmp = await github.rest.repos.compareCommitsWithBasehead({
                       owner: headRepoFull.split('/')[0],
@@ -448,11 +559,10 @@ jobs:
                       basehead: `${lastSha}...${headSha}`,
                     });
                   } catch (e) {
-                    cmp = null;
                     note(`compare ${short(lastSha)}...${short(headSha)} failed: ${e.message}`);
                   }
                   const L = [];
-                  L.push(`Last approved commit: \`${short(lastSha)}\` (by \`${last.user.login}\`)`);
+                  L.push(`Last approved commit: \`${short(lastSha)}\` (by \`${mdEsc(last.user.login)}\`)${staleTag}`);
                   L.push(`Current HEAD: \`${short(headSha)}\``);
                   L.push('');
                   if (cmp) {
@@ -467,18 +577,19 @@ jobs:
                     for (const f of changed.slice(0, 40)) {
                       const areas = matchAreas(f);
                       const sub = TOP_SUBMODULES.includes(f) ? ' _(submodule pointer)_' : '';
-                      L.push(`- \`${f}\`${areas.length ? ' — ⚠️ ' + areas.join('; ') : ''}${sub}`);
+                      L.push(`- \`${mdEsc(f)}\`${areas.length ? ' — ⚠️ ' + areas.map(mdEsc).join('; ') : ''}${sub}`);
                     }
                     if (changed.length > 40) L.push(`- … and ${changed.length - 40} more`);
                   } else {
-                    L.push('ℹ️ A clean commit-range comparison was not possible ' +
-                           '(rebased / force-pushed history). Manual review recommended.');
+                    L.push('❓ A commit-range comparison was not possible ' +
+                           '(rebased / force-pushed history, or the approved commit is gone). ' +
+                           'Manual review recommended.');
                   }
                   approvalSection = L.join('\n');
                 }
               }
             } catch (e) {
-              approvalSection = `ℹ️ Could not evaluate approval history: ${e.message}`;
+              approvalSection = `❓ Could not evaluate approval history: ${mdEsc(e.message)}`;
             }
 
             // ---------------------------------------------------------------
@@ -488,13 +599,15 @@ jobs:
             out.push(STICKY_MARKER);
             out.push('## PR Security & Change Guard');
             out.push('');
-            out.push('_Informational only — none of the findings below block this PR._');
+            out.push('_Informational only — none of the findings below block this PR. ' +
+                     '❓ marks something the workflow could not verify (treat as "unknown", not "safe")._');
             out.push(`<sub>base \`${short(baseSha)}\` · head \`${short(headSha)}\` · updated ${new Date().toISOString()}</sub>`);
             out.push('');
 
-            // Security-sensitive files
             out.push('### Security-sensitive files');
-            if (securityHits.size === 0) {
+            if (!filesOk) {
+              out.push('❓ Could not retrieve the list of changed files (API error). Manual review required.');
+            } else if (securityHits.size === 0) {
               out.push('✅ No security-sensitive files changed.');
             } else {
               out.push('⚠️ **Security-sensitive changes** — manual security review recommended.');
@@ -502,42 +615,49 @@ jobs:
               out.push('| File | Area |');
               out.push('| --- | --- |');
               for (const [f, areas] of securityHits) {
-                out.push(`| \`${f}\` | ${areas.join('; ')} |`);
+                out.push(`| \`${mdEsc(f)}\` | ${areas.map(mdEsc).join('; ')} |`);
               }
             }
             out.push('');
 
-            // Production signing configuration
             out.push('### Production signing configuration');
             out.push(signingSection);
             out.push('');
 
-            // Submodules
             out.push('### Submodules');
             if (submoduleReport.length === 0) {
               out.push('✅ No submodule pointer changes.');
             } else {
               for (const s of submoduleReport) {
-                out.push(`**${s.path}**`);
-                out.push(`- old: \`${s.old}\``);
-                out.push(`- new: \`${s.new}\``);
-                if (s.link) out.push(`- compare: ${s.link}`);
-                if (s.nested.length) {
+                out.push(`**${mdEsc(s.path)}** — ${s.state}`);
+                if (s.state === 'unverified') {
+                  out.push('- ❓ could not resolve this pointer on both sides — manual review');
                   out.push('');
-                  out.push('  Nested pointer changes:');
-                  for (const n of s.nested) {
-                    out.push(`  - \`${n.path}\`: \`${short(n.old)}\` → \`${short(n.new)}\`` +
-                             (n.link ? ` ([compare](${n.link}))` : ''));
+                  continue;
+                }
+                if (s.old) out.push(`- old: \`${s.old}\``);
+                if (s.new) out.push(`- new: \`${s.new}\``);
+                if (s.link) out.push(`- compare: ${s.link}`);
+                if (s.state === 'changed') {
+                  if (!s.nestedOk) {
+                    out.push('- ❓ nested submodule scan could not be completed — manual review');
+                  } else if (s.nested.length) {
+                    out.push('');
+                    out.push('  Nested submodule changes:');
+                    for (const n of s.nested) {
+                      out.push(`  - \`${mdEsc(n.path)}\` (${n.state}): ` +
+                               `\`${short(n.old)}\` → \`${short(n.new)}\`` +
+                               (n.link ? ` ([compare](${n.link}))` : ''));
+                    }
+                  } else {
+                    out.push('- nested submodule pointers: unchanged');
                   }
-                } else {
-                  out.push('- nested submodule pointers: unchanged');
                 }
                 out.push('');
               }
             }
             out.push('');
 
-            // Changes since last approval
             out.push('### Changes since last approval');
             out.push(approvalSection);
             out.push('');
@@ -546,22 +666,23 @@ jobs:
               out.push('---');
               out.push('<details><summary>Diagnostics (non-fatal)</summary>');
               out.push('');
-              for (const n of notes) out.push(`- ${n}`);
+              for (const n of notes) out.push(`- ${mdEsc(n)}`);
               out.push('');
               out.push('</details>');
             }
 
             const body = out.join('\n');
 
-            // Step summary (always)
             await core.summary.addRaw(body).write();
 
-            // Sticky comment (find-or-create by marker, author = github-actions[bot])
+            // Sticky comment: find-or-create, but only ever touch our own
+            // bot comment carrying the marker.
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: prNumber, per_page: 100,
             });
             const existing = comments.find(
-              (c) => c.body && c.body.includes(STICKY_MARKER));
+              (c) => c.body && c.body.includes(STICKY_MARKER) &&
+                     c.user && c.user.login === BOT_LOGIN);
             if (existing) {
               await github.rest.issues.updateComment({
                 owner, repo, comment_id: existing.id, body,

--- a/.github/workflows/pr-security-change-guard.yml
+++ b/.github/workflows/pr-security-change-guard.yml
@@ -1,0 +1,573 @@
+name: PR Security & Change Guard
+
+# ---------------------------------------------------------------------------
+# Purpose
+# ---------------------------------------------------------------------------
+# Informational review helper. For every pull request it posts / updates a
+# single sticky comment that answers four questions a reviewer can easily
+# miss:
+#
+#   1. Were security-sensitive files touched?
+#   2. Were production signing keys or signature thresholds changed?
+#      (these live in the `bootloader` submodule -> keys/production/pubkeys.c)
+#   3. Was a submodule pointer moved (top level *and* one level of nesting)?
+#   4. What changed since the most recent APPROVED review?
+#
+# This workflow is INFORMATIONAL ONLY. It never fails the PR, never blocks a
+# merge, never dismisses reviews and never edits branch-protection rules.
+#
+# ---------------------------------------------------------------------------
+# Security model (fork PRs)
+# ---------------------------------------------------------------------------
+# `pull_request_target` runs with the workflow definition and token of the
+# BASE repository default branch, and the token can write PR comments. To keep
+# that safe with untrusted fork PRs this job:
+#
+#   * never checks out the PR head (no `actions/checkout` at all),
+#   * never runs any script, action or tool that comes from the PR,
+#   * only reads PR data through authenticated GitHub REST API calls,
+#   * only executes `actions/github-script` (pinned) with code that lives on
+#     the base repo default branch (i.e. this file).
+#
+# Because nothing from the PR is executed, the write-capable token is never
+# exposed to attacker-controlled code.
+# ---------------------------------------------------------------------------
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+# Minimal permissions. `contents: read` is only used for REST reads of this
+# repo; `pull-requests: write` is required to create/update the sticky comment.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-security-change-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Analyse pull request
+    runs-on: ubuntu-latest
+    # Only run on the canonical repository. Forks that copy this workflow
+    # would otherwise try (and fail) to comment.
+    if: >-
+      github.repository == 'cryptoadvance/specter-diy' &&
+      github.event.pull_request.state == 'open'
+    steps:
+      - name: Build & publish report
+        uses: actions/github-script@v7
+        with:
+          # Default GITHUB_TOKEN. Scope is limited by `permissions:` above.
+          script: |
+            const STICKY_MARKER = '<!-- pr-security-change-guard -->';
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const baseSha = pr.base.sha;
+            const headSha = pr.head.sha;
+            // PR head commits are always reachable in the BASE repo under this
+            // ref, so we never need the fork remote for tree reads.
+            const headRef = [headSha, `refs/pull/${prNumber}/head`];
+            const headRepoFull =
+              (pr.head.repo && pr.head.repo.full_name) || `${owner}/${repo}`;
+
+            const notes = [];      // non-fatal problems, surfaced in the report
+            const note = (m) => { notes.push(m); core.warning(m); };
+
+            // ---------------------------------------------------------------
+            // Helpers
+            // ---------------------------------------------------------------
+            async function getRaw(o, r, path, ref) {
+              const res = await github.rest.repos.getContent({
+                owner: o, repo: r, path, ref,
+                mediaType: { format: 'raw' },
+              });
+              return typeof res.data === 'string'
+                ? res.data
+                : Buffer.from(res.data.content, 'base64').toString('utf8');
+            }
+
+            // Submodule pointer at `path` for a given ref, or null.
+            // `ref` may be a string or an array of candidate refs (first hit wins);
+            // this is used for the PR head, which is reachable in the base repo
+            // both as the head SHA and as refs/pull/<n>/head depending on setup.
+            async function submodulePointer(o, r, path, ref) {
+              const refs = Array.isArray(ref) ? ref : [ref];
+              for (const rf of refs) {
+                try {
+                  const res = await github.rest.repos.getContent({
+                    owner: o, repo: r, path, ref: rf,
+                  });
+                  const d = res.data;
+                  if (d && d.type === 'submodule') {
+                    return { sha: d.sha, url: d.submodule_git_url || null };
+                  }
+                } catch (e) {
+                  // try next candidate ref
+                }
+              }
+              return null;
+            }
+
+            // Parse a .gitmodules file into [{ name, path, url }].
+            function parseGitmodules(text) {
+              const out = [];
+              let cur = null;
+              for (const line of text.split('\n')) {
+                const s = line.trim();
+                const h = s.match(/^\[submodule "(.+)"\]$/);
+                if (h) { cur = { name: h[1], path: null, url: null }; out.push(cur); continue; }
+                if (!cur) continue;
+                const kv = s.match(/^(\w+)\s*=\s*(.+)$/);
+                if (!kv) continue;
+                if (kv[1] === 'path') cur.path = kv[2].trim();
+                if (kv[1] === 'url') cur.url = kv[2].trim();
+              }
+              return out.filter((m) => m.path);
+            }
+
+            // Resolve a submodule URL (absolute or relative) to
+            // { host, owner, repo } when it is a GitHub repo, else null.
+            function resolveRepo(url, parentOwner) {
+              if (!url) return null;
+              let u = url.replace(/\.git$/, '');
+              const rel = u.match(/^\.\.\/\.\.\/([^/]+)\/(.+)$/); // ../../owner/repo
+              if (rel) return { host: 'github.com', owner: rel[1], repo: rel[2] };
+              const rel1 = u.match(/^\.\.\/([^/]+)$/);            // ../repo (same owner)
+              if (rel1) return { host: 'github.com', owner: parentOwner, repo: rel1[1] };
+              const m = u.match(/github\.com[/:]([^/]+)\/(.+)$/);
+              if (m) return { host: 'github.com', owner: m[1], repo: m[2] };
+              return null;
+            }
+
+            function compareLink(url, parentOwner, oldSha, newSha) {
+              const g = resolveRepo(url, parentOwner);
+              if (!g) return null;
+              return `https://github.com/${g.owner}/${g.repo}/compare/${oldSha}...${newSha}`;
+            }
+
+            function short(sha) { return sha ? sha.substring(0, 12) : '(none)'; }
+
+            // ---------------------------------------------------------------
+            // Security-sensitive path catalogue
+            // (derived from an inspection of the current repository layout)
+            // ---------------------------------------------------------------
+            const SECURITY_AREAS = [
+              { label: 'Bootloader submodule (production signing keys live here)',
+                globs: ['bootloader'] },
+              { label: 'Board / platform submodule (f469-disco)',
+                globs: ['f469-disco'] },
+              { label: 'Submodule configuration',
+                globs: ['.gitmodules'] },
+              { label: 'Boot sequence',
+                globs: ['boot/**'] },
+              { label: 'Build / release tooling',
+                globs: ['build_firmware.sh', 'Dockerfile', 'Makefile',
+                        'flake.nix', 'flake.lock', 'shell.nix',
+                        'manifests/**', 'tools/**'] },
+              { label: 'CI / GitHub Actions',
+                globs: ['.github/workflows/**', '.github/actions/**'] },
+              { label: 'Keystore / secret handling',
+                globs: ['src/keystore/**'] },
+              { label: 'Mnemonic / seed entry & BIP-85',
+                globs: ['src/gui/screens/mnemonic.py', 'src/gui/components/mnemonic.py',
+                        'src/apps/bip85.py', 'src/apps/backup.py'] },
+              { label: 'RNG / entropy',
+                globs: ['src/rng.py', 'src/apps/getrandom.py'] },
+              { label: 'Wallet / PSBT / descriptor / transaction handling',
+                globs: ['src/apps/wallets/**', 'src/gui/screens/transaction.py'] },
+              { label: 'Message signing',
+                globs: ['src/apps/signmessage/**'] },
+              { label: 'Blinding keys (Liquid)',
+                globs: ['src/apps/blindingkeys/**'] },
+              { label: 'Host transports (QR / USB / SD)',
+                globs: ['src/hosts/**'] },
+              { label: 'Core coordinator / app entrypoints',
+                globs: ['src/specter.py', 'src/app.py', 'src/main.py',
+                        'src/platform.py', 'src/keystore/core.py'] },
+              { label: 'Reproducible-build metadata',
+                globs: ['tools/embed_git_info.py'] },
+            ];
+
+            function globToRe(glob) {
+              const esc = (s) => s
+                .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+                .replace(/\*/g, '[^/]*');
+              return new RegExp('^' + glob.split('**').map(esc).join('.*') + '$');
+            }
+            const SECURITY_RES = SECURITY_AREAS.map((a) => ({
+              label: a.label,
+              res: a.globs.map(globToRe),
+            }));
+            function matchAreas(file) {
+              const hit = [];
+              for (const a of SECURITY_RES) {
+                if (a.res.some((r) => r.test(file))) hit.push(a.label);
+              }
+              return hit;
+            }
+
+            // ---------------------------------------------------------------
+            // 1. Changed files in the PR (via API, no checkout)
+            // ---------------------------------------------------------------
+            let files = [];
+            try {
+              files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+            } catch (e) {
+              note(`Could not list PR files: ${e.message}`);
+            }
+
+            const securityHits = new Map(); // file -> [areas]
+            for (const f of files) {
+              const areas = matchAreas(f.filename);
+              if (areas.length) securityHits.set(f.filename, areas);
+            }
+
+            // ---------------------------------------------------------------
+            // 2 + 3. Submodule pointer changes (top level + one nested level)
+            // ---------------------------------------------------------------
+            const TOP_SUBMODULES = ['bootloader', 'f469-disco'];
+            const submoduleReport = [];
+            let bootloaderOld = null;
+            let bootloaderNew = null;
+
+            for (const path of TOP_SUBMODULES) {
+              const before = await submodulePointer(owner, repo, path, baseSha);
+              const after = await submodulePointer(owner, repo, path, headRef);
+              if (!before || !after) {
+                if (!before && !after) continue; // not a submodule here
+                note(`Could not resolve both pointers for submodule '${path}'.`);
+                continue;
+              }
+              if (path === 'bootloader') {
+                bootloaderOld = before.sha;
+                bootloaderNew = after.sha;
+              }
+              if (before.sha === after.sha) continue;
+
+              const entry = {
+                path,
+                old: before.sha,
+                new: after.sha,
+                url: before.url || after.url,
+                link: compareLink(before.url || after.url, owner, before.sha, after.sha),
+                nested: [],
+              };
+
+              // one level of nesting
+              const g = resolveRepo(entry.url, owner);
+              if (g) {
+                try {
+                  const [gmOld, gmNew] = await Promise.all([
+                    getRaw(g.owner, g.repo, '.gitmodules', before.sha).catch(() => ''),
+                    getRaw(g.owner, g.repo, '.gitmodules', after.sha).catch(() => ''),
+                  ]);
+                  const modsOld = parseGitmodules(gmOld);
+                  const modsNew = parseGitmodules(gmNew);
+                  const paths = new Set([
+                    ...modsOld.map((m) => m.path),
+                    ...modsNew.map((m) => m.path),
+                  ]);
+                  for (const np of paths) {
+                    const nOld = await submodulePointer(g.owner, g.repo, np, before.sha);
+                    const nNew = await submodulePointer(g.owner, g.repo, np, after.sha);
+                    if (!nOld || !nNew) continue;
+                    if (nOld.sha === nNew.sha) continue;
+                    const nurl = nNew.url || nOld.url ||
+                      (modsNew.find((m) => m.path === np) || {}).url ||
+                      (modsOld.find((m) => m.path === np) || {}).url;
+                    entry.nested.push({
+                      path: np,
+                      old: nOld.sha,
+                      new: nNew.sha,
+                      link: compareLink(nurl, g.owner, nOld.sha, nNew.sha),
+                    });
+                  }
+                } catch (e) {
+                  note(`Nested submodule scan for '${path}' failed: ${e.message}`);
+                }
+              }
+              submoduleReport.push(entry);
+            }
+
+            // ---------------------------------------------------------------
+            // 2. Production signing configuration (bootloader pubkeys.c)
+            // ---------------------------------------------------------------
+            const PUBKEYS_PATH = 'keys/production/pubkeys.c';
+            let signingSection = '';
+
+            function parsePubkeys(src) {
+              const res = { thresholds: {}, lists: {} };
+              const t1 = src.match(/\.bootloader_sig_threshold\s*=\s*(\d+)/);
+              const t2 = src.match(/\.main_fw_sig_threshold\s*=\s*(\d+)/);
+              res.thresholds.bootloader = t1 ? t1[1] : null;
+              res.thresholds.main_fw = t2 ? t2[1] : null;
+
+              for (const listName of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
+                // list body runs from `name[] = {` to the first `};`
+                // (individual entries end in `}},` so `};` is unambiguous)
+                const re = new RegExp(
+                  listName + '\\s*\\[\\]\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*;');
+                const m = src.match(re);
+                const keys = [];
+                if (m) {
+                  const body = m[1];
+                  // split into "{.bytes = { ... }}" blocks, keep preceding // comment
+                  const blockRe = /(?:\/\/\s*(.*)\s*\n\s*)?\{\s*\.bytes\s*=\s*\{([\s\S]*?)\}\s*\}/g;
+                  let bm;
+                  while ((bm = blockRe.exec(body)) !== null) {
+                    const owner = (bm[1] || '').trim() || '(unlabelled)';
+                    const bytes = (bm[2].match(/0x[0-9a-fA-F]{1,2}/g) || [])
+                      .map((h) => parseInt(h, 16).toString(16).padStart(2, '0'))
+                      .join('');
+                    if (!bytes) continue;
+                    keys.push({ owner, bytes });
+                  }
+                }
+                res.lists[listName] = keys;
+              }
+              return res;
+            }
+
+            const crypto = require('crypto');
+            const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+            const fpr = (bytes) => sha256(bytes).substring(0, 16);
+
+            function keysetDigest(parsed) {
+              const parts = [];
+              for (const ln of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
+                parts.push(ln + ':' +
+                  parsed.lists[ln].map((k) => k.bytes).sort().join(','));
+              }
+              return sha256(parts.join('|'));
+            }
+
+            if (bootloaderOld && bootloaderNew && bootloaderOld !== bootloaderNew) {
+              try {
+                const [srcOld, srcNew] = await Promise.all([
+                  getRaw('cryptoadvance', 'specter-bootloader', PUBKEYS_PATH, bootloaderOld),
+                  getRaw('cryptoadvance', 'specter-bootloader', PUBKEYS_PATH, bootloaderNew),
+                ]);
+                const pOld = parsePubkeys(srcOld);
+                const pNew = parsePubkeys(srcNew);
+
+                const digOld = keysetDigest(pOld);
+                const digNew = keysetDigest(pNew);
+
+                const lines = [];
+                const tChanged =
+                  pOld.thresholds.bootloader !== pNew.thresholds.bootloader ||
+                  pOld.thresholds.main_fw !== pNew.thresholds.main_fw;
+                const kChanged = digOld !== digNew;
+
+                if (!tChanged && !kChanged) {
+                  lines.push('✅ **Production signing configuration unchanged**');
+                  lines.push('');
+                  lines.push('The `bootloader` pointer moved, but the vendor / maintainer');
+                  lines.push('public keys and both signature thresholds are identical.');
+                } else {
+                  lines.push('⚠️ **Production signing configuration changed**');
+                  lines.push('');
+                  lines.push('| Setting | Old | New |');
+                  lines.push('| --- | --- | --- |');
+                  lines.push(`| \`bootloader_sig_threshold\` | ${pOld.thresholds.bootloader ?? '?'} | ${pNew.thresholds.bootloader ?? '?'} |`);
+                  lines.push(`| \`main_fw_sig_threshold\` | ${pOld.thresholds.main_fw ?? '?'} | ${pNew.thresholds.main_fw ?? '?'} |`);
+                  lines.push(`| Production key set | ${kChanged ? '**CHANGED**' : 'unchanged'} | |`);
+                  lines.push('');
+                  lines.push(`Old key-set SHA256: \`${digOld}\``);
+                  lines.push(`New key-set SHA256: \`${digNew}\``);
+
+                  for (const ln of ['vendor_pubkey_list', 'maintainer_pubkey_list']) {
+                    const before = new Map(pOld.lists[ln].map((k) => [k.bytes, k.owner]));
+                    const after = new Map(pNew.lists[ln].map((k) => [k.bytes, k.owner]));
+                    const added = [...after].filter(([b]) => !before.has(b));
+                    const removed = [...before].filter(([b]) => !after.has(b));
+                    if (added.length || removed.length) {
+                      lines.push('');
+                      lines.push(`**${ln.replace('_pubkey_list', '')} keys**`);
+                      for (const [b, o] of added)
+                        lines.push(`- ➕ added — owner \`${o}\`, fingerprint \`${fpr(b)}\``);
+                      for (const [b, o] of removed)
+                        lines.push(`- ➖ removed — owner \`${o}\`, fingerprint \`${fpr(b)}\``);
+                    }
+                  }
+                  lines.push('');
+                  lines.push('> This is flagged prominently but **not blocking**. A production');
+                  lines.push('> signing-config change must be reviewed by the maintainers.');
+                }
+                signingSection = lines.join('\n');
+              } catch (e) {
+                signingSection =
+                  `ℹ️ Could not load \`${PUBKEYS_PATH}\` from one/both bootloader commits ` +
+                  `(\`${short(bootloaderOld)}\` → \`${short(bootloaderNew)}\`): ${e.message}. ` +
+                  `Manual review of the bootloader bump is recommended.`;
+              }
+            } else if (bootloaderOld && bootloaderNew) {
+              signingSection =
+                '✅ **Production signing configuration unchanged** — the `bootloader` ' +
+                'submodule pointer was not modified by this PR.';
+            } else {
+              signingSection =
+                'ℹ️ Could not resolve the `bootloader` submodule pointer on both sides; ' +
+                'skipping signing-config comparison.';
+            }
+
+            // ---------------------------------------------------------------
+            // 4. Changes since last approval
+            // ---------------------------------------------------------------
+            let approvalSection = '';
+            try {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              const approved = reviews.filter((r) => r.state === 'APPROVED');
+              const last = approved[approved.length - 1];
+              if (!last) {
+                approvalSection = 'ℹ️ No previous approval found. (This is not an error.)';
+              } else {
+                const lastSha = last.commit_id;
+                if (lastSha === headSha) {
+                  approvalSection =
+                    `✅ No changes since last approval.\n\n` +
+                    `Approved by \`${last.user.login}\` at \`${short(lastSha)}\` (current HEAD).`;
+                } else {
+                  let cmp;
+                  try {
+                    cmp = await github.rest.repos.compareCommitsWithBasehead({
+                      owner: headRepoFull.split('/')[0],
+                      repo: headRepoFull.split('/')[1],
+                      basehead: `${lastSha}...${headSha}`,
+                    });
+                  } catch (e) {
+                    cmp = null;
+                    note(`compare ${short(lastSha)}...${short(headSha)} failed: ${e.message}`);
+                  }
+                  const L = [];
+                  L.push(`Last approved commit: \`${short(lastSha)}\` (by \`${last.user.login}\`)`);
+                  L.push(`Current HEAD: \`${short(headSha)}\``);
+                  L.push('');
+                  if (cmp) {
+                    const c = cmp.data;
+                    const add = (c.files || []).reduce((a, f) => a + (f.additions || 0), 0);
+                    const del = (c.files || []).reduce((a, f) => a + (f.deletions || 0), 0);
+                    L.push(`Changes after approval: **${c.total_commits} commit(s)**, ` +
+                           `**${(c.files || []).length} file(s)**, **+${add} / -${del}** lines`);
+                    L.push('');
+                    const changed = (c.files || []).map((f) => f.filename);
+                    L.push('Files changed since approval:');
+                    for (const f of changed.slice(0, 40)) {
+                      const areas = matchAreas(f);
+                      const sub = TOP_SUBMODULES.includes(f) ? ' _(submodule pointer)_' : '';
+                      L.push(`- \`${f}\`${areas.length ? ' — ⚠️ ' + areas.join('; ') : ''}${sub}`);
+                    }
+                    if (changed.length > 40) L.push(`- … and ${changed.length - 40} more`);
+                  } else {
+                    L.push('ℹ️ A clean commit-range comparison was not possible ' +
+                           '(rebased / force-pushed history). Manual review recommended.');
+                  }
+                  approvalSection = L.join('\n');
+                }
+              }
+            } catch (e) {
+              approvalSection = `ℹ️ Could not evaluate approval history: ${e.message}`;
+            }
+
+            // ---------------------------------------------------------------
+            // Assemble the report
+            // ---------------------------------------------------------------
+            const out = [];
+            out.push(STICKY_MARKER);
+            out.push('## PR Security & Change Guard');
+            out.push('');
+            out.push('_Informational only — none of the findings below block this PR._');
+            out.push(`<sub>base \`${short(baseSha)}\` · head \`${short(headSha)}\` · updated ${new Date().toISOString()}</sub>`);
+            out.push('');
+
+            // Security-sensitive files
+            out.push('### Security-sensitive files');
+            if (securityHits.size === 0) {
+              out.push('✅ No security-sensitive files changed.');
+            } else {
+              out.push('⚠️ **Security-sensitive changes** — manual security review recommended.');
+              out.push('');
+              out.push('| File | Area |');
+              out.push('| --- | --- |');
+              for (const [f, areas] of securityHits) {
+                out.push(`| \`${f}\` | ${areas.join('; ')} |`);
+              }
+            }
+            out.push('');
+
+            // Production signing configuration
+            out.push('### Production signing configuration');
+            out.push(signingSection);
+            out.push('');
+
+            // Submodules
+            out.push('### Submodules');
+            if (submoduleReport.length === 0) {
+              out.push('✅ No submodule pointer changes.');
+            } else {
+              for (const s of submoduleReport) {
+                out.push(`**${s.path}**`);
+                out.push(`- old: \`${s.old}\``);
+                out.push(`- new: \`${s.new}\``);
+                if (s.link) out.push(`- compare: ${s.link}`);
+                if (s.nested.length) {
+                  out.push('');
+                  out.push('  Nested pointer changes:');
+                  for (const n of s.nested) {
+                    out.push(`  - \`${n.path}\`: \`${short(n.old)}\` → \`${short(n.new)}\`` +
+                             (n.link ? ` ([compare](${n.link}))` : ''));
+                  }
+                } else {
+                  out.push('- nested submodule pointers: unchanged');
+                }
+                out.push('');
+              }
+            }
+            out.push('');
+
+            // Changes since last approval
+            out.push('### Changes since last approval');
+            out.push(approvalSection);
+            out.push('');
+
+            if (notes.length) {
+              out.push('---');
+              out.push('<details><summary>Diagnostics (non-fatal)</summary>');
+              out.push('');
+              for (const n of notes) out.push(`- ${n}`);
+              out.push('');
+              out.push('</details>');
+            }
+
+            const body = out.join('\n');
+
+            // Step summary (always)
+            await core.summary.addRaw(body).write();
+
+            // Sticky comment (find-or-create by marker, author = github-actions[bot])
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.body && c.body.includes(STICKY_MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }

--- a/.github/workflows/pr-security-change-guard.yml
+++ b/.github/workflows/pr-security-change-guard.yml
@@ -286,15 +286,21 @@ jobs:
               return 'none';
             }
 
-            // Fetch a repo's .gitmodules at a ref. A 404 means "this commit
-            // has no .gitmodules" (legitimately empty); any other failure is
-            // unknown and must NOT be silently treated as empty.
+            // Fetch a repo's .gitmodules at a ref. A 404 is only safe to read
+            // as "this commit has no .gitmodules" once we have confirmed the
+            // commit itself resolves — a 404 on the contents endpoint can also
+            // mean the ref / repo is unreachable. Any other failure is unknown.
             async function getGitmodules(o, r, ref) {
               try {
                 return { ok: true, text: await getRaw(o, r, '.gitmodules', ref) };
               } catch (e) {
-                if (e.status === 404) return { ok: true, text: '' };
-                return { ok: false, text: '' };
+                if (e.status !== 404) return { ok: false, text: '' };
+                try {
+                  await github.rest.repos.getCommit({ owner: o, repo: r, ref });
+                  return { ok: true, text: '' }; // commit exists, no .gitmodules
+                } catch (e2) {
+                  return { ok: false, text: '' }; // ref/repo not resolvable
+                }
               }
             }
 
@@ -596,7 +602,12 @@ jobs:
                   L.push(`Last approved commit: \`${short(lastSha)}\` (by \`${mdEsc(last.user.login)}\`)${staleTag}`);
                   L.push(`Current HEAD: \`${short(headSha)}\``);
                   L.push('');
-                  if (cmp) {
+                  // Only `status === 'ahead'` is a clean linear "everything
+                  // added on top of the approved commit". `diverged` / `behind`
+                  // mean the approved commit is no longer an ancestor of HEAD
+                  // (rebase / force-push / rewrite) and the file list would
+                  // misrepresent that as a normal post-approval diff.
+                  if (cmp && cmp.data.status === 'ahead') {
                     const c = cmp.data;
                     const add = (c.files || []).reduce((a, f) => a + (f.additions || 0), 0);
                     const del = (c.files || []).reduce((a, f) => a + (f.deletions || 0), 0);
@@ -611,9 +622,14 @@ jobs:
                       L.push(`- \`${mdEsc(f)}\`${areas.length ? ' — ⚠️ ' + areas.map(mdEsc).join('; ') : ''}${sub}`);
                     }
                     if (changed.length > 40) L.push(`- … and ${changed.length - 40} more`);
+                  } else if (cmp) {
+                    L.push(`❓ The approved commit \`${short(lastSha)}\` is no longer a clean ` +
+                           `ancestor of the current HEAD (compare status: \`${cmp.data.status}\`). ` +
+                           `The branch was rebased / force-pushed / rewritten, so the diff since ` +
+                           `approval cannot be shown reliably. **Manual review required.**`);
                   } else {
                     L.push('❓ A commit-range comparison was not possible ' +
-                           '(rebased / force-pushed history, or the approved commit is gone). ' +
+                           '(API error, or the approved commit is no longer reachable). ' +
                            'Manual review recommended.');
                   }
                   approvalSection = L.join('\n');

--- a/.github/workflows/pr-security-change-guard.yml
+++ b/.github/workflows/pr-security-change-guard.yml
@@ -195,20 +195,33 @@ jobs:
             // have moved on with unrelated commits since the PR was opened.
             // Comparing submodule / signing config against it would attribute
             // those unrelated base-branch changes to this PR. The correct
-            // baseline is the merge-base of base...head. Fall back to
-            // `pr.base.sha` only if the compare API is unavailable.
-            let mergeBaseSha = baseSha;
+            // baseline is the merge-base of base...head.
+            //
+            // Fail closed: if the merge-base cannot be determined we do NOT
+            // silently fall back to `pr.base.sha` (that is the very baseline
+            // that can produce a wrong ✅ / wrong ⚠️). Instead `mergeBaseSha`
+            // stays null and the submodule + production-signing sections
+            // report ❓ "unable to verify". The security-sensitive file scan
+            // (via pulls.listFiles) is independent of the merge-base and keeps
+            // running.
+            let mergeBaseSha = null;
+            let mergeBaseOk = false;
             try {
               const mb = await github.rest.repos.compareCommitsWithBasehead({
                 owner, repo, basehead: `${baseSha}...${headSha}`,
               });
               if (mb.data.merge_base_commit && mb.data.merge_base_commit.sha) {
                 mergeBaseSha = mb.data.merge_base_commit.sha;
+                mergeBaseOk = true;
+              } else {
+                note('The base/head compare returned no merge-base commit; ' +
+                     'submodule and production-signing verification is reported ' +
+                     'as ❓ unknown (fail-closed).');
               }
             } catch (e) {
               note(`Could not determine the base/head merge-base (${e.message}); ` +
-                   `comparing against the base branch tip \`${short(baseSha)}\` instead — ` +
-                   `unrelated base-branch changes may be misattributed to this PR.`);
+                   `submodule and production-signing verification is reported as ` +
+                   `❓ unknown (fail-closed).`);
             }
 
             // ---------------------------------------------------------------
@@ -392,6 +405,14 @@ jobs:
             }
 
             for (const path of TOP_SUBMODULES) {
+              if (!mergeBaseOk) {
+                // No trustworthy baseline -> cannot say whether this PR moved
+                // the pointer. Report ❓, never ✅.
+                if (path === 'bootloader') bootloaderResolved = false;
+                submoduleReport.push({ path, state: 'unverified', old: null,
+                                       new: null, nested: [], nestedOk: false });
+                continue;
+              }
               const before = await pathState(owner, repo, path, mergeBaseSha);
               const after = await pathState(owner, repo, path, headRefs);
               const state = classify(before, after);
@@ -498,7 +519,12 @@ jobs:
               return sha256(parts.join('|'));
             }
 
-            if (!bootloaderResolved) {
+            if (!mergeBaseOk) {
+              signingSection =
+                '❓ The PR merge-base could not be determined, so the `bootloader` ' +
+                'pointer before this PR is unknown — production signing configuration ' +
+                '**not verified**. Manual review required.';
+            } else if (!bootloaderResolved) {
               signingSection =
                 '❓ Could not resolve the `bootloader` submodule pointer on both sides — ' +
                 'production signing configuration **not verified**. Manual review recommended.';
@@ -709,7 +735,8 @@ jobs:
             out.push('');
             out.push('_Informational only — none of the findings below block this PR. ' +
                      '❓ marks something the workflow could not verify (treat as "unknown", not "safe")._');
-            out.push(`<sub>merge-base \`${short(mergeBaseSha)}\` · base tip \`${short(baseSha)}\` · ` +
+            out.push(`<sub>merge-base \`${mergeBaseOk ? short(mergeBaseSha) : 'unknown (fail-closed)'}\` · ` +
+                     `base tip \`${short(baseSha)}\` · ` +
                      `head \`${short(headSha)}\` · updated ${new Date().toISOString()}</sub>`);
             out.push('');
 

--- a/.github/workflows/pr-security-change-guard.yml
+++ b/.github/workflows/pr-security-change-guard.yml
@@ -44,8 +44,13 @@ name: PR Security & Change Guard
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
+  # NOTE: `pull_request_review` is deliberately NOT a trigger. For pull
+  # requests from a fork, GitHub runs a `pull_request_review` workflow with a
+  # read-only GITHUB_TOKEN (only `pull_request_target` keeps write access on
+  # fork PRs), so the sticky-comment update would fail there. It is not needed
+  # either: the "changes since approval" section matters once new commits
+  # arrive after an approval, and that fires `synchronize` on
+  # `pull_request_target`, which does have write access.
 
 # Minimal permissions. `contents: read` is only used for REST reads of this
 # repo; `pull-requests: write` is required to create/update the sticky comment.
@@ -68,9 +73,10 @@ jobs:
       github.event.pull_request.state == 'open'
     steps:
       - name: Build & publish report
-        # Pinned to the commit the `v7` tag pointed at (v7.0.1). Update the
+        # Pinned to a full commit SHA. This SHA is the actions/github-script
+        # v7.1.0 release (also where the moving `v7` tag points). Update the
         # SHA and the trailing comment together when bumping.
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           # Default GITHUB_TOKEN. Scope is limited by `permissions:` above.
           script: |
@@ -121,6 +127,7 @@ jobs:
             async function pathState(o, r, path, ref) {
               const refs = Array.isArray(ref) ? ref : [ref];
               let lastErr = null;
+              let saw404 = false;
               for (const rf of refs) {
                 try {
                   const res = await github.rest.repos.getContent({
@@ -132,11 +139,15 @@ jobs:
                   }
                   return { kind: 'other' };
                 } catch (e) {
-                  if (e.status === 404) return { kind: 'absent' };
+                  // Only conclude "absent" after every candidate ref 404s;
+                  // a non-404 (403/429/5xx/network) is an unknown, not absent.
+                  if (e.status === 404) { saw404 = true; continue; }
                   lastErr = e;
                 }
               }
-              return { kind: 'error', message: lastErr ? lastErr.message : 'unknown' };
+              if (lastErr) return { kind: 'error', message: lastErr.message };
+              if (saw404) return { kind: 'absent' };
+              return { kind: 'error', message: 'no candidate ref resolved' };
             }
 
             function parseGitmodules(text) {
@@ -275,23 +286,33 @@ jobs:
               return 'none';
             }
 
+            // Fetch a repo's .gitmodules at a ref. A 404 means "this commit
+            // has no .gitmodules" (legitimately empty); any other failure is
+            // unknown and must NOT be silently treated as empty.
+            async function getGitmodules(o, r, ref) {
+              try {
+                return { ok: true, text: await getRaw(o, r, '.gitmodules', ref) };
+              } catch (e) {
+                if (e.status === 404) return { ok: true, text: '' };
+                return { ok: false, text: '' };
+              }
+            }
+
             async function nestedChanges(parentUrl, parentOwner, oldSha, newSha) {
               const g = resolveRepo(parentUrl, parentOwner);
               const result = { ok: true, entries: [] };
               if (!g) { result.ok = false; return result; }
-              let gmOld = '';
-              let gmNew = '';
-              try {
-                [gmOld, gmNew] = await Promise.all([
-                  getRaw(g.owner, g.repo, '.gitmodules', oldSha).catch(() => ''),
-                  getRaw(g.owner, g.repo, '.gitmodules', newSha).catch(() => ''),
-                ]);
-              } catch (e) {
+              const [gmOldR, gmNewR] = await Promise.all([
+                getGitmodules(g.owner, g.repo, oldSha),
+                getGitmodules(g.owner, g.repo, newSha),
+              ]);
+              if (!gmOldR.ok || !gmNewR.ok) {
+                // Could not read one/both .gitmodules for a non-404 reason.
                 result.ok = false;
                 return result;
               }
-              const modsOld = parseGitmodules(gmOld);
-              const modsNew = parseGitmodules(gmNew);
+              const modsOld = parseGitmodules(gmOldR.text);
+              const modsNew = parseGitmodules(gmNewR.text);
               const paths = new Set([
                 ...modsOld.map((m) => m.path),
                 ...modsNew.map((m) => m.path),
@@ -300,6 +321,7 @@ jobs:
                 const nb = await pathState(g.owner, g.repo, np, oldSha);
                 const na = await pathState(g.owner, g.repo, np, newSha);
                 const state = classify(nb, na);
+                if (state === 'unverified') { result.ok = false; continue; }
                 if (state === 'unchanged' || state === 'none') continue;
                 const nurl =
                   na.url || nb.url ||
@@ -519,6 +541,7 @@ jobs:
               // Reviews that were APPROVED and later dismissed still matter as
               // "the last approval". Recover them from the timeline.
               const dismissedApprovalIds = new Set();
+              let timelineOk = true;
               try {
                 const timeline = await github.paginate(
                   github.rest.issues.listEventsForTimeline,
@@ -531,15 +554,23 @@ jobs:
                   }
                 }
               } catch (e) {
+                timelineOk = false;
                 note(`Could not read PR timeline for dismissed approvals: ${e.message}`);
               }
 
+              const hasCurrentApproval = reviews.some((r) => r.state === 'APPROVED');
               const approvals = reviews
                 .filter((r) => r.state === 'APPROVED' || dismissedApprovalIds.has(r.id))
                 .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at));
               const last = approvals[approvals.length - 1];
 
-              if (!last) {
+              if (!last && !hasCurrentApproval && !timelineOk) {
+                // No standing approval, and we could not check the timeline for
+                // a dismissed one -> unknown, not "none".
+                approvalSection =
+                  '❓ Could not determine whether a previously dismissed approval ' +
+                  'exists (PR timeline API unavailable). Manual review recommended.';
+              } else if (!last) {
                 approvalSection = 'ℹ️ No previous approval found. (This is not an error.)';
               } else {
                 const lastSha = last.commit_id;


### PR DESCRIPTION
## What

Adds one informational GitHub Actions workflow,
`.github/workflows/pr-security-change-guard.yml`, that helps reviewers by
posting **one sticky comment per PR** (also mirrored to
`GITHUB_STEP_SUMMARY`) answering four questions that are easy to miss:

1. **Security-sensitive files** – were files in an explicitly curated
   catalogue of sensitive areas touched (bootloader / f469-disco / boot
   sequence / build & release tooling / CI / keystore / mnemonic & seed
   entry / RNG / wallet-PSBT-descriptor / **xpub export & authorization**
   / message signing / blinding keys / host transports / core
   coordinator / reproducible-build metadata)? It deliberately does
   **not** flag every `src/` change.
2. **Production signing configuration** – if the `bootloader` submodule
   pointer moved, it loads `keys/production/pubkeys.c` from the old and
   the new bootloader commit and compares the vendor + maintainer public
   keys and both signature thresholds (`bootloader_sig_threshold`,
   `main_fw_sig_threshold`). Reports `✅ unchanged`, a prominent
   `⚠️ changed` block (old/new thresholds, old/new key-set SHA256,
   added/removed key owners + fingerprints), or `❓ unable to verify`.
3. **Submodule pointer changes** – top level (`bootloader`, `f469-disco`)
   **and one nested level**, discovered by reading each submodule's
   `.gitmodules` (so new nested submodules – e.g. `libs/common/embit` –
   are picked up automatically). Detects moved **and added/removed**
   pointers, with `old...new` compare links.
4. **Changes since last approval** – finds the most recent `APPROVED`
   review (recovering an approval that was later **dismissed as stale**
   via the PR timeline), compares its `commit_id` with the current head,
   and lists commits / files / `+/-` lines added since, re-highlighting
   security-sensitive and submodule changes. `ℹ️ No previous approval
   found` is treated as normal, not an error.

## Not blocking – but fail-closed

Every finding is informational. The workflow never fails the check,
never blocks merge, never dismisses reviews and never touches
branch-protection rules.

For its **own** reporting it fails closed: when it cannot determine
something (API error, unparseable `pubkeys.c`, unresolvable pointer) it
prints a distinct `❓ … manual review required` instead of a green `✅`.

## Fork-PR safety

Uses `pull_request_target` **only** to obtain a token that can update the
sticky comment. It:

* has no `actions/checkout` step at all,
* never runs any script, action or tool originating from the PR,
* reads all PR data exclusively through authenticated GitHub REST API
  calls,
* runs only `actions/github-script`, **pinned to a full commit SHA**,
  with code from the base branch (this file),
* has no `run:` steps, so no PR-controlled string is ever interpolated
  into a shell command; externally sourced strings (file names, key
  owner comments) are Markdown-escaped before display.

Because no PR-controlled code is executed, the writable token is never
exposed to attacker-controlled code.

Permissions: `contents: read`, `pull-requests: write`.
Trigger: `pull_request_target` [opened, reopened, synchronize,
ready_for_review] only. `pull_request_review` is deliberately not used —
on a fork PR GitHub runs it with a read-only token, so the comment
update would fail; `synchronize` covers the case that matters (new
commits after an approval). The sticky comment is an issue comment
(matched by marker **and** bot author), which does not re-trigger the
event, so there is no loop.

## Known limitations

* `pull_request_target` always runs the workflow version on the base
  branch, so this cannot fully self-test on its own PR. It has been
  YAML- and JS-syntax-checked and its parsers / branches exercised
  offline against the real `pubkeys.c` and `.gitmodules` and against
  mocked API responses (clean PR, threshold change, unparseable keys,
  nested submodule added, listFiles failure, dismissed approval).
* The bootloader `pubkeys.c` parser is regex-based and intentionally
  strict; a future refactor of that file will trip the `❓ unable to
  verify` path rather than silently misreport.
* Commit-range comparisons for "changes since approval" rely on the
  approved commit still being reachable; a force-push that removed it
  yields `❓ manual review`.


## Review round 3 (commit `1a8bc4b`)

* Nested-submodule scan is now genuinely fail-closed: reading a parent
  `.gitmodules` treats only a 404 as "no submodules"; a 403/429/5xx marks
  the scan incomplete (`❓`) instead of being swallowed and reported as
  "unchanged".
* Removed the `pull_request_review` trigger (see above).
* Timeline API failure while checking for a dismissed approval no longer
  degrades to "No previous approval found" — it becomes a distinct `❓`
  when there is also no standing approval.
* `pathState` now tries every candidate head ref before concluding
  "absent".
* Pinned `actions/github-script` SHA corrected in the comment to `v7.1.0`
  (the SHA was right, the version label was wrong).

Offline scenario coverage extended to: nested `.gitmodules` API error,
and dismissed-approval + timeline-down.


## Review round 4 (commit `b6cba92`)

* **Blocker fixed:** "changes since last approval" now checks the compare
  status. `compareCommitsWithBasehead` returns `200 diverged` / `behind`
  when the branch was rebased / force-pushed after the approval (the
  approved commit is no longer an ancestor of HEAD). Only status `ahead`
  is shown as a normal post-approval file list; `diverged` / `behind` /
  API error all render `❓ … rebased / force-pushed / rewritten … manual
  review required`.
* `.gitmodules` 404 handling: a 404 is treated as "no submodules" only
  after `getCommit` confirms the parent commit resolves; an unreachable
  ref/repo now marks the nested scan incomplete.

Offline scenarios added: rebased-after-approval (`diverged`), compare API
down, `.gitmodules` 404 with commit present vs. commit also unreachable.
