### PR TITLE
Documentation: Fix 404 for udev nav entry via docs/udev symlink

### DIFF
--- a/docs/udev/README.md
+++ b/docs/udev/README.md
@@ -1,0 +1,1 @@
+../../udev/README.md


### PR DESCRIPTION
## Problem

PR #345 added a nav entry for the udev rules doc:

```yaml
- 'USB udev rules (Linux)': udev/README.md
```

`udev/README.md` lives at the repo root, outside `docs_dir` (`docs/`). MkDocs only resolves nav paths relative to `docs_dir`, so it treats this entry as an unresolved/external link, and the generated link 404s on https://docs.specter.solutions/diy/udev/README.md.

## Fix

Add `docs/udev/README.md` as a symlink to `../../udev/README.md`. MkDocs follows the symlink and renders a normal internal page at `/diy/udev/`, with no content duplication — `udev/README.md` remains the single source of truth.

## Verification

Built the site locally with the pinned `mkdocs==1.3.0` (from `requirements.txt`), using the actual `mkdocs.yml`:

- Before the fix: `udev/README.md` listed under "pages ... not included in the nav configuration" (treated as external/unresolved).
- After the fix: no such warning; `site/udev/index.html" is generated with `<title>USB udev rules (Linux) - Specter DIY Documentation</title>` and the real udev rules content.
- Homepage nav link resolves internally (`href="udev/"`) instead of pointing off-site.