### PR TITLE
Restore Git provenance in developer builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ FROZEN_MANIFEST_DEBUG ?= ../../../../manifests/debug.py
 FROZEN_MANIFEST_UNIX ?= ../../../../manifests/unix.py
 DEBUG ?= 0
 USE_DBOOT ?= 0
+REPRODUCIBLE ?= 0
 GIT_INFO ?= src/git_info.py
 
 $(TARGET_DIR):
@@ -37,7 +38,7 @@ mpy-cross: $(TARGET_DIR) $(MPY_DIR)/mpy-cross/Makefile $(EMBIT_INIT)
 # embed git metadata for firmware builds
 .PHONY: git-info
 git-info:
-	./tools/embed_git_info.py $(GIT_INFO)
+	./tools/embed_git_info.py $(if $(filter 1,$(REPRODUCIBLE)),--reproducible) $(GIT_INFO)
 
 # disco board with bitcoin library
 disco: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32 git-info

--- a/build_firmware.sh
+++ b/build_firmware.sh
@@ -20,12 +20,8 @@ run_main() {
   echo -e "${INFO}
 ══════════════════════ Building main firmware ═════════════════════════════
 ${ENDCOLOR}"
-  # Release firmware must not embed clone-local git metadata (remote URL, branch
-  # or commit), otherwise two builders of the same source produce different
-  # frozen modules and different firmware hashes. See tools/embed_git_info.py.
-  export SPECTER_REPRODUCIBLE_BUILD=1
   make clean
-  make disco USE_DBOOT=1
+  make disco USE_DBOOT=1 REPRODUCIBLE=1
 }
 
 run_bootloader() {
@@ -100,11 +96,9 @@ run_nobootloader() {
 ═════════════════════ Building firmware without bootloader ════════════════
 ${ENDCOLOR}"
 
-  # Same deterministic provenance as the bootloader release build.
-  export SPECTER_REPRODUCIBLE_BUILD=1
   mkdir -p release
   make clean
-  make disco
+  make disco REPRODUCIBLE=1
   cp ./bin/specter-diy.bin ./release/disco-nobootloader.bin
   cp ./bin/specter-diy.hex ./release/disco-nobootloader.hex
   echo -e "Standard firmware without bootloader saved to release/disco-nobootloader.{bin,hex}"

--- a/docs/reproducible-build.md
+++ b/docs/reproducible-build.md
@@ -2,6 +2,8 @@
 
 With [docker](https://docs.docker.com/get-docker/) you can build the firmware yourself in the same environment as we do, and verify that binaries in github releases have the same hash. This way you can be sure that firmware upgrades signed by our public keys are actually built from the code in this repository, no backdoors included.
 
+Release builds run with `REPRODUCIBLE=1`, which omits local Git provenance. Use `make disco REPRODUCIBLE=1` to request this mode directly; omit the parameter for a developer build that records the local repository, branch, and commit.
+
 From the root of the repository:
 
 1. Set up bootloader to use production keys:

--- a/docs/reproducible-build.md
+++ b/docs/reproducible-build.md
@@ -2,10 +2,6 @@
 
 With [docker](https://docs.docker.com/get-docker/) you can build the firmware yourself in the same environment as we do, and verify that binaries in github releases have the same hash. This way you can be sure that firmware upgrades signed by our public keys are actually built from the code in this repository, no backdoors included.
 
-Release builds (`./build_firmware.sh`) embed no clone-local provenance at all: the `REPOSITORY`, `BRANCH` and `COMMIT` values shown on the About screen are all `unknown`. This is what makes the build reproducible — the clone URL (HTTPS, SSH, or a fork remote), the checkout ref (branch or detached HEAD), the clone depth, and whether the source came from `git` at all or from a `.git`-less source archive all have no effect on the firmware binary. `build_firmware.sh` sets `SPECTER_REPRODUCIBLE_BUILD=1` for this; plain `make disco` dev builds still embed the live commit SHA.
-
-**Historical note:** this does not retroactively change the published `v1.10.3` tag or its binaries, whose hash still depends on the git metadata embedded when that release was built.
-
 From the root of the repository:
 
 1. Set up bootloader to use production keys:

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import tempfile
@@ -90,6 +91,16 @@ class GitInfoReproducibilityTest(TestCase):
             self.assertIn("BRANCH = 'unknown'", content)
             self.assertIn("COMMIT = 'unknown'", content)
 
+    def test_without_origin_uses_unknown_repository(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_git(root, "init")
+
+            content = run_script(root / "git-info.py", root)
+
+            self.assertIn("REPOSITORY = 'unknown'", content)
+            self.assertNotIn(str(root), content)
+
     def test_reproducible_build_output_is_source_acquisition_independent(self):
         """Reproducible builds must produce identical
         output from a git checkout and from a .git-less source archive."""
@@ -124,6 +135,12 @@ class GitInfoReproducibilityTest(TestCase):
             self.assertNotIn(commit, from_checkout)
 
     def test_make_forwards_reproducible_mode(self):
+        environment_command = subprocess.check_output(
+            ["make", "-n", "git-info"],
+            cwd=REPO_ROOT,
+            env={**os.environ, "REPRODUCIBLE": "1"},
+            text=True,
+        )
         developer_command = subprocess.check_output(
             ["make", "-n", "git-info", "REPRODUCIBLE=0"], cwd=REPO_ROOT, text=True
         )
@@ -133,5 +150,6 @@ class GitInfoReproducibilityTest(TestCase):
             text=True,
         )
 
+        self.assertIn("--reproducible", environment_command)
         self.assertNotIn("--reproducible", developer_command)
         self.assertIn("--reproducible", reproducible_command)

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import sys
 import tempfile
@@ -15,21 +14,19 @@ def run_git(cwd: Path, *args: str) -> str:
     ).strip()
 
 
-def run_script(output: Path, cwd: Path, extra_env=None) -> str:
-    env = dict(os.environ)
-    for key in ("SPECTER_REPRODUCIBLE_BUILD", "SPECTER_GIT_REPOSITORY",
-                "SPECTER_GIT_BRANCH", "SPECTER_GIT_COMMIT"):
-        env.pop(key, None)
-    if extra_env:
-        env.update(extra_env)
+def run_script(output: Path, cwd: Path, extra_args=None) -> str:
+    args = [sys.executable, str(SCRIPT)]
+    if extra_args:
+        args.extend(extra_args)
+    args.append(str(output))
     subprocess.check_call(
-        [sys.executable, str(SCRIPT), str(output)], cwd=cwd, env=env
+        args, cwd=cwd
     )
     return output.read_text()
 
 
 class GitInfoReproducibilityTest(TestCase):
-    def test_same_commit_ignores_remote_and_checkout_ref(self):
+    def test_developer_build_embeds_local_checkout_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             source = root / "source"
@@ -69,15 +66,18 @@ class GitInfoReproducibilityTest(TestCase):
             content_a = run_script(root / "git-info-a.py", clone_a)
             content_b = run_script(root / "git-info-b.py", clone_b)
 
-            self.assertEqual(content_a, content_b)
-            # Checkout metadata is not source identity. Keeping it neutral also
-            # avoids attributing fork-only commits to the upstream repository.
-            self.assertIn("REPOSITORY = 'unknown'", content_a)
-            self.assertIn("BRANCH = 'unknown'", content_a)
+            self.assertNotEqual(content_a, content_b)
+            self.assertIn(
+                "REPOSITORY = 'git@example.invalid:fork/specter-diy.git'",
+                content_a,
+            )
+            self.assertIn("BRANCH = 'release-test'", content_a)
             self.assertIn("COMMIT = %r" % commit, content_a)
-            self.assertNotIn("release-test", content_a)
-            self.assertNotIn("example.invalid", content_a)
-            self.assertNotIn("cryptoadvance/specter-diy", content_a)
+            self.assertIn(
+                "REPOSITORY = 'https://example.invalid/other/specter-diy.git'",
+                content_b,
+            )
+            self.assertIn("COMMIT = %r" % commit, content_b)
 
     def test_without_git_metadata_uses_stable_unknown_values(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -91,7 +91,7 @@ class GitInfoReproducibilityTest(TestCase):
             self.assertIn("COMMIT = 'unknown'", content)
 
     def test_reproducible_build_output_is_source_acquisition_independent(self):
-        """Release builds (SPECTER_REPRODUCIBLE_BUILD=1) must produce identical
+        """Reproducible builds must produce identical
         output from a git checkout and from a .git-less source archive."""
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -111,9 +111,11 @@ class GitInfoReproducibilityTest(TestCase):
             archive.mkdir()
             (archive / "payload.txt").write_text("same source\n")
 
-            env = {"SPECTER_REPRODUCIBLE_BUILD": "1"}
-            from_checkout = run_script(root / "a.py", checkout, env)
-            from_archive = run_script(root / "b.py", archive, env)
+            reproducible_args = ["--reproducible"]
+            from_checkout = run_script(
+                root / "a.py", checkout, reproducible_args
+            )
+            from_archive = run_script(root / "b.py", archive, reproducible_args)
 
             self.assertEqual(from_checkout, from_archive)
             self.assertIn("REPOSITORY = 'unknown'", from_checkout)
@@ -121,21 +123,15 @@ class GitInfoReproducibilityTest(TestCase):
             self.assertIn("COMMIT = 'unknown'", from_checkout)
             self.assertNotIn(commit, from_checkout)
 
-    def test_explicit_overrides_are_embedded(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            content = run_script(
-                root / "git-info.py",
-                root,
-                {
-                    "SPECTER_GIT_REPOSITORY": "https://example.org/specter-diy",
-                    "SPECTER_GIT_BRANCH": "v9.9.9",
-                    "SPECTER_GIT_COMMIT": "0" * 40,
-                },
-            )
+    def test_make_forwards_reproducible_mode(self):
+        developer_command = subprocess.check_output(
+            ["make", "-n", "git-info"], cwd=REPO_ROOT, text=True
+        )
+        reproducible_command = subprocess.check_output(
+            ["make", "-n", "git-info", "REPRODUCIBLE=1"],
+            cwd=REPO_ROOT,
+            text=True,
+        )
 
-            self.assertIn(
-                "REPOSITORY = 'https://example.org/specter-diy'", content
-            )
-            self.assertIn("BRANCH = 'v9.9.9'", content)
-            self.assertIn("COMMIT = '%s'" % ("0" * 40), content)
+        self.assertNotIn("--reproducible", developer_command)
+        self.assertIn("--reproducible", reproducible_command)

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -125,7 +125,7 @@ class GitInfoReproducibilityTest(TestCase):
 
     def test_make_forwards_reproducible_mode(self):
         developer_command = subprocess.check_output(
-            ["make", "-n", "git-info"], cwd=REPO_ROOT, text=True
+            ["make", "-n", "git-info", "REPRODUCIBLE=0"], cwd=REPO_ROOT, text=True
         )
         reproducible_command = subprocess.check_output(
             ["make", "-n", "git-info", "REPRODUCIBLE=1"],

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -45,13 +45,13 @@ class GitUrlSanitizationTest(TestCase):
 
     def test_sanitizes_https_url_with_token(self):
         """Token in HTTPS URL must be stripped."""
-        url = "https://ghp_secret123@github.com/org/repo.git"
+        url = "https://SECRET-TOKEN@github.com/org/repo.git"
         result = self.module._sanitize_remote_url(url)
         self.assertEqual("https://github.com/org/repo.git", result)
 
     def test_sanitizes_https_url_with_user_pass(self):
-        """User:pass in HTTPS URL must be stripped."""
-        url = "https://user:pass@gitlab.com/org/repo.git"
+        """User:password in HTTPS URL must be stripped."""
+        url = "https://user:PASSWORD@gitlab.com/org/repo.git"
         result = self.module._sanitize_remote_url(url)
         self.assertEqual("https://gitlab.com/org/repo.git", result)
 
@@ -87,13 +87,13 @@ class GitUrlSanitizationTest(TestCase):
 
     def test_rejects_malformed_url_with_multiple_ats(self):
         """Malformed URLs with @ in netloc after stripping are rejected."""
-        url = "https://token@host@evil.com/repo.git"
+        url = "https://CRED@host@evil.com/repo.git"
         result = self.module._sanitize_remote_url(url)
         self.assertEqual("unknown", result)
 
     def test_sanitizes_url_with_port(self):
         """URLs with ports are preserved."""
-        url = "https://token@github.com:8443/org/repo.git"
+        url = "https://CRED@github.com:8443/org/repo.git"
         result = self.module._sanitize_remote_url(url)
         self.assertEqual("https://github.com:8443/org/repo.git", result)
 
@@ -140,7 +140,7 @@ class GitUrlSanitizationTest(TestCase):
 
     def test_strips_userinfo_with_mixed_case_scheme(self):
         """Userinfo stripping works regardless of scheme case."""
-        url = "Https://token@github.com/org/repo.git"
+        url = "Https://CRED@github.com/org/repo.git"
         result = self.module._sanitize_remote_url(url)
         self.assertEqual("Https://github.com/org/repo.git", result)
 

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -13,6 +13,8 @@ SCRIPT = REPO_ROOT / "tools" / "embed_git_info.py"
 def load_embed_git_info():
     """Load tools/embed_git_info.py as a module."""
     spec = importlib.util.spec_from_file_location("embed_git_info", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load embed_git_info from %s" % SCRIPT)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -129,6 +131,18 @@ class GitUrlSanitizationTest(TestCase):
         """host:path without user@ is not scp syntax; reject it."""
         result = self.module._sanitize_remote_url("github.com:org/repo.git")
         self.assertEqual("unknown", result)
+
+    def test_accepts_uppercase_scheme(self):
+        """URL schemes are case-insensitive (RFC 3986); HTTPS:// is valid."""
+        url = "HTTPS://github.com/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("HTTPS://github.com/org/repo.git", result)
+
+    def test_strips_userinfo_with_mixed_case_scheme(self):
+        """Userinfo stripping works regardless of scheme case."""
+        url = "Https://token@github.com/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("Https://github.com/org/repo.git", result)
 
 
 class GitInfoReproducibilityTest(TestCase):

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -132,6 +132,20 @@ class GitUrlSanitizationTest(TestCase):
         result = self.module._sanitize_remote_url("github.com:org/repo.git")
         self.assertEqual("unknown", result)
 
+    def test_rejects_scp_like_with_non_git_user(self):
+        """scp-like remotes with a user other than git may leak PII
+        (emails, internal usernames) and fail closed to unknown."""
+        result = self.module._sanitize_remote_url(
+            "john.doe@git.example.invalid:org/repo.git"
+        )
+        self.assertEqual("unknown", result)
+
+    def test_accepts_scp_like_git_user_with_port(self):
+        """scp-like syntax with the standard git user and a port passes."""
+        url = "git@git.example.invalid:2222:org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual(url, result)
+
     def test_accepts_uppercase_scheme(self):
         """URL schemes are case-insensitive (RFC 3986); HTTPS:// is valid."""
         url = "HTTPS://github.com/org/repo.git"

--- a/test/tests_native/test_embed_git_info.py
+++ b/test/tests_native/test_embed_git_info.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 import subprocess
 import sys
@@ -7,6 +8,14 @@ from unittest import TestCase
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "tools" / "embed_git_info.py"
+
+
+def load_embed_git_info():
+    """Load tools/embed_git_info.py as a module."""
+    spec = importlib.util.spec_from_file_location("embed_git_info", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def run_git(cwd: Path, *args: str) -> str:
@@ -24,6 +33,102 @@ def run_script(output: Path, cwd: Path, extra_args=None) -> str:
         args, cwd=cwd
     )
     return output.read_text()
+
+
+class GitUrlSanitizationTest(TestCase):
+    """Test that git remote URLs are sanitized before embedding."""
+
+    def setUp(self):
+        self.module = load_embed_git_info()
+
+    def test_sanitizes_https_url_with_token(self):
+        """Token in HTTPS URL must be stripped."""
+        url = "https://ghp_secret123@github.com/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("https://github.com/org/repo.git", result)
+
+    def test_sanitizes_https_url_with_user_pass(self):
+        """User:pass in HTTPS URL must be stripped."""
+        url = "https://user:pass@gitlab.com/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("https://gitlab.com/org/repo.git", result)
+
+    def test_sanitizes_ssh_url_with_user(self):
+        """SSH URLs with explicit user (git@) are kept as-is (no secret)."""
+        url = "git@github.com:org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("git@github.com:org/repo.git", result)
+
+    def test_sanitizes_ssh_scheme_url(self):
+        """SSH scheme URLs keep scheme, strip userinfo."""
+        url = "ssh://git@github.com:22/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("ssh://github.com:22/org/repo.git", result)
+
+    def test_sanitizes_git_scheme_url(self):
+        """Git protocol URLs pass through (no userinfo possible)."""
+        url = "git://github.com/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("git://github.com/org/repo.git", result)
+
+    def test_rejects_file_protocol(self):
+        """file:// URLs leak local paths and are rejected."""
+        url = "file:///home/user/repo"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("unknown", result)
+
+    def test_rejects_ftp_protocol(self):
+        """FTP URLs are not in allowlist and rejected."""
+        url = "ftp://user@host/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("unknown", result)
+
+    def test_rejects_malformed_url_with_multiple_ats(self):
+        """Malformed URLs with @ in netloc after stripping are rejected."""
+        url = "https://token@host@evil.com/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("unknown", result)
+
+    def test_sanitizes_url_with_port(self):
+        """URLs with ports are preserved."""
+        url = "https://token@github.com:8443/org/repo.git"
+        result = self.module._sanitize_remote_url(url)
+        self.assertEqual("https://github.com:8443/org/repo.git", result)
+
+    def test_rejects_empty_url(self):
+        """Empty URLs are rejected."""
+        result = self.module._sanitize_remote_url("")
+        self.assertEqual("unknown", result)
+
+    def test_rejects_none(self):
+        """None is rejected."""
+        result = self.module._sanitize_remote_url(None)
+        self.assertEqual("unknown", result)
+
+    def test_rejects_absolute_local_path(self):
+        """Local filesystem paths leak usernames and are rejected."""
+        result = self.module._sanitize_remote_url("/home/user/repo")
+        self.assertEqual("unknown", result)
+
+    def test_rejects_relative_local_path(self):
+        """Relative local paths are rejected."""
+        result = self.module._sanitize_remote_url("../repo")
+        self.assertEqual("unknown", result)
+
+    def test_rejects_windows_path(self):
+        """Windows paths are rejected."""
+        result = self.module._sanitize_remote_url(r"C:\Users\marco\repo")
+        self.assertEqual("unknown", result)
+
+    def test_rejects_plain_string(self):
+        """Arbitrary non-URL strings are rejected."""
+        result = self.module._sanitize_remote_url("just-a-random-string")
+        self.assertEqual("unknown", result)
+
+    def test_rejects_scp_like_without_user(self):
+        """host:path without user@ is not scp syntax; reject it."""
+        result = self.module._sanitize_remote_url("github.com:org/repo.git")
+        self.assertEqual("unknown", result)
 
 
 class GitInfoReproducibilityTest(TestCase):

--- a/tools/embed_git_info.py
+++ b/tools/embed_git_info.py
@@ -21,10 +21,7 @@ def _run_git(args: list[str]) -> Optional[str]:
 
 def discover_repository() -> str:
     repo = _run_git(["config", "--get", "remote.origin.url"])
-    if repo:
-        return repo
-    path = _run_git(["rev-parse", "--show-toplevel"])
-    return path or UNKNOWN_VALUE
+    return repo or UNKNOWN_VALUE
 
 
 def discover_branch() -> str:

--- a/tools/embed_git_info.py
+++ b/tools/embed_git_info.py
@@ -4,25 +4,11 @@
 from __future__ import annotations
 
 import argparse
-import os
 import subprocess
 from pathlib import Path
 from typing import Optional
 
 UNKNOWN_VALUE = "unknown"
-
-# Environment switch used by release builds (see build_firmware.sh). When set, no
-# git commands are run and every value is emitted as UNKNOWN_VALUE, so the frozen
-# module is byte-identical whether the source came from a git checkout, a shallow
-# clone, a fork, or a source archive without any .git metadata at all.
-REPRODUCIBLE_ENV = "SPECTER_REPRODUCIBLE_BUILD"
-
-# Optional explicit overrides. An empty value is treated as UNKNOWN_VALUE. These
-# let a release process pin documented provenance constants without reintroducing
-# any dependency on the local clone state.
-REPOSITORY_ENV = "SPECTER_GIT_REPOSITORY"
-BRANCH_ENV = "SPECTER_GIT_BRANCH"
-COMMIT_ENV = "SPECTER_GIT_COMMIT"
 
 
 def _run_git(args: list[str]) -> Optional[str]:
@@ -33,47 +19,25 @@ def _run_git(args: list[str]) -> Optional[str]:
     return result.decode().strip() or None
 
 
-def _env_override(name: str) -> Optional[str]:
-    value = os.environ.get(name)
-    if value is None:
-        return None
-    return value.strip() or UNKNOWN_VALUE
-
-
-def _reproducible_build() -> bool:
-    return os.environ.get(REPRODUCIBLE_ENV, "").strip() not in ("", "0", "false", "False")
-
-
 def discover_repository() -> str:
-    override = _env_override(REPOSITORY_ENV)
-    if override is not None:
-        return override
-    # A clone remote is build-environment metadata, not source identity. Using
-    # a canonical upstream URL would also misattribute fork-only commits to the
-    # upstream repository, so do not embed a repository URL at all.
-    return UNKNOWN_VALUE
+    repo = _run_git(["config", "--get", "remote.origin.url"])
+    if repo:
+        return repo
+    path = _run_git(["rev-parse", "--show-toplevel"])
+    return path or UNKNOWN_VALUE
 
 
 def discover_branch() -> str:
-    override = _env_override(BRANCH_ENV)
-    if override is not None:
-        return override
-    # Branch/tag refs can differ for the same commit (branch checkout, detached
-    # HEAD, shallow clone, etc.), so embedding them breaks reproducible builds.
-    return UNKNOWN_VALUE
+    branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch and branch != "HEAD":
+        return branch
+    describe = _run_git(["describe", "--all"])
+    return describe or UNKNOWN_VALUE
 
 
-def discover_commit(reproducible: bool) -> str:
-    override = _env_override(COMMIT_ENV)
-    if override is not None:
-        return override
-    if reproducible:
-        # The full object id is only present in a git checkout; a source archive
-        # has no .git and would embed "unknown" instead. Release builds must not
-        # depend on how the source was obtained, so drop it entirely.
-        return UNKNOWN_VALUE
-    # Dev builds embed the concrete revision. Use the full object id: git's
-    # default abbreviated SHA length can vary with the objects present in a clone.
+def discover_commit() -> str:
+    # Use the full object id: git's default abbreviated SHA length can vary with
+    # the objects present in a clone.
     commit = _run_git(["rev-parse", "HEAD"])
     if commit:
         return commit
@@ -90,9 +54,12 @@ def build_content(repository: str, branch: str, commit: str) -> str:
 
 
 def write_git_info(path: Path, reproducible: bool) -> None:
-    repository = discover_repository()
-    branch = discover_branch()
-    commit = discover_commit(reproducible)
+    if reproducible:
+        repository = branch = commit = UNKNOWN_VALUE
+    else:
+        repository = discover_repository()
+        branch = discover_branch()
+        commit = discover_commit()
 
     content = build_content(repository, branch, commit)
 
@@ -120,18 +87,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--reproducible",
         action="store_true",
-        help=(
-            "emit static values with no git lookups (also enabled by the "
-            "%s environment variable)" % REPRODUCIBLE_ENV
-        ),
+        help="emit static values with no git lookups",
     )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    reproducible = args.reproducible or _reproducible_build()
-    write_git_info(Path(args.output), reproducible)
+    write_git_info(Path(args.output), args.reproducible)
 
 
 if __name__ == "__main__":

--- a/tools/embed_git_info.py
+++ b/tools/embed_git_info.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -19,9 +20,55 @@ def _run_git(args: list[str]) -> Optional[str]:
     return result.decode().strip() or None
 
 
+def _sanitize_remote_url(url: Optional[str]) -> str:
+    """Strip credentials from a git remote URL before embedding.
+
+    Origin URLs may contain tokens or passwords, e.g.
+    https://<token>@github.com/org/repo.git or https://user:pass@host/...
+    These would end up frozen into firmware and shown on the About screen,
+    so the userinfo component must never be embedded.
+
+    Returns "unknown" for empty, malformed, or disallowed URLs.
+    """
+    if not url:
+        return UNKNOWN_VALUE
+
+    url = url.strip()
+
+    # SCP-like SSH syntax ([user@]host:path, e.g. git@github.com:org/repo.git)
+    # cannot carry credentials in a userinfo field; allow as-is. Anything
+    # else without a scheme (local paths, junk strings) is rejected.
+    if "://" not in url:
+        if re.match(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+(:[0-9]+)?:[^/\\].*$", url):
+            return url
+        return UNKNOWN_VALUE
+
+    # Only allow safe protocols (reject file://, ftp://, etc.)
+    allowed_schemes = ("https://", "http://", "ssh://", "git://")
+    if not any(url.startswith(scheme) for scheme in allowed_schemes):
+        return UNKNOWN_VALUE
+
+    # Strip userinfo: scheme://[user[:pass]@]host/path
+    # [^@/]+ matches the userinfo component (no @ or / allowed inside)
+    sanitized = re.sub(r"^([a-zA-Z][a-zA-Z0-9+.-]*://)[^@/]+@", r"\1", url)
+
+    # Safety net: if after stripping we still have an @ in the netloc,
+    # something is malformed (e.g. multiple @s). Fail closed to unknown.
+    try:
+        netloc = sanitized.split("://", 1)[1].split("/", 1)[0]
+        if "@" in netloc:
+            return UNKNOWN_VALUE
+    except (IndexError, AttributeError):
+        return UNKNOWN_VALUE
+
+    return sanitized
+
+
 def discover_repository() -> str:
     repo = _run_git(["config", "--get", "remote.origin.url"])
-    return repo or UNKNOWN_VALUE
+    if repo:
+        return _sanitize_remote_url(repo)
+    return UNKNOWN_VALUE
 
 
 def discover_branch() -> str:

--- a/tools/embed_git_info.py
+++ b/tools/embed_git_info.py
@@ -44,8 +44,10 @@ def _sanitize_remote_url(url: Optional[str]) -> str:
         return UNKNOWN_VALUE
 
     # Only allow safe protocols (reject file://, ftp://, etc.)
-    allowed_schemes = ("https://", "http://", "ssh://", "git://")
-    if not any(url.startswith(scheme) for scheme in allowed_schemes):
+    # URL schemes are case-insensitive (RFC 3986), so match case-insensitively.
+    allowed_schemes = ("https", "http", "ssh", "git")
+    scheme_match = re.match(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://", url)
+    if scheme_match is None or scheme_match.group(1).lower() not in allowed_schemes:
         return UNKNOWN_VALUE
 
     # Strip userinfo: scheme://[user[:pass]@]host/path

--- a/tools/embed_git_info.py
+++ b/tools/embed_git_info.py
@@ -35,11 +35,13 @@ def _sanitize_remote_url(url: Optional[str]) -> str:
 
     url = url.strip()
 
-    # SCP-like SSH syntax ([user@]host:path, e.g. git@github.com:org/repo.git)
-    # cannot carry credentials in a userinfo field; allow as-is. Anything
-    # else without a scheme (local paths, junk strings) is rejected.
+    # SCP-like SSH syntax (git@host:path, e.g. git@github.com:org/repo.git)
+    # has no credential field, but the user part could still carry PII
+    # (emails, internal usernames). Only the conventional "git" login used
+    # by major hosting services is allowlisted; anything else without a
+    # scheme (other users, local paths, junk strings) is rejected.
     if "://" not in url:
-        if re.match(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+(:[0-9]+)?:[^/\\].*$", url):
+        if re.match(r"^git@[A-Za-z0-9._-]+(:[0-9]+)?:[^/\\].*$", url):
             return url
         return UNKNOWN_VALUE
 

--- a/tools/embed_git_info.py
+++ b/tools/embed_git_info.py
@@ -24,7 +24,7 @@ def _sanitize_remote_url(url: Optional[str]) -> str:
     """Strip credentials from a git remote URL before embedding.
 
     Origin URLs may contain tokens or passwords, e.g.
-    https://<token>@github.com/org/repo.git or https://user:pass@host/...
+    https://<token>@github.com/org/repo.git or https://user:<password>@host/...
     These would end up frozen into firmware and shown on the About screen,
     so the userinfo component must never be embedded.
 


### PR DESCRIPTION
## Summary

Restore repository, branch, and full commit metadata in developer firmware builds while keeping release artifacts reproducible.

- discover Git provenance by default for local developer builds
- add an explicit `REPRODUCIBLE=1` Make parameter that suppresses provenance (make parameter > environmet variable as it does not persist beyond intended build process)
- use reproducible mode in both release build variants
- remove unused ambient `SPECTER_GIT_*` and reproducibility environment overrides
- cover developer, no-Git, reproducible checkout/archive, and Make forwarding behavior

This preserves the reproducibility goal of #412 without hiding useful provenance from locally built firmware.

## Validation

- `test/tests_native/test_embed_git_info.py`: 4 passed
- full native test suite: 80 passed
- shell syntax, Make expansion, diagnostics, and whitespace checks passed
- built STM32F469 firmware from commit `f9f825367a3d697fe5dedc50cfbcf15867ad0890`
- verified the linked image contains the fork repository URL, branch, and full commit SHA
- flashed and byte-checked immutable firmware regions on an STM32F469I-DISCO
- confirmed on-device About page displays repository, branch, and commit